### PR TITLE
Re-export types and Parser trait top-level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+
+- Added `Parser` trait.
+
+### Changed
+
+- Made `types` module private and re-exported all types top-level.
+
+## [0.0.1] - 2023-04-23
+
+### Added
+
+- Minor usability adjustments such as added accessors for internal state of structs.
+
+## [0.0.0] - 2023-04-23
+
+### Internal
+
+- 🎉 Initial release.
+
+[0.0.1]: https://github.com/sunsided/pddl-rs/releases/tag/0.0.1
+[0.0.0]: https://github.com/sunsided/pddl-rs/releases/tag/0.0.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,7 @@
 //!
 //! ## Example
 //! ```
-//! use pddl::parsers::Parser;
-//! use pddl::types::{Domain, Problem};
+//! use pddl::{Parser, Domain, Problem};
 //!
 //! const BRIEFCASE_WORLD: &'static str = r#"
 //!     (define (domain briefcase-world)
@@ -60,7 +59,7 @@
 //! assert_eq!(problem.domain(), &"briefcase-world".into());
 //! assert!(problem.requirements().is_empty());
 //! assert_eq!(problem.init().len(), 9);
-//! assert!(matches! { problem.goal(), pddl::types::PreGD::And(_) });
+//! assert!(matches! { problem.goal(), pddl::PreGD::And(_) });
 //! ```
 
 // only enables the `doc_cfg` feature when
@@ -70,5 +69,13 @@
 #[cfg_attr(docsrs, doc(cfg(feature = "parser")))]
 #[cfg(feature = "parser")]
 pub mod parsers;
-pub mod types;
+mod types;
 pub(crate) mod visitor;
+
+// re-export Parser trait.
+#[cfg_attr(docsrs, doc(cfg(feature = "parser")))]
+#[cfg(feature = "parser")]
+pub use parsers::Parser;
+
+// re-export types
+pub use types::*;

--- a/src/parsers/action_def.rs
+++ b/src/parsers/action_def.rs
@@ -81,6 +81,7 @@ pub fn parse_action_def(input: &str) -> IResult<&str, ActionDefinition> {
 impl<'a> crate::parsers::Parser<'a> for ActionDefinition<'a> {
     type Item = ActionDefinition<'a>;
 
+    /// See [`parse_action_def`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_action_def(input)
     }

--- a/src/parsers/action_def.rs
+++ b/src/parsers/action_def.rs
@@ -13,10 +13,8 @@ use nom::IResult;
 ///
 /// ## Example
 /// ```
+/// # use pddl::{ActionDefinition, ActionSymbol, AtomicFormula, CEffect, Effect, GoalDefinition, Name, PEffect, Predicate, PreferenceGD, PreGD, Term, ToTyped, TypedList, Variable};
 /// # use pddl::parsers::parse_action_def;
-/// # use pddl::types::{ActionDefinition, ActionSymbol, AtomicFormula, CEffect, Effect, GoalDefinition, PEffect, Predicate, PreferenceGD, PreGD, Term, Variable};
-/// # use pddl::types::{Name, ToTyped, TypedList};
-///
 /// let input = r#"(:action take-out
 ///                     :parameters (?x - physob)
 ///                     :precondition (not (= ?x B))

--- a/src/parsers/action_symbol.rs
+++ b/src/parsers/action_symbol.rs
@@ -28,6 +28,7 @@ pub fn parse_action_symbol(input: &str) -> IResult<&str, ActionSymbol> {
 impl<'a> crate::parsers::Parser<'a> for ActionSymbol<'a> {
     type Item = ActionSymbol<'a>;
 
+    /// See [`parse_action_symbol`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_action_symbol(input)
     }

--- a/src/parsers/assign_op.rs
+++ b/src/parsers/assign_op.rs
@@ -32,6 +32,7 @@ pub fn parse_assign_op(input: &str) -> IResult<&str, AssignOp> {
 impl<'a> crate::parsers::Parser<'a> for AssignOp {
     type Item = AssignOp;
 
+    /// See [`parse_assign_op`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_assign_op(input)
     }

--- a/src/parsers/assign_op.rs
+++ b/src/parsers/assign_op.rs
@@ -12,7 +12,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_assign_op;
-/// # use pddl::types::{AssignOp};
+/// # use pddl::{AssignOp};
 /// assert_eq!(parse_assign_op("assign"), Ok(("", AssignOp::Assign)));
 /// assert_eq!(parse_assign_op("scale-up"), Ok(("", AssignOp::ScaleUp)));
 ///```

--- a/src/parsers/assign_op_t.rs
+++ b/src/parsers/assign_op_t.rs
@@ -12,7 +12,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_assign_op_t;
-/// # use pddl::types::{AssignOpT};
+/// # use pddl::{AssignOpT};
 /// assert_eq!(parse_assign_op_t("increase"), Ok(("", AssignOpT::Increase)));
 /// assert_eq!(parse_assign_op_t("decrease"), Ok(("", AssignOpT::Decrease)));
 ///```

--- a/src/parsers/assign_op_t.rs
+++ b/src/parsers/assign_op_t.rs
@@ -26,6 +26,7 @@ pub fn parse_assign_op_t(input: &str) -> IResult<&str, AssignOpT> {
 impl<'a> crate::parsers::Parser<'a> for AssignOpT {
     type Item = AssignOpT;
 
+    /// See [`parse_assign_op_t`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_assign_op_t(input)
     }

--- a/src/parsers/atomic_formula.rs
+++ b/src/parsers/atomic_formula.rs
@@ -17,8 +17,7 @@ use nom::IResult;
 /// # use nom::character::complete::alpha1;
 /// # use pddl::parsers::atomic_formula;
 /// # use pddl::parsers::parse_name;
-/// # use pddl::types::{AtomicFormula, EqualityAtomicFormula, PredicateAtomicFormula, Predicate};
-///
+/// # use pddl::{AtomicFormula, EqualityAtomicFormula, PredicateAtomicFormula, Predicate};
 /// assert_eq!(atomic_formula(parse_name)("(= x y)"), Ok(("",
 ///     AtomicFormula::Equality(EqualityAtomicFormula::new("x".into(), "y".into()))
 /// )));

--- a/src/parsers/atomic_formula_skeleton.rs
+++ b/src/parsers/atomic_formula_skeleton.rs
@@ -33,6 +33,7 @@ pub fn parse_atomic_formula_skeleton(input: &str) -> IResult<&str, AtomicFormula
 impl<'a> crate::parsers::Parser<'a> for AtomicFormulaSkeleton<'a> {
     type Item = AtomicFormulaSkeleton<'a>;
 
+    /// See [`parse_atomic_formula_skeleton`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_atomic_formula_skeleton(input)
     }

--- a/src/parsers/atomic_formula_skeleton.rs
+++ b/src/parsers/atomic_formula_skeleton.rs
@@ -12,9 +12,8 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_atomic_formula_skeleton;
-/// # use pddl::types::{Variable, AtomicFormulaSkeleton, Predicate};
-/// # use pddl::types::{ToTyped, TypedList};
-///
+/// # use pddl::{Variable, AtomicFormulaSkeleton, Predicate};
+/// # use pddl::{ToTyped, TypedList};
 /// assert_eq!(parse_atomic_formula_skeleton("(at ?x - physob ?y - location)"), Ok(("",
 ///     AtomicFormulaSkeleton::new(
 ///         Predicate::from("at"),

--- a/src/parsers/atomic_function_skeleton.rs
+++ b/src/parsers/atomic_function_skeleton.rs
@@ -35,6 +35,7 @@ pub fn parse_atomic_function_skeleton(input: &str) -> IResult<&str, AtomicFuncti
 impl<'a> crate::parsers::Parser<'a> for AtomicFunctionSkeleton<'a> {
     type Item = AtomicFunctionSkeleton<'a>;
 
+    /// See [`parse_atomic_function_skeleton`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_atomic_function_skeleton(input)
     }

--- a/src/parsers/atomic_function_skeleton.rs
+++ b/src/parsers/atomic_function_skeleton.rs
@@ -12,9 +12,8 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_atomic_function_skeleton;
-/// # use pddl::types::{Variable, AtomicFunctionSkeleton, Predicate, FunctionSymbol};
-/// # use pddl::types::{ToTyped, TypedList};
-///
+/// # use pddl::{Variable, AtomicFunctionSkeleton, Predicate, FunctionSymbol};
+/// # use pddl::{ToTyped, TypedList};
 /// assert_eq!(parse_atomic_function_skeleton("(battery-amount ?r - rover)"), Ok(("",
 ///     AtomicFunctionSkeleton::new(
 ///         FunctionSymbol::from("battery-amount"),

--- a/src/parsers/basic_function_term.rs
+++ b/src/parsers/basic_function_term.rs
@@ -12,7 +12,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_basic_function_term;
-/// # use pddl::types::{BasicFunctionTerm, Term};
+/// # use pddl::{BasicFunctionTerm, Term};
 /// assert_eq!(parse_basic_function_term("abcde"), Ok(("",
 ///     BasicFunctionTerm::new("abcde".into(), [])
 /// )));

--- a/src/parsers/basic_function_term.rs
+++ b/src/parsers/basic_function_term.rs
@@ -40,6 +40,7 @@ pub fn parse_basic_function_term(input: &str) -> IResult<&str, BasicFunctionTerm
 impl<'a> crate::parsers::Parser<'a> for BasicFunctionTerm<'a> {
     type Item = BasicFunctionTerm<'a>;
 
+    /// See [`parse_basic_function_term`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_basic_function_term(input)
     }

