### PR TITLE
Add parser for action definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ listed in the paper:
 - [x] `<primitive-type>`
 - [x] `<type>`
 - [x] `<emptyOr (x)>`
-- [ ] `<action-def>`
+- [x] `<action-def>`
 - [x] `<action-symbol>`
-- [ ] `<action-def body>`
+- [x] `<action-def body>`
 - [x] `<pre-GD>`
 - [x] `<pref-GD>`
 - [x] `<pref-name>`

--- a/src/parsers/action_def.rs
+++ b/src/parsers/action_def.rs
@@ -1,0 +1,82 @@
+//! Provides parsers for action definitions.
+
+use crate::parsers::{
+    empty_or, parens, parse_action_symbol, parse_effect, parse_pre_gd, parse_variable, prefix_expr,
+    typed_list, ws,
+};
+use crate::types::ActionDefinition;
+use nom::bytes::complete::tag;
+use nom::character::complete::multispace1;
+use nom::combinator::{map, opt};
+use nom::sequence::{preceded, tuple};
+use nom::IResult;
+
+/// Parses an action definition.
+///
+/// ## Example
+/// ```
+/// # use pddl::parsers::parse_action_def;
+/// # use pddl::types::{ActionDefinition, ActionSymbol, AtomicFormula, CEffect, Effect, GD, Literal, Name, PEffect, Predicate, Preference, PrefGD, PreGD, Term, Type, Typed, TypedList, Variable};
+///
+/// let input = r#"(:action take-out
+///                     :parameters (?x - physob)
+///                     :precondition (not (= ?x B))
+///                     :effect (not (in ?x))
+///                 )"#;
+///
+/// let action = parse_action_def(input);
+///
+/// assert_eq!(action, Ok(("",
+///     ActionDefinition::new(
+///         ActionSymbol::from_str("take-out"),
+///         TypedList::from_iter([
+///             Typed::new(Variable::from_str("x"), Type::Exactly("physob".into()))
+///         ]),
+///         Some(PreGD::Preference(PrefGD::from_gd(
+///             GD::new_literal(
+///                 Literal::new_not(
+///                     AtomicFormula::new_equality(
+///                         Term::Variable(Variable::from_str("x")),
+///                         Term::Name(Name::from_str("B"))
+///                     )
+///                 )
+///             )
+///         ))),
+///         Some(Effect::new(CEffect::new_p_effect(
+///             PEffect::NotAtomicFormula(
+///                 AtomicFormula::new_predicate(
+///                     Predicate::from_str("in"),
+///                     vec![Term::Variable(Variable::from_str("x"))]
+///                 )
+///             )
+///         )))
+///     )
+/// )));
+/// ```
+pub fn parse_action_def(input: &str) -> IResult<&str, ActionDefinition> {
+    let precondition = preceded(
+        tag(":precondition"),
+        preceded(multispace1, empty_or(parse_pre_gd)),
+    );
+    let effect = preceded(
+        tag(":effect"),
+        preceded(multispace1, empty_or(parse_effect)),
+    );
+    let action_def_body = tuple((opt(ws(precondition)), opt(ws(effect))));
+    let parameters = preceded(
+        tag(":parameters"),
+        preceded(multispace1, parens(typed_list(parse_variable))),
+    );
+    let action_def = prefix_expr(
+        ":action",
+        tuple((
+            parse_action_symbol,
+            preceded(multispace1, parameters),
+            ws(action_def_body),
+        )),
+    );
+
+    map(action_def, |(symbol, params, (preconditions, effects))| {
+        ActionDefinition::new(symbol, params, preconditions.flatten(), effects.flatten())
+    })(input)
+}

--- a/src/parsers/atomic_formula.rs
+++ b/src/parsers/atomic_formula.rs
@@ -1,6 +1,6 @@
 //! Provides parsers for atomic formulae.
 
-use crate::parsers::{parse_predicate, space_separated_list0, ws};
+use crate::parsers::{parens, parse_predicate, space_separated_list0, ws};
 use crate::types::AtomicFormula;
 use nom::branch::alt;
 use nom::bytes::complete::tag;
@@ -43,11 +43,7 @@ where
     );
 
     let predicate = map(
-        delimited(
-            char('('),
-            tuple((parse_predicate, ws(space_separated_list0(inner)))),
-            char(')'),
-        ),
+        parens(tuple((parse_predicate, ws(space_separated_list0(inner))))),
         |tuple| AtomicFormula::Predicate(tuple.into()),
     );
 

--- a/src/parsers/atomic_formula_skeleton.rs
+++ b/src/parsers/atomic_formula_skeleton.rs
@@ -1,10 +1,9 @@
 //! Provides parsers for atomic formula skeletons.
 
