### PR TITLE
Add PDDL 1.2 domain extensions parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Parsers were implemented based on the BNF elements listed in the paper:
 > "Complete BNF description of PDDL 3.1 (completely corrected)",
 > _Daniel L. Kovacs_
 
+Additional elements were added based on the individual specification papers.
+
 ### Domain Description
 
 - [x] [`<domain>`](src/parsers/domain.rs)
@@ -95,6 +97,12 @@ Parsers were implemented based on the BNF elements listed in the paper:
 - [x] [`<assign-op-t>`](src/parsers/assign_op_t.rs)
 - [x] [`<f-exp-t>`](src/parsers/f_exp_t.rs)
 - [x] [`<derived-def>`](src/parsers/derived_predicate.rs)
+
+Additional elements:
+
+- [x] [`<extension-def>`](src/parsers/domain.rs)
+- [ ] `<domain-vars-def>`
+- [ ] `<timeless-def>`
 
 ### Problem Description
 

--- a/src/parsers/domain.rs
+++ b/src/parsers/domain.rs
@@ -66,6 +66,10 @@ pub fn parse_domain(input: &str) -> IResult<&str, Domain> {
             "define",
             tuple((
                 prefix_expr("domain", parse_name),
+                opt(preceded(
+                    multispace1,
+                    prefix_expr(":extends", space_separated_list1(parse_name)),
+                )),
                 opt(preceded(multispace1, parse_require_def)),
                 // :typing
                 opt(preceded(multispace1, parse_types_def)),
@@ -84,9 +88,20 @@ pub fn parse_domain(input: &str) -> IResult<&str, Domain> {
                 )),
             )),
         )),
-        |(name, require, types, constants, predicates, functions, constraints, structure)| {
+        |(
+            name,
+            extends,
+            require,
+            types,
+            constants,
+            predicates,
+            functions,
+            constraints,
+            structure,
+        )| {
             Domain::new(
                 name,
+                extends.unwrap_or(Vec::default()),
                 require.unwrap_or(Requirements::default()),
                 types.unwrap_or(Types::default()),
                 constants.unwrap_or(Constants::default()),

--- a/src/types/domain.rs
+++ b/src/types/domain.rs
@@ -1,7 +1,7 @@
 //! Contains the [`Domain`] type.
 
 use crate::types::{
-    ConGD, Constants, Functions, PredicateDefinitions, Requirements, StructureDefs,
+    ConGD, Constants, Functions, PredicateDefinitions, Requirement, Requirements, StructureDefs,
 };
 use crate::types::{Name, Types};
 
@@ -9,14 +9,16 @@ use crate::types::{Name, Types};
 #[derive(Debug, Clone, PartialEq)]
 pub struct Domain<'a> {
     name: Name<'a>,
+    /// PDDL 1.2
+    extends: Vec<Name<'a>>,
     requirements: Requirements,
-    /// Requires [Typing](crate::types::Requirement::Typing).
+    /// Requires [Typing](Requirement::Typing).
     types: Types<'a>,
     constants: Constants<'a>,
     predicates: PredicateDefinitions<'a>,
-    /// Requires [Fluents](crate::types::Requirement::Fluents).
+    /// Requires [Fluents](Requirement::Fluents).
     functions: Functions<'a>,
-    /// Requires [Constraints](crate::types::Requirement::Constraints).
+    /// Requires [Constraints](Requirement::Constraints).
     constraints: ConGD<'a>,
     structure: StructureDefs<'a>,
 }
@@ -24,6 +26,7 @@ pub struct Domain<'a> {
 impl<'a> Domain<'a> {
     pub fn new(
         name: Name<'a>,
+        extends: Vec<Name<'a>>,
         requirements: Requirements,
         types: Types<'a>,
         constants: Constants<'a>,
@@ -34,6 +37,7 @@ impl<'a> Domain<'a> {
     ) -> Self {
         Self {
             name,
+            extends,
             requirements,
             types,
             constants,
@@ -44,19 +48,86 @@ impl<'a> Domain<'a> {
         }
     }
 
+    /// Creates a builder to easily construct problems.
+    pub fn builder(name: Name<'a>, structure: StructureDefs<'a>) -> Self {
+        Self {
+            name,
+            extends: Vec::default(),
+            requirements: Requirements::default(),
+            types: Types::default(),
+            constants: Constants::default(),
+            predicates: PredicateDefinitions::default(),
+            functions: Functions::default(),
+            constraints: ConGD::default(),
+            structure,
+        }
+    }
+
+    /// Adds a list of optional domain names this domain definition extends upon.
+    /// This is a PDDL 1.2 construct.
+    pub fn with_extends<N: IntoIterator<Item = Name<'a>>>(mut self, names: N) -> Self {
+        self.extends = names.into_iter().collect();
+        self
+    }
+
+    /// Adds a list of optional domain requirements.
+    pub fn with_requirements<R: IntoIterator<Item = Requirement>>(
+        mut self,
+        requirements: R,
+    ) -> Self {
+        self.requirements = requirements.into_iter().collect();
+        self
+    }
+
+    /// Adds a list of optional type declarations.
+    pub fn with_types<T: Into<Types<'a>>>(mut self, types: T) -> Self {
+        self.types = types.into();
+        self
+    }
+
+    /// Adds a list of optional constant declarations.
+    pub fn with_constants<C: Into<Constants<'a>>>(mut self, constants: C) -> Self {
+        self.constants = constants.into();
+        self
+    }
+
+    /// Adds a list of optional predicate definitions.
+    pub fn with_predicates<P: Into<PredicateDefinitions<'a>>>(mut self, predicates: P) -> Self {
+        self.predicates = predicates.into();
+        self
+    }
+
+    /// Adds a list of optional function definitions.
+    pub fn with_functions<F: Into<Functions<'a>>>(mut self, functions: F) -> Self {
+        self.functions = functions.into();
+        self
+    }
+
+    /// Adds a list of optional constraints.
+    pub fn with_constraints(mut self, constraints: ConGD<'a>) -> Self {
+        self.constraints = constraints;
+        self
+    }
+
     /// Gets the domain name.
     pub const fn name(&self) -> &Name<'a> {
         &self.name
     }
 
+    /// Gets the names of the domains this definition extends.
+    /// This is a PDDL 1.2 construct.
+    pub fn extends(&self) -> &[Name<'a>] {
+        &self.extends.as_slice()
+    }
+
     /// Returns the optional domain requirements.
-    /// If no requirements were specified by the domain, [Strips](crate::types::Requirement::Strips) is implied.
+    /// If no requirements were specified by the domain, [Strips](Requirement::Strips) is implied.
     pub const fn requirements(&self) -> &Requirements {
         &self.requirements
     }
 
     /// Returns the optional type declarations.
-    /// Requires [Typing](crate::types::Requirement::Typing).
+    /// Requires [Typing](Requirement::Typing).
     pub const fn types(&self) -> &Types<'a> {
         &self.types
     }
@@ -72,7 +143,7 @@ impl<'a> Domain<'a> {
     }
 
     /// Returns the optional function definitions.
-    /// Requires [Fluents](crate::types::Requirement::Fluents).
+    /// Requires [Fluents](Requirement::Fluents).
     pub const fn functions(&self) -> &Functions<'a> {
         &self.functions
     }


### PR DESCRIPTION
This adds `(:extends <name>+)` support from PDDL 1.2.