--- a/src/parsers/binary_comp.rs
+++ b/src/parsers/binary_comp.rs
@@ -34,6 +34,7 @@ pub fn parse_binary_comp(input: &str) -> IResult<&str, BinaryComp> {
 impl<'a> crate::parsers::Parser<'a> for BinaryComp {
     type Item = BinaryComp;
 
+    /// See [`parse_binary_comp`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_binary_comp(input)
     }

--- a/src/parsers/binary_comp.rs
+++ b/src/parsers/binary_comp.rs
@@ -11,7 +11,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_binary_comp;
-/// # use pddl::types::{AssignOp, BinaryComp};
+/// # use pddl::{AssignOp, BinaryComp};
 /// assert_eq!(parse_binary_comp(">"), Ok(("", BinaryComp::GreaterThan)));
 /// assert_eq!(parse_binary_comp("<"), Ok(("", BinaryComp::LessThan)));
 /// assert_eq!(parse_binary_comp("="), Ok(("", BinaryComp::Equal)));

--- a/src/parsers/binary_op.rs
+++ b/src/parsers/binary_op.rs
@@ -11,7 +11,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_binary_op;
-/// # use pddl::types::{BinaryOp};
+/// # use pddl::{BinaryOp};
 /// assert_eq!(parse_binary_op("*"), Ok(("", BinaryOp::Multiplication)));
 /// assert_eq!(parse_binary_op("+"), Ok(("", BinaryOp::Addition)));
 /// assert_eq!(parse_binary_op("-"), Ok(("", BinaryOp::Subtraction)));

--- a/src/parsers/binary_op.rs
+++ b/src/parsers/binary_op.rs
@@ -32,6 +32,7 @@ pub fn parse_binary_op(input: &str) -> IResult<&str, BinaryOp> {
 impl<'a> crate::parsers::Parser<'a> for BinaryOp {
     type Item = BinaryOp;
 
+    /// See [`parse_binary_op`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_binary_op(input)
     }

--- a/src/parsers/c_effect.rs
+++ b/src/parsers/c_effect.rs
@@ -80,6 +80,7 @@ pub fn parse_c_effect(input: &str) -> IResult<&str, CEffect> {
 impl<'a> crate::parsers::Parser<'a> for CEffect<'a> {
     type Item = CEffect<'a>;
 
+    /// See [`parse_c_effect`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_c_effect(input)
     }

--- a/src/parsers/c_effect.rs
+++ b/src/parsers/c_effect.rs
@@ -14,8 +14,8 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_c_effect;
-/// # use pddl::types::{AtomicFormula, CEffect, Effect, EqualityAtomicFormula, PEffect, Term, Variable};
-/// # use pddl::types::{Typed, TypedList};
+/// # use pddl::{AtomicFormula, CEffect, Effect, EqualityAtomicFormula, PEffect, Term, Variable};
+/// # use pddl::{Typed, TypedList};
 /// assert_eq!(parse_c_effect("(= x y)"), Ok(("",
 ///     CEffect::Effect(
 ///         PEffect::AtomicFormula(AtomicFormula::Equality(

--- a/src/parsers/con_gd.rs
+++ b/src/parsers/con_gd.rs
@@ -15,7 +15,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_con_gd;
-/// # use pddl::types::{AtomicFormula, Con2GD, ConGD, GoalDefinition, Number, Term, ToTyped, Type, TypedList, Variable};
+/// # use pddl::{AtomicFormula, Con2GD, ConGD, GoalDefinition, Number, Term, ToTyped, Type, TypedList, Variable};
 /// // (= x y)
 /// let gd_a =
 ///     GoalDefinition::new_atomic_formula(
@@ -132,7 +132,7 @@ use nom::IResult;
 ///
 /// ```
 /// # use pddl::parsers::parse_con_gd;
-/// # use pddl::types::{AtomicFormula, Con2GD, ConGD, GoalDefinition, Number, Term};
+/// # use pddl::{AtomicFormula, Con2GD, ConGD, GoalDefinition, Number, Term};
 /// # // (= x y)
 /// # let gd =
 /// #    GoalDefinition::new_atomic_formula(

--- a/src/parsers/con_gd.rs
+++ b/src/parsers/con_gd.rs
@@ -268,6 +268,7 @@ fn parse_con2_gd(input: &str) -> IResult<&str, Con2GD> {
 impl<'a> crate::parsers::Parser<'a> for ConGD<'a> {
     type Item = ConGD<'a>;
 
+    /// See [`parse_con_gd`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_con_gd(input)
     }
@@ -276,6 +277,7 @@ impl<'a> crate::parsers::Parser<'a> for ConGD<'a> {
 impl<'a> crate::parsers::Parser<'a> for Con2GD<'a> {
     type Item = Con2GD<'a>;
 
+    /// See [`parse_con2_gd`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_con2_gd(input)
     }

--- a/src/parsers/cond_effect.rs
+++ b/src/parsers/cond_effect.rs
@@ -12,7 +12,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_cond_effect;
-/// # use pddl::types::{AtomicFormula, CEffect, ConditionalEffect, EqualityAtomicFormula, PEffect, Term};
+/// # use pddl::{AtomicFormula, CEffect, ConditionalEffect, EqualityAtomicFormula, PEffect, Term};
 /// assert_eq!(parse_cond_effect("(= x y)"), Ok(("",
 ///     ConditionalEffect::Single(
 ///         PEffect::AtomicFormula(AtomicFormula::Equality(

--- a/src/parsers/cond_effect.rs
+++ b/src/parsers/cond_effect.rs
@@ -54,6 +54,7 @@ pub fn parse_cond_effect(input: &str) -> IResult<&str, ConditionalEffect> {
 impl<'a> crate::parsers::Parser<'a> for ConditionalEffect<'a> {
     type Item = ConditionalEffect<'a>;
 
+    /// See [`parse_cond_effect`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_cond_effect(input)
     }

--- a/src/parsers/constants_def.rs
+++ b/src/parsers/constants_def.rs
@@ -10,9 +10,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_constants_def;
-/// # use pddl::types::{Variable, AtomicFormulaSkeleton, Predicate, PredicateDefinitions, Constants};
-/// use pddl::types::{Name, ToTyped, TypedList};
-///
+/// # use pddl::{Variable, AtomicFormulaSkeleton, Predicate, PredicateDefinitions, Constants, Name, ToTyped, TypedList};
 /// let input = "(:constants B P D - physob)";
 /// assert_eq!(parse_constants_def(input), Ok(("",
 ///     Constants::new(TypedList::from_iter([

--- a/src/parsers/constants_def.rs
+++ b/src/parsers/constants_def.rs
@@ -29,6 +29,7 @@ pub fn parse_constants_def(input: &str) -> IResult<&str, Constants> {
 impl<'a> crate::parsers::Parser<'a> for Constants<'a> {
     type Item = Constants<'a>;
 
+    /// See [`parse_constants_def`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_constants_def(input)
     }

--- a/src/parsers/d_op.rs
+++ b/src/parsers/d_op.rs
@@ -31,6 +31,7 @@ pub fn parse_d_op(input: &str) -> IResult<&str, DOp> {
 impl<'a> crate::parsers::Parser<'a> for DOp {
     type Item = DOp;
 
+    /// See [`parse_d_op`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_d_op(input)
     }

--- a/src/parsers/d_op.rs
+++ b/src/parsers/d_op.rs
@@ -11,7 +11,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_d_op;
-/// # use pddl::types::{DOp};
+/// # use pddl::{DOp};
 /// assert_eq!(parse_d_op("<="), Ok(("", DOp::LessThanOrEqual)));
 /// assert_eq!(parse_d_op(">="), Ok(("", DOp::GreaterOrEqual)));
 /// assert_eq!(parse_d_op("="), Ok(("", DOp::Equal)));

--- a/src/parsers/d_value.rs
+++ b/src/parsers/d_value.rs
@@ -12,7 +12,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_d_value;
-/// # use pddl::types::{BinaryOp, DurationValue, FExp, FHead, FunctionSymbol, MultiOp};
+/// # use pddl::{BinaryOp, DurationValue, FExp, FHead, FunctionSymbol, MultiOp};
 /// assert_eq!(parse_d_value("1.23"), Ok(("",
 ///     DurationValue::new_number(1.23)
 /// )));

--- a/src/parsers/d_value.rs
+++ b/src/parsers/d_value.rs
@@ -35,6 +35,7 @@ pub fn parse_d_value(input: &str) -> IResult<&str, DurationValue> {
 impl<'a> crate::parsers::Parser<'a> for DurationValue<'a> {
     type Item = DurationValue<'a>;
 
+    /// See [`parse_d_value`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_d_value(input)
     }

--- a/src/parsers/da_def.rs
+++ b/src/parsers/da_def.rs
@@ -16,8 +16,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_action_def, parse_da_def};
-/// # use pddl::types::{ActionDefinition, ActionSymbol, AtomicFormula, CEffect, Effect, GoalDefinition, Literal, PEffect, Predicate, Preference, PreferenceGD, PreGD, Term, Variable};
-///
+/// # use pddl::{ActionDefinition, ActionSymbol, AtomicFormula, CEffect, Effect, GoalDefinition, Literal, PEffect, Predicate, Preference, PreferenceGD, PreGD, Term, Variable};
 /// let input = r#"(:durative-action move
 ///         :parameters
 ///             (?r - rover

--- a/src/parsers/da_def.rs
+++ b/src/parsers/da_def.rs
@@ -95,6 +95,7 @@ pub fn parse_da_def(input: &str) -> IResult<&str, DurativeActionDefinition> {
 impl<'a> crate::parsers::Parser<'a> for DurativeActionDefinition<'a> {
     type Item = DurativeActionDefinition<'a>;
 
+    /// See [`parse_da_def`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_da_def(input)
     }

--- a/src/parsers/da_effect.rs
+++ b/src/parsers/da_effect.rs
@@ -112,6 +112,7 @@ pub fn parse_da_effect(input: &str) -> IResult<&str, DurativeActionEffect> {
 impl<'a> crate::parsers::Parser<'a> for DurativeActionEffect<'a> {
     type Item = DurativeActionEffect<'a>;
 
+    /// See [`parse_da_effect`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_da_effect(input)
     }

--- a/src/parsers/da_effect.rs
+++ b/src/parsers/da_effect.rs
@@ -14,8 +14,8 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_da_effect;
-/// # use pddl::types::{AtomicFormula, ConditionalEffect, DurativeActionEffect, EqualityAtomicFormula, PEffect, Term, TimedEffect, TimeSpecifier, Variable};
-/// # use pddl::types::{Typed, TypedList};
+/// # use pddl::{AtomicFormula, ConditionalEffect, DurativeActionEffect, EqualityAtomicFormula, PEffect, Term, TimedEffect, TimeSpecifier, Variable};
+/// # use pddl::{Typed, TypedList};
 /// assert_eq!(parse_da_effect("(at start (= x y))"), Ok(("",
 ///     DurativeActionEffect::Timed(
 ///         TimedEffect::new_conditional(

--- a/src/parsers/da_gd.rs
+++ b/src/parsers/da_gd.rs
@@ -110,6 +110,7 @@ pub fn parse_da_gd(input: &str) -> IResult<&str, DurativeActionGoalDefinition> {
 impl<'a> crate::parsers::Parser<'a> for DurativeActionGoalDefinition<'a> {
     type Item = DurativeActionGoalDefinition<'a>;
 
+    /// See [`parse_da_gd`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_da_gd(input)
     }

--- a/src/parsers/da_gd.rs
+++ b/src/parsers/da_gd.rs
@@ -14,9 +14,8 @@ use nom::IResult;
 /// ## Examples
 /// ```
 /// # use pddl::parsers::{parse_da_gd};
-/// # use pddl::types::{AtomicFormula, EqualityAtomicFormula, GoalDefinition, Literal, Preference, PreferenceName, PreferenceGD, PreGD, Term, Variable, DurativeActionGoalDefinition, PrefTimedGD, TimedGD, TimeSpecifier, Interval};
-/// # use pddl::types::{Typed, TypedList};
-///
+/// # use pddl::{AtomicFormula, EqualityAtomicFormula, GoalDefinition, Literal, Preference, PreferenceName, PreferenceGD, PreGD, Term, Variable, DurativeActionGoalDefinition, PrefTimedGD, TimedGD, TimeSpecifier, Interval};
+/// # use pddl::{Typed, TypedList};
 /// assert_eq!(parse_da_gd("(at start (= x y))"), Ok(("",
 ///     DurativeActionGoalDefinition::Timed(
 ///         PrefTimedGD::Required(

--- a/src/parsers/da_symbol.rs
+++ b/src/parsers/da_symbol.rs
@@ -19,6 +19,7 @@ pub fn parse_da_symbol(input: &str) -> IResult<&str, DurativeActionSymbol> {
 impl<'a> crate::parsers::Parser<'a> for DurativeActionSymbol<'a> {
     type Item = DurativeActionSymbol<'a>;
 
+    /// See [`parse_da_symbol`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_da_symbol(input)
     }

--- a/src/parsers/derived_predicate.rs
+++ b/src/parsers/derived_predicate.rs
@@ -41,6 +41,7 @@ pub fn parse_derived_predicate(input: &str) -> IResult<&str, DerivedPredicate> {
 impl<'a> crate::parsers::Parser<'a> for DerivedPredicate<'a> {
     type Item = DerivedPredicate<'a>;
 
+    /// See [`parse_derived_predicate`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_derived_predicate(input)
     }

--- a/src/parsers/derived_predicate.rs
+++ b/src/parsers/derived_predicate.rs
@@ -13,8 +13,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_derived_predicate;
-/// # use pddl::types::GoalDefinition;
-///
+/// # use pddl::GoalDefinition;
 /// let input = r#"(:derived (train-usable ?t - train)
 ///                     (and
 ///                         (train-has-guard ?t)

--- a/src/parsers/domain.rs
+++ b/src/parsers/domain.rs
@@ -19,7 +19,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_action_def, parse_domain};
-/// # use pddl::types::Name;
+/// # use pddl::Name;
 ///
 /// let input = r#"(define (domain briefcase-world)
 ///       (:requirements :strips :equality :typing :conditional-effects)