-use crate::parsers::{parse_predicate, parse_variable, typed_list, ws};
+use crate::parsers::{parens, parse_predicate, parse_variable, typed_list, ws};
 use crate::types::AtomicFormulaSkeleton;
-use nom::character::complete::char;
 use nom::combinator::map;
-use nom::sequence::{delimited, tuple};
+use nom::sequence::tuple;
 use nom::IResult;
 
 /// Parser that parses an atomic formula skeleton, i.e. `(<predicate> <typed list (variable)>)`.
@@ -25,11 +24,7 @@ use nom::IResult;
 /// ```
 pub fn parse_atomic_formula_skeleton(input: &str) -> IResult<&str, AtomicFormulaSkeleton> {
     map(
-        delimited(
-            char('('),
-            tuple((parse_predicate, ws(typed_list(parse_variable)))),
-            char(')'),
-        ),
+        parens(tuple((parse_predicate, ws(typed_list(parse_variable))))),
         |tuple| AtomicFormulaSkeleton::from(tuple),
     )(input)
 }

--- a/src/parsers/atomic_function_skeleton.rs
+++ b/src/parsers/atomic_function_skeleton.rs
@@ -1,10 +1,9 @@
 //! Provides parsers for atomic function skeletons.
 
-use crate::parsers::{parse_function_symbol, parse_variable, typed_list, ws};
+use crate::parsers::{parens, parse_function_symbol, parse_variable, typed_list, ws};
 use crate::types::AtomicFunctionSkeleton;
-use nom::character::complete::char;
 use nom::combinator::map;
-use nom::sequence::{delimited, tuple};
+use nom::sequence::tuple;
 use nom::IResult;
 
 /// Parser that parses an atomic function skeleton, i.e. `(<function-symbol> <typed list (variable)>)`.
@@ -24,11 +23,10 @@ use nom::IResult;
 /// ```
 pub fn parse_atomic_function_skeleton(input: &str) -> IResult<&str, AtomicFunctionSkeleton> {
     map(
-        delimited(
-            char('('),
-            tuple((parse_function_symbol, ws(typed_list(parse_variable)))),
-            char(')'),
-        ),
+        parens(tuple((
+            parse_function_symbol,
+            ws(typed_list(parse_variable)),
+        ))),
         |tuple| AtomicFunctionSkeleton::from(tuple),
     )(input)
 }

--- a/src/parsers/c_effect.rs
+++ b/src/parsers/c_effect.rs
@@ -1,14 +1,14 @@
 //! Provides parsers for c-effects.
 
 use crate::parsers::{
-    parse_cond_effect, parse_effect, parse_gd, parse_p_effect, parse_variable, prefix_expr,
+    parens, parse_cond_effect, parse_effect, parse_gd, parse_p_effect, parse_variable, prefix_expr,
     typed_list,
 };
 use crate::types::CEffect;
 use nom::branch::alt;
-use nom::character::complete::{char, multispace1};
+use nom::character::complete::multispace1;
 use nom::combinator::map;
-use nom::sequence::{delimited, preceded, tuple};
+use nom::sequence::{preceded, tuple};
 use nom::IResult;
 
 /// Parser combinator that parses c-effects.