--- a/src/parsers/domain.rs
+++ b/src/parsers/domain.rs
@@ -114,6 +114,7 @@ pub fn parse_domain(input: &str) -> IResult<&str, Domain> {
 impl<'a> crate::parsers::Parser<'a> for Domain<'a> {
     type Item = Domain<'a>;
 
+    /// See [`parse_domain`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_domain(input)
     }

--- a/src/parsers/domain_constraints_def.rs
+++ b/src/parsers/domain_constraints_def.rs
@@ -28,6 +28,7 @@ pub fn parse_domain_constraints_def(input: &str) -> IResult<&str, DomainConstrai
 impl<'a> crate::parsers::Parser<'a> for DomainConstraintsDef<'a> {
     type Item = DomainConstraintsDef<'a>;
 
+    /// See [`parse_domain_constraints_def`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_domain_constraints_def(input)
     }

--- a/src/parsers/domain_constraints_def.rs
+++ b/src/parsers/domain_constraints_def.rs
@@ -10,8 +10,8 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_domain_constraints_def, parse_functions_def};
-/// # use pddl::types::{Variable, AtomicFormulaSkeleton, Predicate, PredicateDefinitions, FunctionTypedList, FunctionTyped, AtomicFunctionSkeleton, FunctionSymbol, Functions, ConGD, DomainConstraintsDef};
-/// # use pddl::types::{Type, Typed, TypedList};
+/// # use pddl::{Variable, AtomicFormulaSkeleton, Predicate, PredicateDefinitions, FunctionTypedList, FunctionTyped, AtomicFunctionSkeleton, FunctionSymbol, Functions, ConGD, DomainConstraintsDef};
+/// # use pddl::{Type, Typed, TypedList};
 ///
 /// let input = "(:constraints (and))";
 /// assert_eq!(parse_domain_constraints_def(input), Ok(("",

--- a/src/parsers/duration_constraint.rs
+++ b/src/parsers/duration_constraint.rs
@@ -78,6 +78,7 @@ pub fn parse_duration_constraint(input: &str) -> IResult<&str, Option<DurationCo
 impl<'a> crate::parsers::Parser<'a> for DurationConstraint<'a> {
     type Item = Option<DurationConstraint<'a>>;
 
+    /// See [`parse_duration_constraint`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_duration_constraint(input)
     }

--- a/src/parsers/duration_constraint.rs
+++ b/src/parsers/duration_constraint.rs
@@ -13,8 +13,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_duration_constraint;
-/// # use pddl::types::{DOp, DurationConstraint, DurationValue, FunctionType, SimpleDurationConstraint, TimeSpecifier};
-///
+/// # use pddl::{DOp, DurationConstraint, DurationValue, FunctionType, SimpleDurationConstraint, TimeSpecifier};
 /// let input = "()";
 /// assert_eq!(parse_duration_constraint(input), Ok(("", None)));
 ///

--- a/src/parsers/effect.rs
+++ b/src/parsers/effect.rs
@@ -59,6 +59,7 @@ pub fn parse_effect(input: &str) -> IResult<&str, Effect> {
 impl<'a> crate::parsers::Parser<'a> for Effect<'a> {
     type Item = Effect<'a>;
 
+    /// See [`parse_effect`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_effect(input)
     }

--- a/src/parsers/effect.rs
+++ b/src/parsers/effect.rs
@@ -12,7 +12,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_effect;
-/// # use pddl::types::{AtomicFormula, CEffect, Effect, EqualityAtomicFormula, PEffect, Term};
+/// # use pddl::{AtomicFormula, CEffect, Effect, EqualityAtomicFormula, PEffect, Term};
 /// assert_eq!(parse_effect("(= x y)"), Ok(("",
 ///     Effect::Single(
 ///         CEffect::Effect(

--- a/src/parsers/empty_or.rs
+++ b/src/parsers/empty_or.rs
@@ -12,7 +12,7 @@ use nom::IResult;
 /// ```
 /// # use pddl::parsers::parse_variable;
 /// # use pddl::parsers::empty_or;
-/// # use pddl::types::Variable;
+/// # use pddl::Variable;
 /// let mut parser = empty_or(parse_variable);
 /// assert_eq!(parser("()"), Ok(("", None)));
 /// assert_eq!(parser("?abc"), Ok(("", Some(Variable::from("abc")))));

--- a/src/parsers/f_assign_da.rs
+++ b/src/parsers/f_assign_da.rs
@@ -29,6 +29,7 @@ pub fn parse_f_assign_da(input: &str) -> IResult<&str, FAssignDa> {
 impl<'a> crate::parsers::Parser<'a> for FAssignDa<'a> {
     type Item = FAssignDa<'a>;
 
+    /// See [`parse_f_assign_da`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_f_assign_da(input)
     }