@@ -61,7 +61,7 @@ pub fn parse_c_effect(input: &str) -> IResult<&str, CEffect> {
         prefix_expr(
             "forall",
             tuple((
-                delimited(char('('), typed_list(parse_variable), char(')')),
+                parens(typed_list(parse_variable)),
                 preceded(multispace1, parse_effect),
             )),
         ),

--- a/src/parsers/gd.rs
+++ b/src/parsers/gd.rs
@@ -1,14 +1,14 @@
 //! Provides parsers for goal definitions.
 
 use crate::parsers::{
-    atomic_formula, literal, parse_term, parse_variable, prefix_expr, space_separated_list0,
-    typed_list,
+    atomic_formula, literal, parens, parse_term, parse_variable, prefix_expr,
+    space_separated_list0, typed_list,
 };
 use crate::types::GD;
 use nom::branch::alt;
-use nom::character::complete::{char, multispace1};
+use nom::character::complete::multispace1;
 use nom::combinator::map;
-use nom::sequence::{delimited, preceded, tuple};
+use nom::sequence::{preceded, tuple};
 use nom::IResult;
 
 /// Parser for goal definitions.
@@ -145,7 +145,7 @@ pub fn parse_gd(input: &str) -> IResult<&str, GD> {
         prefix_expr(
             "exists",
             tuple((
-                delimited(char('('), typed_list(parse_variable), char(')')),
+                parens(typed_list(parse_variable)),
                 preceded(multispace1, parse_gd),
             )),
         ),
@@ -157,7 +157,7 @@ pub fn parse_gd(input: &str) -> IResult<&str, GD> {
         prefix_expr(
             "forall",
             tuple((
-                delimited(char('('), typed_list(parse_variable), char(')')),
+                parens(typed_list(parse_variable)),
                 preceded(multispace1, parse_gd),
             )),
         ),

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -1,3 +1,4 @@
+mod action_def;
 mod action_symbol;
 mod assign_op;
 mod atomic_formula;
@@ -33,6 +34,7 @@ mod utilities;
 mod variable;
 
 // Parsers.
+pub use action_def::parse_action_def;
 pub use action_symbol::parse_action_symbol;
 pub use assign_op::parse_assign_op;
 pub use atomic_formula::atomic_formula;
@@ -70,4 +72,4 @@ pub use typed_list::typed_list;
 
 // Utility parser combinators.
 #[allow(unused_imports)]
-pub(crate) use utilities::{prefix_expr, space_separated_list0, space_separated_list1, ws};
+pub(crate) use utilities::{parens, prefix_expr, space_separated_list0, space_separated_list1, ws};

--- a/src/parsers/pre_gd.rs
+++ b/src/parsers/pre_gd.rs
@@ -1,13 +1,13 @@
 //! Provides parsers for goal definitions.
 
 use crate::parsers::{
-    parse_pref_gd, parse_variable, prefix_expr, space_separated_list0, typed_list,
+    parens, parse_pref_gd, parse_variable, prefix_expr, space_separated_list0, typed_list,
 };
 use crate::types::PreGD;
 use nom::branch::alt;
-use nom::character::complete::{char, multispace1};
+use nom::character::complete::multispace1;
 use nom::combinator::map;
-use nom::sequence::{delimited, preceded, tuple};
+use nom::sequence::{preceded, tuple};
 use nom::IResult;
 
 /// Parser for goal definitions.
@@ -80,7 +80,7 @@ pub fn parse_pre_gd(input: &str) -> IResult<&str, PreGD> {
         prefix_expr(
             "forall",
             tuple((
-                delimited(char('('), typed_list(parse_variable), char(')')),
+                parens(typed_list(parse_variable)),
                 preceded(multispace1, parse_pre_gd),
             )),
         ),

--- a/src/types/action_definition.rs
+++ b/src/types/action_definition.rs
@@ -1,0 +1,50 @@
+//! Contains action definitions.
+
+use crate::types::{ActionSymbol, Effect, PreGD, TypedList, Variable};
+
+/// An action definition.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ActionDefinition<'a> {
+    symbol: ActionSymbol<'a>,
+    parameters: TypedList<'a, Variable<'a>>,
+    precondition: Option<PreGD<'a>>,
+    effect: Option<Effect<'a>>,
+}
+
+impl<'a> ActionDefinition<'a> {
+    pub const fn new(
+        symbol: ActionSymbol<'a>,
+        parameters: TypedList<'a, Variable<'a>>,
+        precondition: Option<PreGD<'a>>,
+        effect: Option<Effect<'a>>,
+    ) -> Self {
+        Self {
+            symbol,
+            parameters,
+            precondition,
+            effect,
+        }
+    }
+
+    pub const fn symbol(&self) -> &ActionSymbol<'a> {
+        &self.symbol
+    }
+
+    pub const fn parameters(&self) -> &TypedList<'a, Variable<'a>> {
+        &self.parameters
+    }
+
+    pub const fn precondition(&self) -> &Option<PreGD<'a>> {
+        &self.precondition
+    }
+
+    pub const fn effect(&self) -> &Option<Effect<'a>> {
+        &self.effect
+    }
+}
+
+impl<'a> AsRef<ActionSymbol<'a>> for ActionDefinition<'a> {
+    fn as_ref(&self) -> &ActionSymbol<'a> {
+        &self.symbol
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,3 +1,4 @@
+mod action_definition;
 mod action_symbols;
 pub(crate) mod assign_op;
 mod atomic_formula;
@@ -31,6 +32,7 @@ mod typed_list;
 mod types;
 mod variables;
 
+pub use action_definition::ActionDefinition;
 pub use action_symbols::ActionSymbol;
 pub use assign_op::AssignOp;
 pub use atomic_formula::{AtomicFormula, EqualityAtomicFormula, PredicateAtomicFormula};

--- a/src/types/pre_gd.rs
+++ b/src/types/pre_gd.rs
@@ -1,8 +1,8 @@
-//! Contains goal definitions.
+//! Contains precondition goal definitions.
 
 use crate::types::{PrefGD, Preference, TypedList, Variable};
 
-/// A goal definition.
+/// A precondition goal definition.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum PreGD<'a> {
     Preference(PrefGD<'a>),


### PR DESCRIPTION
With this, action definitions can be parsed (modulo p-effects of `:numeric-fluents` and `:object-fluents`).