--- a/src/parsers/f_comp.rs
+++ b/src/parsers/f_comp.rs
@@ -44,6 +44,7 @@ pub fn parse_f_comp(input: &str) -> IResult<&str, FComp> {
 impl<'a> crate::parsers::Parser<'a> for FComp<'a> {
     type Item = FComp<'a>;
 
+    /// See [`parse_f_comp`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_f_comp(input)
     }

--- a/src/parsers/f_comp.rs
+++ b/src/parsers/f_comp.rs
@@ -13,7 +13,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_f_comp;
-/// # use pddl::types::{FunctionTerm, Variable, FunctionSymbol, Term, FComp, BinaryComp, FExp, BinaryOp};
+/// # use pddl::{FunctionTerm, Variable, FunctionSymbol, Term, FComp, BinaryComp, FExp, BinaryOp};
 /// assert_eq!(parse_f_comp("(= (+ 1.23 2.34) (+ 1.23 2.34))"), Ok(("",
 ///     FComp::new(
 ///         BinaryComp::Equal,

--- a/src/parsers/f_exp.rs
+++ b/src/parsers/f_exp.rs
@@ -14,7 +14,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_f_exp;
-/// # use pddl::types::{BinaryOp, FExp, FHead, FunctionSymbol, MultiOp};
+/// # use pddl::{BinaryOp, FExp, FHead, FunctionSymbol, MultiOp};
 /// assert_eq!(parse_f_exp("1.23"), Ok(("",
 ///     FExp::new_number(1.23)
 /// )));

--- a/src/parsers/f_exp.rs
+++ b/src/parsers/f_exp.rs
@@ -84,6 +84,7 @@ pub fn parse_f_exp(input: &str) -> IResult<&str, FExp> {
 impl<'a> crate::parsers::Parser<'a> for FExp<'a> {
     type Item = FExp<'a>;
 
+    /// See [`parse_f_exp`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_f_exp(input)
     }

--- a/src/parsers/f_exp_da.rs
+++ b/src/parsers/f_exp_da.rs
@@ -15,7 +15,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_f_exp_da;
-/// # use pddl::types::{BinaryOp, FExpDa, FExp, FunctionSymbol, MultiOp};
+/// # use pddl::{BinaryOp, FExpDa, FExp, FunctionSymbol, MultiOp};
 /// assert_eq!(parse_f_exp_da("?duration"), Ok(("",
 ///     FExpDa::Duration
 /// )));

--- a/src/parsers/f_exp_da.rs
+++ b/src/parsers/f_exp_da.rs
@@ -71,6 +71,7 @@ pub fn parse_f_exp_da(input: &str) -> IResult<&str, FExpDa> {
 impl<'a> crate::parsers::Parser<'a> for FExpDa<'a> {
     type Item = FExpDa<'a>;
 
+    /// See [`parse_f_exp_da`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_f_exp_da(input)
     }

--- a/src/parsers/f_exp_t.rs
+++ b/src/parsers/f_exp_t.rs
@@ -15,7 +15,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_f_exp, parse_f_exp_t};
-/// # use pddl::types::{BinaryOp, FExp, FExpT, FHead, FunctionSymbol, MultiOp, Term, Variable};
+/// # use pddl::{BinaryOp, FExp, FExpT, FHead, FunctionSymbol, MultiOp, Term, Variable};
 /// assert_eq!(parse_f_exp_t("#t"), Ok(("", FExpT::Now)));
 ///
 /// assert_eq!(parse_f_exp_t("(* (fuel ?tank) #t)"), Ok(("",

--- a/src/parsers/f_exp_t.rs
+++ b/src/parsers/f_exp_t.rs
@@ -59,6 +59,7 @@ pub fn parse_f_exp_t(input: &str) -> IResult<&str, FExpT> {
 impl<'a> crate::parsers::Parser<'a> for FExpT<'a> {
     type Item = FExpT<'a>;
 
+    /// See [`parse_f_exp_t`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_f_exp_t(input)
     }

--- a/src/parsers/f_head.rs
+++ b/src/parsers/f_head.rs
@@ -14,7 +14,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_f_head;
-/// # use pddl::types::{FunctionTerm, Variable, FunctionSymbol, Term, FHead};
+/// # use pddl::{FunctionTerm, Variable, FunctionSymbol, Term, FHead};
 /// assert_eq!(parse_f_head("fun-sym"), Ok(("",
 ///     FHead::new(FunctionSymbol::from_str("fun-sym"))
 /// )));

--- a/src/parsers/f_head.rs
+++ b/src/parsers/f_head.rs
@@ -46,6 +46,7 @@ pub fn parse_f_head(input: &str) -> IResult<&str, FHead> {
 impl<'a> crate::parsers::Parser<'a> for FHead<'a> {
     type Item = FHead<'a>;
 
+    /// See [`parse_f_head`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_f_head(input)
     }

--- a/src/parsers/function_symbol.rs
+++ b/src/parsers/function_symbol.rs
@@ -28,6 +28,7 @@ pub fn parse_function_symbol(input: &str) -> IResult<&str, FunctionSymbol> {
 impl<'a> crate::parsers::Parser<'a> for FunctionSymbol<'a> {
     type Item = FunctionSymbol<'a>;
 
+    /// See [`parse_function_symbol`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_function_symbol(input)
     }

--- a/src/parsers/function_term.rs
+++ b/src/parsers/function_term.rs
@@ -40,6 +40,7 @@ pub fn parse_function_term(input: &str) -> IResult<&str, FunctionTerm> {
 impl<'a> crate::parsers::Parser<'a> for FunctionTerm<'a> {
     type Item = FunctionTerm<'a>;
 
+    /// See [`parse_function_term`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_function_term(input)
     }

--- a/src/parsers/function_term.rs
+++ b/src/parsers/function_term.rs
@@ -12,7 +12,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_function_term;
-/// # use pddl::types::{FunctionTerm, Variable, FunctionSymbol, Term};
+/// # use pddl::{FunctionTerm, Variable, FunctionSymbol, Term};
 /// assert_eq!(parse_function_term("(fun-sym)"), Ok(("", FunctionTerm::new("fun-sym".into(), vec![]))));
 ///
 /// let x = Term::Name("x".into());

--- a/src/parsers/function_type.rs
+++ b/src/parsers/function_type.rs
@@ -10,8 +10,8 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_function_type;
-/// # use pddl::types::{FunctionType};
-/// # use pddl::types::Type;
+/// # use pddl::{FunctionType};
+/// # use pddl::Type;
 /// assert_eq!(parse_function_type("number"), Ok(("", FunctionType::new(Type::Exactly("number".into())))));
 /// assert_eq!(parse_function_type("(either object number)"), Ok(("", FunctionType::new(Type::from_iter(["object", "number"])))));
 ///```

--- a/src/parsers/function_type.rs
+++ b/src/parsers/function_type.rs
@@ -22,6 +22,7 @@ pub fn parse_function_type(input: &str) -> IResult<&str, FunctionType> {
 impl<'a> crate::parsers::Parser<'a> for FunctionType<'a> {
     type Item = FunctionType<'a>;
 
+    /// See [`parse_function_type`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_function_type(input)
     }

--- a/src/parsers/function_typed_list.rs
+++ b/src/parsers/function_typed_list.rs
@@ -12,9 +12,8 @@ use nom::IResult;
 /// ```
 /// # use nom::character::complete::alpha1;
 /// # use pddl::parsers::{function_typed_list, parse_atomic_function_skeleton};
-/// # use pddl::types::{AtomicFunctionSkeleton, FunctionSymbol, FunctionTyped, FunctionTypedList, Variable};
-/// # use pddl::types::{Type, Typed, TypedList};
-///
+/// # use pddl::{AtomicFunctionSkeleton, FunctionSymbol, FunctionTyped, FunctionTypedList, Variable};
+/// # use pddl::{Type, Typed, TypedList};
 /// // Single implicitly typed element.
 /// assert_eq!(function_typed_list(parse_atomic_function_skeleton)("(battery-amount ?r - rover)"), Ok(("",
 ///     FunctionTypedList::from_iter([

--- a/src/parsers/functions_def.rs
+++ b/src/parsers/functions_def.rs
@@ -40,6 +40,7 @@ pub fn parse_functions_def(input: &str) -> IResult<&str, Functions> {
 impl<'a> crate::parsers::Parser<'a> for Functions<'a> {
     type Item = Functions<'a>;
 
+    /// See [`parse_functions_def`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_functions_def(input)
     }

--- a/src/parsers/functions_def.rs
+++ b/src/parsers/functions_def.rs
@@ -11,9 +11,8 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_functions_def;
-/// # use pddl::types::{Variable, AtomicFormulaSkeleton, Predicate, PredicateDefinitions, FunctionTypedList, FunctionTyped, AtomicFunctionSkeleton, FunctionSymbol, Functions};
-/// # use pddl::types::{Type, Typed, TypedList};
-///
+/// # use pddl::{Variable, AtomicFormulaSkeleton, Predicate, PredicateDefinitions, FunctionTypedList, FunctionTyped, AtomicFunctionSkeleton, FunctionSymbol, Functions};
+/// # use pddl::{Type, Typed, TypedList};
 /// let input = "(:functions (battery-amount ?r - rover))";
 /// assert_eq!(parse_functions_def(input), Ok(("",
 ///     Functions::from_iter([

--- a/src/parsers/gd.rs
+++ b/src/parsers/gd.rs
@@ -14,9 +14,8 @@ use nom::IResult;
 /// ## Examples
 /// ```
 /// # use pddl::parsers::parse_gd;
-/// # use pddl::types::{AtomicFormula, BinaryComp, BinaryOp, EqualityAtomicFormula, FComp, FExp, GoalDefinition, Literal, Term, Variable};
-/// # use pddl::types::TypedList;
-///
+/// # use pddl::{AtomicFormula, BinaryComp, BinaryOp, EqualityAtomicFormula, FComp, FExp, GoalDefinition, Literal, Term, Variable};
+/// # use pddl::TypedList;
 /// // Atomic formula
 /// assert_eq!(parse_gd("(= x y)"), Ok(("",
 ///     GoalDefinition::AtomicFormula(

--- a/src/parsers/gd.rs
+++ b/src/parsers/gd.rs
@@ -192,6 +192,7 @@ pub fn parse_gd(input: &str) -> IResult<&str, GoalDefinition> {
 impl<'a> crate::parsers::Parser<'a> for GoalDefinition<'a> {
     type Item = GoalDefinition<'a>;
 
+    /// See [`parse_gd`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_gd(input)
     }

--- a/src/parsers/goal_def.rs
+++ b/src/parsers/goal_def.rs
@@ -10,8 +10,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_problem_goal_def};
-/// use pddl::types::{AtomicFormula, GoalDef, GoalDefinition, PreferenceGD, PreGD, Term};
-///
+/// # use pddl::{AtomicFormula, GoalDef, GoalDefinition, PreferenceGD, PreGD, Term};
 /// let input = "(:goal (= x y))";
 /// assert_eq!(parse_problem_goal_def(input), Ok(("",
 ///     GoalDef::new(

--- a/src/parsers/goal_def.rs
+++ b/src/parsers/goal_def.rs
@@ -34,6 +34,7 @@ pub fn parse_problem_goal_def(input: &str) -> IResult<&str, GoalDef> {
 impl<'a> crate::parsers::Parser<'a> for GoalDef<'a> {
     type Item = GoalDef<'a>;
 
+    /// See [`parse_problem_goal_def`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_problem_goal_def(input)
     }

--- a/src/parsers/init_def.rs
+++ b/src/parsers/init_def.rs
@@ -43,6 +43,7 @@ pub fn parse_problem_init_def(input: &str) -> IResult<&str, InitElements> {
 impl<'a> crate::parsers::Parser<'a> for InitElements<'a> {
     type Item = InitElements<'a>;
 
+    /// See [`parse_problem_init_def`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_problem_init_def(input)
     }

--- a/src/parsers/init_def.rs
+++ b/src/parsers/init_def.rs
@@ -10,8 +10,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_problem_init_def};
-/// # use pddl::types::{AtomicFormula, InitElement, InitElements, NameLiteral, Number};
-///
+/// # use pddl::{AtomicFormula, InitElement, InitElements, NameLiteral, Number};
 /// let input = "(:init (train-not-in-use train1) (at 10 (train-not-in-use train2)))";
 /// assert_eq!(parse_problem_init_def(input), Ok(("",
 ///     InitElements::from_iter([

--- a/src/parsers/init_el.rs
+++ b/src/parsers/init_el.rs
@@ -90,6 +90,7 @@ pub fn parse_init_el(input: &str) -> IResult<&str, InitElement> {
 impl<'a> crate::parsers::Parser<'a> for InitElement<'a> {
     type Item = InitElement<'a>;
 
+    /// See [`parse_init_el`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_init_el(input)
     }

--- a/src/parsers/init_el.rs
+++ b/src/parsers/init_el.rs
@@ -13,7 +13,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_init_el;
-/// # use pddl::types::{AtomicFormula, BasicFunctionTerm, InitElement, Name, NameLiteral, Number, Predicate};
+/// # use pddl::{AtomicFormula, BasicFunctionTerm, InitElement, Name, NameLiteral, Number, Predicate};
 /// assert_eq!(parse_init_el("(train-not-in-use train1)"), Ok(("",
 ///     InitElement::new_literal(
 ///         NameLiteral::new(

--- a/src/parsers/interval.rs
+++ b/src/parsers/interval.rs
@@ -21,6 +21,7 @@ pub fn parse_interval(input: &str) -> IResult<&str, Interval> {
 impl<'a> crate::parsers::Parser<'a> for Interval {
     type Item = Interval;
 
+    /// See [`parse_interval`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_interval(input)
     }

--- a/src/parsers/interval.rs
+++ b/src/parsers/interval.rs
@@ -11,7 +11,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_interval;
-/// # use pddl::types::{Interval};
+/// # use pddl::{Interval};
 /// assert_eq!(parse_interval("all"), Ok(("", Interval::All)));
 ///```
 pub fn parse_interval(input: &str) -> IResult<&str, Interval> {

--- a/src/parsers/length_spec.rs
+++ b/src/parsers/length_spec.rs
@@ -12,7 +12,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_problem_length_spec;
-/// # use pddl::types::LengthSpec;
+/// # use pddl::LengthSpec;
 /// assert_eq!(parse_problem_length_spec("(:length)"), Ok(("", LengthSpec::default())));
 /// assert_eq!(parse_problem_length_spec("(:length (:serial 123))"), Ok(("", LengthSpec::new_serial(123))));
 /// assert_eq!(parse_problem_length_spec("(:length (:parallel 42))"), Ok(("", LengthSpec::new_parallel(42))));

--- a/src/parsers/length_spec.rs
+++ b/src/parsers/length_spec.rs
@@ -34,6 +34,7 @@ pub fn parse_problem_length_spec(input: &str) -> IResult<&str, LengthSpec> {
 impl<'a> crate::parsers::Parser<'a> for LengthSpec {
     type Item = LengthSpec;
 
+    /// See [`parse_problem_length_spec`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_problem_length_spec(input)
     }

--- a/src/parsers/literal.rs
+++ b/src/parsers/literal.rs
@@ -14,8 +14,7 @@ use nom::IResult;
 /// # use nom::character::complete::alpha1;
 /// # use pddl::parsers::literal;
 /// # use pddl::parsers::parse_name;
-/// # use pddl::types::{AtomicFormula, EqualityAtomicFormula, PredicateAtomicFormula, Predicate, Literal};
-///
+/// # use pddl::{AtomicFormula, EqualityAtomicFormula, PredicateAtomicFormula, Predicate, Literal};
 /// assert_eq!(literal(parse_name)("(= x y)"), Ok(("",
 ///     Literal::AtomicFormula(
 ///         AtomicFormula::Equality(

--- a/src/parsers/metric_f_exp.rs
+++ b/src/parsers/metric_f_exp.rs
@@ -139,6 +139,7 @@ pub fn parse_metric_f_exp(input: &str) -> IResult<&str, MetricFExp> {
 impl<'a> crate::parsers::Parser<'a> for MetricFExp<'a> {
     type Item = MetricFExp<'a>;
 
+    /// See [`parse_metric_f_exp`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_metric_f_exp(input)
     }

--- a/src/parsers/metric_f_exp.rs
+++ b/src/parsers/metric_f_exp.rs
@@ -18,7 +18,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_metric_f_exp;
-/// # use pddl::types::{BinaryOp, MetricFExp, FunctionSymbol, MultiOp, Name, PreferenceName};
+/// # use pddl::{BinaryOp, MetricFExp, FunctionSymbol, MultiOp, Name, PreferenceName};
 /// assert_eq!(parse_metric_f_exp("1.23"), Ok(("",
 ///     MetricFExp::new_number(1.23)
 /// )));

--- a/src/parsers/metric_spec.rs
+++ b/src/parsers/metric_spec.rs
@@ -37,6 +37,7 @@ pub fn parse_problem_metric_spec(input: &str) -> IResult<&str, MetricSpec> {
 impl<'a> crate::parsers::Parser<'a> for MetricSpec<'a> {
     type Item = MetricSpec<'a>;
 
+    /// See [`parse_problem_metric_spec`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_problem_metric_spec(input)
     }

--- a/src/parsers/metric_spec.rs
+++ b/src/parsers/metric_spec.rs
@@ -12,7 +12,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_problem_metric_spec;
-/// # use pddl::types::{MetricFExp, MetricSpec, Optimization};
+/// # use pddl::{MetricFExp, MetricSpec, Optimization};
 /// assert_eq!(parse_problem_metric_spec("(:metric minimize total-time)"), Ok(("",
 ///     MetricSpec::new(
 ///         Optimization::Minimize,

--- a/src/parsers/multi_op.rs
+++ b/src/parsers/multi_op.rs
@@ -11,7 +11,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_multi_op;
-/// # use pddl::types::{MultiOp};
+/// # use pddl::{MultiOp};
 /// assert_eq!(parse_multi_op("*"), Ok(("", MultiOp::Multiplication)));
 /// assert_eq!(parse_multi_op("+"), Ok(("", MultiOp::Addition)));
 ///```

--- a/src/parsers/multi_op.rs
+++ b/src/parsers/multi_op.rs
@@ -25,6 +25,7 @@ pub fn parse_multi_op(input: &str) -> IResult<&str, MultiOp> {
 impl<'a> crate::parsers::Parser<'a> for MultiOp {
     type Item = MultiOp;
 
+    /// See [`parse_multi_op`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_multi_op(input)
     }

--- a/src/parsers/name.rs
+++ b/src/parsers/name.rs
@@ -53,6 +53,7 @@ pub fn parse_alpha(input: &str) -> IResult<&str, &str> {
 impl<'a> crate::parsers::Parser<'a> for Name<'a> {
     type Item = Name<'a>;
 
+    /// See [`parse_name`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_name(input)
     }

--- a/src/parsers/number.rs
+++ b/src/parsers/number.rs
@@ -52,6 +52,7 @@ pub fn parse_digit(input: &str) -> IResult<&str, &str> {
 impl<'a> crate::parsers::Parser<'a> for Number {
     type Item = Number;
 
+    /// See [`parse_number`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_number(input)
     }

--- a/src/parsers/objects_def.rs
+++ b/src/parsers/objects_def.rs
@@ -10,8 +10,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_problem_objects_declaration};
-/// # use pddl::types::{Name, Objects, ToTyped, Type};
-///
+/// # use pddl::{Name, Objects, ToTyped, Type};
 /// let input = "(:objects train1 train2)";
 /// assert_eq!(parse_problem_objects_declaration(input), Ok(("",
 ///     Objects::new([

--- a/src/parsers/objects_def.rs
+++ b/src/parsers/objects_def.rs
@@ -29,6 +29,7 @@ pub fn parse_problem_objects_declaration(input: &str) -> IResult<&str, Objects> 
 impl<'a> crate::parsers::Parser<'a> for Objects<'a> {
     type Item = Objects<'a>;
 
+    /// See [`parse_problem_objects_declaration`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_problem_objects_declaration(input)
     }

--- a/src/parsers/optimization.rs
+++ b/src/parsers/optimization.rs
@@ -25,6 +25,7 @@ pub fn parse_optimization(input: &str) -> IResult<&str, Optimization> {
 impl<'a> crate::parsers::Parser<'a> for Optimization {
     type Item = Optimization;
 
+    /// See [`parse_optimization`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_optimization(input)
     }

--- a/src/parsers/optimization.rs
+++ b/src/parsers/optimization.rs
@@ -11,7 +11,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_optimization;
-/// # use pddl::types::{Optimization};
+/// # use pddl::{Optimization};
 /// assert_eq!(parse_optimization("minimize"), Ok(("", Optimization::Minimize)));
 /// assert_eq!(parse_optimization("maximize"), Ok(("", Optimization::Maximize)));
 ///```

--- a/src/parsers/p_effect.rs
+++ b/src/parsers/p_effect.rs
@@ -17,7 +17,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_p_effect;
-/// # use pddl::types::{AssignOp, AtomicFormula, EqualityAtomicFormula, FExp, FHead, FunctionSymbol, FunctionTerm, PEffect, Term};
+/// # use pddl::{AssignOp, AtomicFormula, EqualityAtomicFormula, FExp, FHead, FunctionSymbol, FunctionTerm, PEffect, Term};
 /// assert_eq!(parse_p_effect("(= x y)"), Ok(("",
 ///     PEffect::AtomicFormula(AtomicFormula::Equality(
 ///         EqualityAtomicFormula::new(

--- a/src/parsers/p_effect.rs
+++ b/src/parsers/p_effect.rs
@@ -104,6 +104,7 @@ pub fn parse_p_effect(input: &str) -> IResult<&str, PEffect> {
 impl<'a> crate::parsers::Parser<'a> for PEffect<'a> {
     type Item = PEffect<'a>;
 
+    /// See [`parse_p_effect`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_p_effect(input)
     }

--- a/src/parsers/pre_gd.rs
+++ b/src/parsers/pre_gd.rs
@@ -91,6 +91,7 @@ pub fn parse_pre_gd(input: &str) -> IResult<&str, PreGD> {
 impl<'a> crate::parsers::Parser<'a> for PreGD<'a> {
     type Item = PreGD<'a>;
 
+    /// See [`parse_pre_gd`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_pre_gd(input)
     }

--- a/src/parsers/pre_gd.rs
+++ b/src/parsers/pre_gd.rs
@@ -14,9 +14,7 @@ use nom::IResult;
 /// ## Examples
 /// ```
 /// # use pddl::parsers::{parse_pre_gd};
-/// # use pddl::types::{AtomicFormula, EqualityAtomicFormula, GoalDefinition, Literal, Preference, PreferenceName, PreferenceGD, PreGD, Term, Variable};
-/// use pddl::types::{Type, Typed, TypedList};
-///
+/// # use pddl::{AtomicFormula, EqualityAtomicFormula, GoalDefinition, Literal, Preference, PreferenceName, PreferenceGD, PreGD, Term, Variable, Type, Typed, TypedList};
 /// assert_eq!(parse_pre_gd("(= x y)"), Ok(("",
 ///     PreGD::Preference(
 ///         PreferenceGD::Goal(

--- a/src/parsers/predicate.rs
+++ b/src/parsers/predicate.rs
@@ -28,6 +28,7 @@ pub fn parse_predicate(input: &str) -> IResult<&str, Predicate> {
 impl<'a> crate::parsers::Parser<'a> for Predicate<'a> {
     type Item = Predicate<'a>;
 
+    /// See [`parse_predicate`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_predicate(input)
     }

--- a/src/parsers/predicates_def.rs
+++ b/src/parsers/predicates_def.rs
@@ -11,9 +11,8 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_predicates_def;
-/// # use pddl::types::{Variable, AtomicFormulaSkeleton, Predicate, PredicateDefinitions};
-/// # use pddl::types::{ToTyped, TypedList};
-///
+/// # use pddl::{Variable, AtomicFormulaSkeleton, Predicate, PredicateDefinitions};
+/// # use pddl::{ToTyped, TypedList};
 /// let input = r#"(:predicates
 ///                     (at ?x - physob ?y - location)
 ///                     (in ?x ?y - physob)

--- a/src/parsers/predicates_def.rs
+++ b/src/parsers/predicates_def.rs
@@ -48,6 +48,7 @@ pub fn parse_predicates_def(input: &str) -> IResult<&str, PredicateDefinitions> 
 impl<'a> crate::parsers::Parser<'a> for PredicateDefinitions<'a> {
     type Item = PredicateDefinitions<'a>;
 
+    /// See [`parse_predicates_def`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_predicates_def(input)
     }

--- a/src/parsers/pref_con_gd.rs
+++ b/src/parsers/pref_con_gd.rs
@@ -16,7 +16,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_pref_con_gd;
-/// # use pddl::types::{AtomicFormula, Con2GD, ConGD, GoalDefinition, Number, PrefConGD, Term, ToTyped, Type, TypedList, Variable};
+/// # use pddl::{AtomicFormula, Con2GD, ConGD, GoalDefinition, Number, PrefConGD, Term, ToTyped, Type, TypedList, Variable};
 /// // (= x y)
 /// let gd_a =
 ///     GoalDefinition::new_atomic_formula(

--- a/src/parsers/pref_con_gd.rs
+++ b/src/parsers/pref_con_gd.rs
@@ -121,6 +121,7 @@ pub fn parse_pref_con_gd(input: &str) -> IResult<&str, PrefConGD> {
 impl<'a> crate::parsers::Parser<'a> for PrefConGD<'a> {
     type Item = PrefConGD<'a>;
 
+    /// See [`parse_pref_con_gd`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_pref_con_gd(input)
     }

--- a/src/parsers/pref_gd.rs
+++ b/src/parsers/pref_gd.rs
@@ -79,6 +79,7 @@ pub fn parse_pref_gd(input: &str) -> IResult<&str, PreferenceGD> {
 impl<'a> crate::parsers::Parser<'a> for PreferenceGD<'a> {
     type Item = PreferenceGD<'a>;
 
+    /// See [`parse_pref_gd`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_pref_gd(input)
     }

--- a/src/parsers/pref_gd.rs
+++ b/src/parsers/pref_gd.rs
@@ -14,8 +14,7 @@ use nom::IResult;
 /// ## Examples
 /// ```
 /// # use pddl::parsers::parse_pref_gd;
-/// # use pddl::types::{AtomicFormula, EqualityAtomicFormula, GoalDefinition, Literal, Preference, PreferenceName, PreferenceGD, Term, Variable};
-///
+/// # use pddl::{AtomicFormula, EqualityAtomicFormula, GoalDefinition, Literal, Preference, PreferenceName, PreferenceGD, Term, Variable};
 /// // Simple goal definition.
 /// assert_eq!(parse_pref_gd("(= x y)"), Ok(("",
 ///     PreferenceGD::Goal(

--- a/src/parsers/pref_name.rs
+++ b/src/parsers/pref_name.rs
@@ -18,6 +18,7 @@ pub fn parse_pref_name(input: &str) -> IResult<&str, PreferenceName> {
 impl<'a> crate::parsers::Parser<'a> for PreferenceName<'a> {
     type Item = PreferenceName<'a>;
 
+    /// See [`parse_pref_name`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_pref_name(input)
     }

--- a/src/parsers/pref_timed_gd.rs
+++ b/src/parsers/pref_timed_gd.rs
@@ -81,6 +81,7 @@ pub fn parse_pref_timed_gd(input: &str) -> IResult<&str, PrefTimedGD> {
 impl<'a> crate::parsers::Parser<'a> for PrefTimedGD<'a> {
     type Item = PrefTimedGD<'a>;
 
+    /// See [`parse_pref_timed_gd`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_pref_timed_gd(input)
     }

--- a/src/parsers/pref_timed_gd.rs
+++ b/src/parsers/pref_timed_gd.rs
@@ -14,8 +14,7 @@ use nom::IResult;
 /// ## Examples
 /// ```
 /// # use pddl::parsers::{parse_pref_timed_gd};
-/// # use pddl::types::{AtomicFormula, GoalDefinition, Interval, PrefTimedGD, Term, TimedGD, TimeSpecifier};
-///
+/// # use pddl::{AtomicFormula, GoalDefinition, Interval, PrefTimedGD, Term, TimedGD, TimeSpecifier};
 /// assert_eq!(parse_pref_timed_gd("(at start (= x y))"), Ok(("",
 ///     PrefTimedGD::Required(
 ///         TimedGD::new_at(

--- a/src/parsers/primitive_type.rs
+++ b/src/parsers/primitive_type.rs
@@ -30,6 +30,7 @@ fn parse_object(input: &str) -> IResult<&str, Name> {
 impl<'a> crate::parsers::Parser<'a> for PrimitiveType<'a> {
     type Item = PrimitiveType<'a>;
 
+    /// See [`parse_primitive_type`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_primitive_type(input)
     }

--- a/src/parsers/problem.rs
+++ b/src/parsers/problem.rs
@@ -18,8 +18,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_action_def, parse_problem};
-/// # use pddl::types::{Name, PreGD};
-///
+/// # use pddl::{Name, PreGD};
 /// let input = r#"(define (problem get-paid)
 ///         (:domain briefcase-world)
 ///         (:init (place home) (place office)

--- a/src/parsers/problem.rs
+++ b/src/parsers/problem.rs
@@ -74,6 +74,7 @@ pub fn parse_problem(input: &str) -> IResult<&str, Problem> {
 impl<'a> crate::parsers::Parser<'a> for Problem<'a> {
     type Item = Problem<'a>;
 
+    /// See [`parse_problem`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_problem(input)
     }

--- a/src/parsers/problem_constraints_def.rs
+++ b/src/parsers/problem_constraints_def.rs
@@ -29,6 +29,7 @@ pub fn parse_problem_constraints_def(input: &str) -> IResult<&str, ProblemConstr
 impl<'a> crate::parsers::Parser<'a> for ProblemConstraintsDef<'a> {
     type Item = ProblemConstraintsDef<'a>;
 
+    /// See [`parse_problem_constraints_def`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_problem_constraints_def(input)
     }

--- a/src/parsers/problem_constraints_def.rs
+++ b/src/parsers/problem_constraints_def.rs
@@ -10,8 +10,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_problem_constraints_def};
-/// # use pddl::types::{ConGD, ProblemConstraintsDef, PrefConGD};
-///
+/// # use pddl::{ConGD, ProblemConstraintsDef, PrefConGD};
 /// let input = "(:constraints (preference test (and)))";
 /// assert_eq!(parse_problem_constraints_def(input), Ok(("",
 ///     ProblemConstraintsDef::new(

--- a/src/parsers/requirements.rs
+++ b/src/parsers/requirements.rs
@@ -13,7 +13,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_require_def;
-/// # use pddl::types::{Requirement, Requirements};
+/// # use pddl::{Requirement, Requirements};
 /// assert_eq!(parse_require_def("(:requirements :adl)"), Ok(("", Requirements::new([Requirement::Adl]))));
 /// assert_eq!(parse_require_def("(:requirements :strips :typing)"), Ok(("", Requirements::new([Requirement::Strips, Requirement::Typing]))));
 /// assert_eq!(parse_require_def("(:requirements\n:strips   :typing  )"), Ok(("", Requirements::new([Requirement::Strips, Requirement::Typing]))));
@@ -30,7 +30,7 @@ pub fn parse_require_def(input: &str) -> IResult<&str, Requirements> {
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_require_key;
-/// use pddl::types::Requirement;
+/// # use pddl::Requirement;
 /// assert_eq!(parse_require_key(":strips"), Ok(("", Requirement::Strips)));
 /// assert_eq!(parse_require_key(":typing"), Ok(("", Requirement::Typing)));
 /// assert_eq!(parse_require_key(":negative-preconditions"), Ok(("", Requirement::NegativePreconditions)));

--- a/src/parsers/requirements.rs
+++ b/src/parsers/requirements.rs
@@ -95,6 +95,7 @@ impl<'a> crate::parsers::Parser<'a> for Requirements {
 impl<'a> crate::parsers::Parser<'a> for Requirement {
     type Item = Requirement;
 
+    /// See [`parse_require_key`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_require_key(input)
     }

--- a/src/parsers/simple_duration_constraint.rs
+++ b/src/parsers/simple_duration_constraint.rs
@@ -15,8 +15,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_simple_duration_constraint;
-/// # use pddl::types::{DOp, DurationValue, FunctionType, SimpleDurationConstraint, TimeSpecifier};
-///
+/// # use pddl::{DOp, DurationValue, FunctionType, SimpleDurationConstraint, TimeSpecifier};
 /// let input = "(>= ?duration 1.23)";
 /// assert_eq!(parse_simple_duration_constraint(input), Ok(("",
 ///     SimpleDurationConstraint::new_op(

--- a/src/parsers/simple_duration_constraint.rs
+++ b/src/parsers/simple_duration_constraint.rs
@@ -64,6 +64,7 @@ pub fn parse_simple_duration_constraint(input: &str) -> IResult<&str, SimpleDura
 impl<'a> crate::parsers::Parser<'a> for SimpleDurationConstraint<'a> {
     type Item = SimpleDurationConstraint<'a>;
 
+    /// See [`parse_simple_duration_constraint`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_simple_duration_constraint(input)
     }

--- a/src/parsers/structure_def.rs
+++ b/src/parsers/structure_def.rs
@@ -61,6 +61,7 @@ pub fn parse_structure_def(input: &str) -> IResult<&str, StructureDef> {
 impl<'a> crate::parsers::Parser<'a> for StructureDef<'a> {
     type Item = StructureDef<'a>;
 
+    /// See [`parse_structure_def`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_structure_def(input)
     }

--- a/src/parsers/structure_def.rs
+++ b/src/parsers/structure_def.rs
@@ -12,9 +12,8 @@ use nom::IResult;
 ///
 /// ```
 /// # use pddl::parsers::{parse_structure_def};
-/// # use pddl::types::{ActionDefinition, ActionSymbol, AtomicFormula, CEffect, Effect, GoalDefinition, Literal, PEffect, Predicate, Preference, PreferenceGD, PreGD, StructureDef, Term, Variable};
-/// # use pddl::types::{Name, ToTyped, TypedList};
-///
+/// # use pddl::{ActionDefinition, ActionSymbol, AtomicFormula, CEffect, Effect, GoalDefinition, Literal, PEffect, Predicate, Preference, PreferenceGD, PreGD, StructureDef, Term, Variable};
+/// # use pddl::{Name, ToTyped, TypedList};
 /// let input = r#"(:action take-out
 ///                     :parameters (?x - physob)
 ///                     :precondition (not (= ?x B))

--- a/src/parsers/term.rs
+++ b/src/parsers/term.rs
@@ -34,6 +34,7 @@ pub fn parse_term(input: &str) -> IResult<&str, Term> {
 impl<'a> crate::parsers::Parser<'a> for Term<'a> {
     type Item = Term<'a>;
 
+    /// See [`parse_term`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_term(input)
     }

--- a/src/parsers/term.rs
+++ b/src/parsers/term.rs
@@ -11,7 +11,7 @@ use nom::{error_position, IResult};
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_term;
-/// # use pddl::types::Term;
+/// # use pddl::Term;
 /// assert_eq!(parse_term("abcde"), Ok(("", Term::Name("abcde".into()))));
 /// assert_eq!(parse_term("?abcde"), Ok(("", Term::Variable("abcde".into()))));
 ///```

--- a/src/parsers/time_specifier.rs
+++ b/src/parsers/time_specifier.rs
@@ -12,7 +12,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_time_specifier;
-/// # use pddl::types::{TimeSpecifier};
+/// # use pddl::{TimeSpecifier};
 /// assert_eq!(parse_time_specifier("start"), Ok(("", TimeSpecifier::Start)));
 /// assert_eq!(parse_time_specifier("end"), Ok(("", TimeSpecifier::End)));
 ///```

--- a/src/parsers/time_specifier.rs
+++ b/src/parsers/time_specifier.rs
@@ -26,6 +26,7 @@ pub fn parse_time_specifier(input: &str) -> IResult<&str, TimeSpecifier> {
 impl<'a> crate::parsers::Parser<'a> for TimeSpecifier {
     type Item = TimeSpecifier;
 
+    /// See [`parse_time_specifier`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_time_specifier(input)
     }

--- a/src/parsers/timed_effect.rs
+++ b/src/parsers/timed_effect.rs
@@ -92,6 +92,7 @@ pub fn parse_timed_effect(input: &str) -> IResult<&str, TimedEffect> {
 impl<'a> crate::parsers::Parser<'a> for TimedEffect<'a> {
     type Item = TimedEffect<'a>;
 
+    /// See [`parse_timed_effect`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_timed_effect(input)
     }

--- a/src/parsers/timed_effect.rs
+++ b/src/parsers/timed_effect.rs
@@ -17,8 +17,8 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_timed_effect;
-/// # use pddl::types::{AssignOp, AssignOpT, AtomicFormula, CEffect, ConditionalEffect, EqualityAtomicFormula, FAssignDa, FExpDa, FExpT, FHead, PEffect, Term, TimedEffect, TimeSpecifier};
-/// # use pddl::types::FExpDa::FExp;
+/// # use pddl::{AssignOp, AssignOpT, AtomicFormula, CEffect, ConditionalEffect, EqualityAtomicFormula, FAssignDa, FExpDa, FExpT, FHead, PEffect, Term, TimedEffect, TimeSpecifier};
+/// # use pddl::FExpDa::FExp;
 /// assert_eq!(parse_timed_effect("(at start (= x y))"), Ok(("",
 ///     TimedEffect::new_conditional(
 ///         TimeSpecifier::Start,

--- a/src/parsers/timed_gd.rs
+++ b/src/parsers/timed_gd.rs
@@ -14,8 +14,7 @@ use nom::IResult;
 /// ## Examples
 /// ```
 /// # use pddl::parsers::{parse_timed_gd};
-/// # use pddl::types::{AtomicFormula, GoalDefinition, Interval, Term, TimedGD, TimeSpecifier};
-///
+/// # use pddl::{AtomicFormula, GoalDefinition, Interval, Term, TimedGD, TimeSpecifier};
 /// assert_eq!(parse_timed_gd("(at start (= x y))"), Ok(("",
 ///     TimedGD::new_at(
 ///         TimeSpecifier::Start,

--- a/src/parsers/timed_gd.rs
+++ b/src/parsers/timed_gd.rs
@@ -64,6 +64,7 @@ pub fn parse_timed_gd(input: &str) -> IResult<&str, TimedGD> {
 impl<'a> crate::parsers::Parser<'a> for TimedGD<'a> {
     type Item = TimedGD<'a>;
 
+    /// See [`parse_timed_gd`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_timed_gd(input)
     }

--- a/src/parsers/timeless_def.rs
+++ b/src/parsers/timeless_def.rs
@@ -11,7 +11,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_timeless_def;
-/// # use pddl::types::{AtomicFormula, EqualityAtomicFormula, Literal, Name, Objects, Timeless, ToTyped, Type};
+/// # use pddl::{AtomicFormula, EqualityAtomicFormula, Literal, Name, Objects, Timeless, ToTyped, Type};
 /// let input = "(:timeless (= x y) (= a b))";
 /// assert_eq!(parse_timeless_def(input), Ok(("",
 ///     Timeless::from_iter([

--- a/src/parsers/timeless_def.rs
+++ b/src/parsers/timeless_def.rs
@@ -45,6 +45,7 @@ pub fn parse_timeless_def(input: &str) -> IResult<&str, Timeless> {
 impl<'a> crate::parsers::Parser<'a> for Timeless<'a> {
     type Item = Timeless<'a>;
 
+    /// See [`parse_timeless_def`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_timeless_def(input)
     }

--- a/src/parsers/type.rs
+++ b/src/parsers/type.rs
@@ -35,6 +35,7 @@ fn parse_either_type(input: &str) -> IResult<&str, Vec<PrimitiveType>> {
 impl<'a> crate::parsers::Parser<'a> for Type<'a> {
     type Item = Type<'a>;
 
+    /// See [`parse_type`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_type(input)
     }

--- a/src/parsers/type.rs
+++ b/src/parsers/type.rs
@@ -11,7 +11,7 @@ use nom::{error_position, IResult};
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_type;
-/// # use pddl::types::Type;
+/// # use pddl::Type;
 /// assert_eq!(parse_type("object"), Ok(("", Type::Exactly("object".into()))));
 /// assert_eq!(parse_type("(either object number)"), Ok(("", Type::from_iter(["object", "number"]))));
 ///```

--- a/src/parsers/typed_list.rs
+++ b/src/parsers/typed_list.rs
@@ -14,8 +14,7 @@ use nom::IResult;
 /// ```
 /// # use nom::character::complete::alpha1;
 /// # use pddl::parsers::{parse_name, typed_list};
-/// # use pddl::types::{Name, PrimitiveType, ToTyped, Type, Typed, TypedList};
-///
+/// # use pddl::{Name, PrimitiveType, ToTyped, Type, Typed, TypedList};
 /// // Single implicitly typed element.
 /// assert_eq!(typed_list(parse_name)("abc"), Ok(("", TypedList::from_iter([
 ///     Name::new("abc").to_typed(Type::OBJECT)

--- a/src/parsers/types_def.rs
+++ b/src/parsers/types_def.rs
@@ -29,6 +29,7 @@ pub fn parse_types_def(input: &str) -> IResult<&str, Types> {
 impl<'a> crate::parsers::Parser<'a> for Types<'a> {
     type Item = Types<'a>;
 
+    /// See [`parse_types_def`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_types_def(input)
     }

--- a/src/parsers/types_def.rs
+++ b/src/parsers/types_def.rs
@@ -10,9 +10,8 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_types_def;
-/// # use pddl::types::{Variable, AtomicFormulaSkeleton, Predicate, PredicateDefinitions};
-/// # use pddl::types::{Name, Type, Typed, TypedList, Types};
-///
+/// # use pddl::{Variable, AtomicFormulaSkeleton, Predicate, PredicateDefinitions};
+/// # use pddl::{Name, Type, Typed, TypedList, Types};
 /// let input = "(:types location physob)";
 /// assert_eq!(parse_types_def(input), Ok(("",
 ///     Types::new(TypedList::from_iter([

--- a/src/parsers/variable.rs
+++ b/src/parsers/variable.rs
@@ -28,6 +28,7 @@ pub fn parse_variable(input: &str) -> IResult<&str, Variable> {
 impl<'a> crate::parsers::Parser<'a> for Variable<'a> {
     type Item = Variable<'a>;
 
+    /// See [`parse_variable`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_variable(input)
     }

--- a/src/types/function_typed_list.rs
+++ b/src/types/function_typed_list.rs
@@ -7,8 +7,8 @@ use std::ops::Deref;
 ///
 /// ## Example
 /// ```
-/// # use pddl::types::{FunctionTypedList, FunctionTyped, FunctionType};
-/// # use pddl::types::{TypedList, Name};
+/// # use pddl::{FunctionTypedList, FunctionTyped, FunctionType};
+/// # use pddl::{TypedList, Name};
 /// let tl = FunctionTypedList::from_iter([
 ///     FunctionTyped::new(Name::from("location"), FunctionType::NUMBER),
 ///     FunctionTyped::new(Name::from("physob"), FunctionType::NUMBER),

--- a/src/types/number.rs
+++ b/src/types/number.rs
@@ -15,7 +15,7 @@ type UnderlyingType = f32;
 /// ## Examples
 /// ```
 /// # use std::panic;
-/// # use pddl::types::Number;
+/// # use pddl::Number;
 /// let number = Number::from(42);
 /// assert_eq!(number, 42);
 /// assert_eq!(number, 42.0);

--- a/src/types/requirements.rs
+++ b/src/types/requirements.rs
@@ -8,7 +8,7 @@ use std::ops::Deref;
 ///
 /// ## Example
 /// ```
-/// # use pddl::types::{Requirement, Requirements};
+/// # use pddl::{Requirement, Requirements};
 /// let requirements = Requirements::new([
 ///     Requirement::Adl,
 ///     Requirement::Strips,
@@ -37,7 +37,7 @@ use std::ops::Deref;
 ///
 /// If no requirements are specified, [`Requirements::to_effective`] implicitly adds `:strips`:
 /// ```
-/// # use pddl::types::{Requirement, Requirements};
+/// # use pddl::{Requirement, Requirements};
 /// let requirements = Requirements::default();
 /// assert_eq!(requirements.len(), 0);
 ///

--- a/src/types/typed.rs
+++ b/src/types/typed.rs
@@ -32,7 +32,7 @@ pub trait ToTyped<'a, T> {
     ///
     /// ## Example
     /// ```
-    /// use pddl::types::{Name, PrimitiveType, ToTyped, Type, Typed};
+    /// # use pddl::{Name, PrimitiveType, ToTyped, Type, Typed};
     /// assert_eq!(
     ///     Name::from("kitchen").to_typed("room"),
     ///     Typed::new(Name::from("kitchen"), Type::Exactly(PrimitiveType::from("room")))
@@ -44,7 +44,7 @@ pub trait ToTyped<'a, T> {
     ///
     /// ## Example
     /// ```
-    /// use pddl::types::{Name, PrimitiveType, ToTyped, Type, Typed};
+    /// # use pddl::{Name, PrimitiveType, ToTyped, Type, Typed};
     /// assert_eq!(
     ///     Name::from("georgia").to_typed_either(["country", "state"]),
     ///     Typed::new(Name::from("georgia"), Type::EitherOf(

--- a/src/types/typed_list.rs
+++ b/src/types/typed_list.rs
@@ -5,7 +5,7 @@ use std::ops::Deref;
 ///
 /// ## Example
 /// ```
-/// # use pddl::types::{Name, TypedList, Typed, Type};
+/// # use pddl::{Name, TypedList, Typed, Type};
 /// let tl = TypedList::from_iter([
 ///     Typed::new(Name::from("location"), Type::OBJECT),
 ///     Typed::new(Name::from("physob"), Type::OBJECT),

--- a/tests/briefcase_world.rs
+++ b/tests/briefcase_world.rs
@@ -1,6 +1,5 @@
-use pddl::parsers::Parser;
-use pddl::types::{
-    AtomicFormula, Domain, GoalDefinition, PreGD, PreferenceGD, Problem, TermLiteral,
+use pddl::{
+    AtomicFormula, Domain, GoalDefinition, Parser, PreGD, PreferenceGD, Problem, TermLiteral,
 };
 
 pub const BRIEFCASE_WORLD: &'static str = r#"


### PR DESCRIPTION
This is a quality-of-life improvement that allows easier access to domain/problem types and the `Parser` trait.

Following #66, the example now becomes:

```rust
use pddl::{Domain, Parser};

let (remainder, domain) = Domain::parse(BRIEFCASE_WORLD).unwrap();
```

Furthermore, `CHANGELOG.md` was added and cross-referencing documentation comments were added on the parser implementations.