### PR TITLE
Add type back-references in comments

### DIFF
--- a/ELEMENTS.md
+++ b/ELEMENTS.md
@@ -360,7 +360,7 @@ Using embedded modal operators:
 - [x] [`<con-GD>`](src/parsers/con_gd.rs)
 - [x] [`<con2-GD>`](src/parsers/con_gd.rs)
 
-### Requirements
+## Requirements
 
 The following requirements can be parsed. Note that all
 requirement specific features are parsed unconditionally.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,10 @@
 //! This crates provides a PDDL 3.1 parser implementation based on [nom](https://crates.io/crates/nom).
 //!
 //! ## Example
+//!
+//! The two core types of a PDDL are [`Domain`] and [`Problem`]. This example shows how to
+//! parse them:
+//!
 //! ```
 //! use pddl::{Parser, Domain, Problem};
 //!

--- a/src/types/action_definition.rs
+++ b/src/types/action_definition.rs
@@ -4,6 +4,9 @@ use crate::types::TypedVariables;
 use crate::types::{ActionSymbol, Effect, PreGD};
 
 /// An action definition.
+///
+/// ## Usage
+/// Used by [`StructureDef`](crate::StructureDef).
 #[derive(Debug, Clone, PartialEq)]
 pub struct ActionDefinition<'a> {
     symbol: ActionSymbol<'a>,

--- a/src/types/action_symbols.rs
+++ b/src/types/action_symbols.rs
@@ -4,6 +4,9 @@ use crate::types::Name;
 use std::ops::Deref;
 
 /// An action symbol name.
+///
+/// ## Usage
+/// Used by [`ActionDefinition`](crate::ActionDefinition).
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Default)]
 pub struct ActionSymbol<'a>(Name<'a>);
 

--- a/src/types/assign_op.rs
+++ b/src/types/assign_op.rs
@@ -4,6 +4,10 @@ use std::borrow::Borrow;
 use std::fmt::{Display, Formatter};
 
 /// An assignment operation.
+///
+/// ## Usage
+/// Used by [`PEffect`](crate::PEffect), [`TimedEffect`](crate::TimedEffect) and
+/// [`FAssignDa`](crate::FAssignDa).
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum AssignOp {
     /// An assign effect assigns the value of a numeric variable to the given amount.

--- a/src/types/assign_op_t.rs
+++ b/src/types/assign_op_t.rs
@@ -3,6 +3,9 @@
 use std::fmt::{Display, Formatter};
 
 /// An assignment operation.
+///
+/// ## Usage
+/// Used by [`TimedEffect`](crate::TimedEffect).
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum AssignOpT {
     Increase,

--- a/src/types/atomic_formula.rs
+++ b/src/types/atomic_formula.rs
@@ -4,6 +4,10 @@ use crate::types::Predicate;
 use std::ops::Deref;
 
 /// An atomic formula.
+///
+/// ## Usage
+/// Used by [`Literal`](crate::Literal), [`GoalDefinition`](crate::GoalDefinition) and
+/// [`PEffect`](crate::PEffect).
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum AtomicFormula<'a, T> {
     Equality(EqualityAtomicFormula<T>),

--- a/src/types/atomic_formula_skeleton.rs
+++ b/src/types/atomic_formula_skeleton.rs
@@ -4,6 +4,9 @@ use crate::types::Predicate;
 use crate::types::{Name, TypedVariables};
 
 /// An atomic formula skeleton.
+///
+/// ## Usage
+/// Used by [`PredicateDefinitions`](crate::PredicateDefinitions) and [`DerivedPredicate`](crate::DerivedPredicate).
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct AtomicFormulaSkeleton<'a> {
     predicate: Predicate<'a>,

--- a/src/types/atomic_function_skeleton.rs
+++ b/src/types/atomic_function_skeleton.rs
@@ -27,6 +27,9 @@ use crate::types::{FunctionSymbol, TypedVariables, Variable};
 ///
 /// There are a number of supported effects for numeric fluents, e.g.
 /// [BinaryOp](crate::types::BinaryOp) and [`AssignOp`](crate::types::AssignOp).
+///
+/// ## Usage
+/// Used by [`Functions`](crate::Functions).
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct AtomicFunctionSkeleton<'a> {
     /// The name of the fluent, e.g. `battery-level`.

--- a/src/types/basic_function_term.rs
+++ b/src/types/basic_function_term.rs
@@ -2,6 +2,8 @@
 
 use crate::types::{FunctionSymbol, Name};
 
+/// ## Usage
+/// Used by [`InitElement`](crate::InitElement).
 #[derive(Debug, Clone, PartialEq)]
 pub struct BasicFunctionTerm<'a>(FunctionSymbol<'a>, Vec<Name<'a>>);
 

--- a/src/types/binary_comp.rs
+++ b/src/types/binary_comp.rs
@@ -3,6 +3,9 @@
 use std::fmt::{Display, Formatter};
 
 /// A binary comparison operation.
+///
+/// ## Usage
+/// Used by [`FComp`](crate::FComp).
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum BinaryComp {
     GreaterThan,

--- a/src/types/binary_op.rs
+++ b/src/types/binary_op.rs
@@ -4,6 +4,9 @@ use crate::types::MultiOp;
 use std::fmt::{Display, Formatter};
 
 /// A binary operation.
+///
+/// ## Usage
+/// Used by [`FExp`](crate::Fexp), [`FExpDa`](crate::FExpDa) and [`Optimization`](crate::Optimization).
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum BinaryOp {
     Multiplication,

--- a/src/types/c_effect.rs
+++ b/src/types/c_effect.rs
@@ -3,12 +3,17 @@
 use crate::types::TypedVariables;
 use crate::types::{ConditionalEffect, Effect, GoalDefinition, PEffect};
 
-/// A c-effect. Occurs as part of [`Effect`].
+/// A conditional effect. Occurs as part of [`Effect`].
+///
+/// ## Usage
+/// Used by [`Effect`](Effect).
 #[derive(Debug, Clone, PartialEq)]
 pub enum CEffect<'a> {
     Effect(PEffect<'a>),
+    /// ## Requirements
     /// Requires [ConditionalEffects](crate::types::Requirement::ConditionalEffects).
     Forall(TypedVariables<'a>, Box<Effect<'a>>),
+    /// ## Requirements
     /// Requires [ConditionalEffects](crate::types::Requirement::ConditionalEffects).
     When(GoalDefinition<'a>, ConditionalEffect<'a>),
 }

--- a/src/types/con_gd.rs
+++ b/src/types/con_gd.rs
@@ -2,6 +2,8 @@
 
 use crate::types::{GoalDefinition, Number, TypedVariables};
 
+/// ## Usage
+/// Used by [`ConGD`](ConGD) itself, as well as [`PrefConGD`](crate::types::PrefConGD) and [`Con2GD`](Con2GD).
 #[derive(Debug, Clone, PartialEq)]
 pub enum ConGD<'a> {
     And(Vec<ConGD<'a>>),
@@ -25,6 +27,9 @@ impl<'a> Default for ConGD<'a> {
 }
 
 /// A type that represents either a [`GoalDefinition`] or an embedded [`ConGD`].
+///
+/// ## Usage
+/// Used by [`ConGD`](ConGD).
 #[derive(Debug, Clone, PartialEq)]
 pub enum Con2GD<'a> {
     Goal(GoalDefinition<'a>),

--- a/src/types/conditional_effect.rs
+++ b/src/types/conditional_effect.rs
@@ -3,10 +3,13 @@
 use crate::types::PEffect;
 
 /// A conditional effect as used by [`CEffect::When`](crate::types::CEffect::When) and [`TimedEffect::Conditional`](crate::types::TimedEffect::Conditional).
+///
+/// ## Usage
+/// Used by [`CEffect`](crate::CEffect) and [`TimedEffect`](crate::types::TimedEffect).
 #[derive(Debug, Clone, PartialEq)]
 pub enum ConditionalEffect<'a> {
     /// Exactly the specified effect applies.
-    Single(PEffect<'a>),
+    Single(PEffect<'a>), // TODO: Unify with `All`; vector is allowed to be empty.
     /// Conjunction: All effects apply (i.e. a and b and c ..).
     All(Vec<PEffect<'a>>),
 }

--- a/src/types/constants.rs
+++ b/src/types/constants.rs
@@ -4,6 +4,9 @@ use crate::types::{Name, Typed, TypedNames};
 use std::ops::Deref;
 
 /// A set of constants.
+///
+/// ## Usage
+/// Used by [`Domain`](crate::Domain).
 #[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct Constants<'a>(TypedNames<'a>);
 

--- a/src/types/d_op.rs
+++ b/src/types/d_op.rs
@@ -2,11 +2,15 @@
 
 use std::fmt::{Display, Formatter};
 
+/// ## Usage
+/// Used by [`SimpleDurationConstraint`](crate::SimpleDurationConstraint).
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum DOp {
     Equal,
+    /// ## Requirements
     /// Requires [DurationInequalities](crate::types::Requirement::DurationInequalities);
     GreaterOrEqual,
+    /// ## Requirements
     /// Requires [DurationInequalities](crate::types::Requirement::DurationInequalities);
     LessThanOrEqual,
 }

--- a/src/types/d_value.rs
+++ b/src/types/d_value.rs
@@ -3,11 +3,15 @@
 use crate::types::{FExp, Number};
 
 /// A duration value, either a [Number] or an [FExp](FExp).
+///
+/// ## Usage
+/// Used by [`SimpleDurationConstraint`](crate::SimpleDurationConstraint).
 #[derive(Debug, Clone, PartialEq)]
 pub enum DurationValue<'a> {
     /// A numerical value.
     Number(Number),
     /// A function expression that produces the duration value.
+    /// ## Requirements
     /// Requires [NumericFluents](crate::types::Requirement::NumericFluents).
     FExp(FExp<'a>),
 }

--- a/src/types/da_def.rs
+++ b/src/types/da_def.rs
@@ -20,6 +20,9 @@ use crate::types::{
 /// found in flight planning, where an action fly requires that a runway be free at
 /// the start and end of an action, in order for the plane to take off and land
 /// whilst the runway does not need to be free whilst the plane is flying.
+///
+/// ## Usage
+/// Used by [`StructureDef`](crate::StructureDef).
 #[derive(Debug, Clone, PartialEq)]
 pub struct DurativeActionDefinition<'a> {
     symbol: DurativeActionSymbol<'a>,

--- a/src/types/da_effect.rs
+++ b/src/types/da_effect.rs
@@ -4,13 +4,18 @@ use crate::types::TypedVariables;
 use crate::types::{DurativeActionGoalDefinition, TimedEffect};
 
 /// A durative action effect used in [DurativeActionDefinition](crate::types::DurativeActionDefinition).
+///
+/// ## Usage
+/// Used by [`DurativeActionDefinition`](crate::DurativeActionDefinition).
 #[derive(Debug, Clone, PartialEq)]
 pub enum DurativeActionEffect<'a> {
     Timed(TimedEffect<'a>),
     /// Conjunction: All effects apply (i.e. a and b and c ..).
     All(Vec<DurativeActionEffect<'a>>),
+    /// ## Requirements
     /// Requires [ConditionalEffects](crate::types::Requirement::ConditionalEffects).
     Forall(TypedVariables<'a>, Box<DurativeActionEffect<'a>>),
+    /// ## Requirements
     /// Requires [ConditionalEffects](crate::types::Requirement::ConditionalEffects).
     When(DurativeActionGoalDefinition<'a>, TimedEffect<'a>),
 }

--- a/src/types/da_gd.rs
+++ b/src/types/da_gd.rs
@@ -4,10 +4,15 @@ use crate::types::PrefTimedGD;
 use crate::types::TypedVariables;
 
 /// A durative action goal definition.
+///
+/// ## Usage
+/// Used by [`DurativeActionGoalDefinition`] itself, as well as [`DurativeActionDefinition`](crate::DurativeActionDefinition) and
+/// [`DurativeActionEffect`](crate::DurativeActionEffect).
 #[derive(Debug, Clone, PartialEq)]
 pub enum DurativeActionGoalDefinition<'a> {
     Timed(PrefTimedGD<'a>),
     And(Vec<DurativeActionGoalDefinition<'a>>),
+    /// ## Requirements
     /// Requires [UniversalPreconditions](crate::types::Requirement::UniversalPreconditions).
     Forall(TypedVariables<'a>, Box<DurativeActionGoalDefinition<'a>>),
 }

--- a/src/types/da_symbol.rs
+++ b/src/types/da_symbol.rs
@@ -4,6 +4,9 @@ use crate::types::Name;
 use std::ops::Deref;
 
 /// A durative action symbol.
+///
+/// ## Usage
+/// Used by [`DurativeActionDefinition`](crate::DurativeActionDefinition).
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Default)]
 pub struct DurativeActionSymbol<'a>(Name<'a>);
 

--- a/src/types/derived_predicate.rs
+++ b/src/types/derived_predicate.rs
@@ -3,6 +3,9 @@
 use crate::types::{AtomicFormulaSkeleton, GoalDefinition};
 
 /// A derived predicate.
+///
+/// ## Usage
+/// Used by [`StructureDef`](crate::StructureDef).
 #[derive(Debug, Clone, PartialEq)]
 pub struct DerivedPredicate<'a>(AtomicFormulaSkeleton<'a>, GoalDefinition<'a>);
 

--- a/src/types/domain.rs
+++ b/src/types/domain.rs
@@ -7,18 +7,24 @@ use crate::types::{
 use crate::types::{Name, Types};
 
 /// The `Domain` type specifies a problem domain in which to plan.
+///
+/// ## Usage
+/// This is the top-level type of a domain description. See also [`Problem`](crate::Problem).
 #[derive(Debug, Clone, PartialEq)]
 pub struct Domain<'a> {
     name: Name<'a>,
     // TODO: PDDL 1.2 - deprecated?
     extends: Vec<Name<'a>>,
     requirements: Requirements,
+    /// ## Requirements
     /// Requires [Typing](crate::types::Requirement::Typing).
     types: Types<'a>,
     constants: Constants<'a>,
     predicates: PredicateDefinitions<'a>,
+    /// ## Requirements
     /// Requires [Fluents](crate::types::Requirement::Fluents).
     functions: Functions<'a>,
+    /// ## Requirements
     /// Requires [Constraints](crate::types::Requirement::Constraints).
     constraints: DomainConstraintsDef<'a>,
     // TODO: PDDL 1.2 - deprecated?
@@ -110,6 +116,7 @@ impl<'a> Domain<'a> {
     }
 
     /// Returns the optional type declarations.
+    /// ## Requirements
     /// Requires [Typing](crate::types::Requirement::Typing).
     pub const fn types(&self) -> &Types<'a> {
         &self.types
@@ -126,6 +133,7 @@ impl<'a> Domain<'a> {
     }
 
     /// Returns the optional function definitions.
+    /// ## Requirements
     /// Requires [Fluents](Requirement::Fluents).
     pub const fn functions(&self) -> &Functions<'a> {
         &self.functions

--- a/src/types/domain_constraints_def.rs
+++ b/src/types/domain_constraints_def.rs
@@ -4,7 +4,12 @@ use crate::types::ConGD;
 use std::ops::Deref;
 
 /// A domain constraints definition; wraps a [`ConGD`].
+///
+/// ## Requirements
 /// Requires [Constraints](crate::types::Requirement::Constraints).
+///
+/// ## Usage
+/// Used by [`Domain`](crate::Domain).
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct DomainConstraintsDef<'a>(ConGD<'a>);
 

--- a/src/types/duration_constraint.rs
+++ b/src/types/duration_constraint.rs
@@ -2,9 +2,12 @@
 
 use crate::types::SimpleDurationConstraint;
 
+/// ## Usage
+/// Used by [`DurativeActionDefinition`](crate::DurativeActionDefinition).
 #[derive(Debug, Clone, PartialEq)]
 pub enum DurationConstraint<'a> {
     Simple(SimpleDurationConstraint<'a>),
+    /// ## Requirements
     /// Requires [DurationInequalities](crate::types::Requirement::DurationInequalities).
     And(Vec<SimpleDurationConstraint<'a>>),
 }

--- a/src/types/effect.rs
+++ b/src/types/effect.rs
@@ -3,10 +3,13 @@
 use crate::types::CEffect;
 
 /// An effect. Occurs e.g. in a [`ActionDefinition`](crate::types::ActionDefinition).
+///
+/// ## Usage
+/// Used by [`ActionDefinition`](crate::ActionDefinition) and [`CEffect`].
 #[derive(Debug, Clone, PartialEq)]
 pub enum Effect<'a> {
     /// Exactly the specified effect applies.
-    Single(CEffect<'a>),
+    Single(CEffect<'a>), // TODO: Unify with `All` variant; this is just a single-element vector and according to spec, this vector may be empty.
     /// Conjunction: All effects apply (i.e. a and b and c ..).
     All(Vec<CEffect<'a>>),
 }

--- a/src/types/f_assign_da.rs
+++ b/src/types/f_assign_da.rs
@@ -2,7 +2,15 @@
 
 use crate::types::{AssignOp, FExpDa, FHead};
 
-/// An f-assign-da.
+/// An timed effect assignment operation. Will perform the
+/// specified assignment `at` [`TimeSpecifier`](crate::TimeSpecifier) when
+/// [`NumericFluents`](crate::Requirement::NumericFluents) is allowed.
+///
+/// ## Requirements
+/// Requires [`NumericFluents`](crate::Requirement::NumericFluents).
+///
+/// ## Usage
+/// Used by [`TimedEffect`](crate::TimedEffect).
 #[derive(Debug, Clone, PartialEq)]
 pub struct FAssignDa<'a>(AssignOp, FHead<'a>, FExpDa<'a>);
 

--- a/src/types/f_comp.rs
+++ b/src/types/f_comp.rs
@@ -2,7 +2,11 @@
 
 use crate::types::{BinaryComp, FExp};
 
-/// An f-comp.
+/// An fluent comparison used as part of a [`GoalDefinition`](crate::GoalDefinition)
+/// when [`NumericFluents`](crate::Requirement::NumericFluents) is allowed.
+///
+/// ## Usage
+/// Used by [`GoalDefinition`](crate::GoalDefinition).
 #[derive(Debug, Clone, PartialEq)]
 pub struct FComp<'a>(BinaryComp, FExp<'a>, FExp<'a>);
 

--- a/src/types/f_exp.rs
+++ b/src/types/f_exp.rs
@@ -4,7 +4,12 @@ use crate::types::{BinaryOp, FHead, MultiOp, Number};
 
 /// A function/fluent expression used e.g. in a [`DurationValue`](crate::types::DurationValue).
 ///
+/// ## Requirements
 /// Requires [NumericFluents](crate::types::Requirement::NumericFluents).
+///
+/// ## Usage
+/// Used by [`FExp`] itself, as well as [`PEffect`](crate::PEffect), [`DurationValue`](crate::DurationValue),
+/// [`FExpDa`](crate::FExpDa) and [`FExpT`](crate::FExpT).
 #[derive(Debug, Clone, PartialEq)]
 pub enum FExp<'a> {
     /// A numerical expression.

--- a/src/types/f_exp_da.rs
+++ b/src/types/f_exp_da.rs
@@ -2,12 +2,15 @@
 
 use crate::types::{AssignOp, BinaryOp, FExp, FHead, MultiOp};
 
+/// ## Usage
+/// Used by [`FExpDa`] itself, as well as [`FAssignDa`](crate::FAssignDa).
 #[derive(Debug, Clone, PartialEq)]
 pub enum FExpDa<'a> {
     Assign(AssignOp, FHead<'a>, Box<FExpDa<'a>>),
     BinaryOp(BinaryOp, Box<FExpDa<'a>>, Box<FExpDa<'a>>),
     MultiOp(MultiOp, Box<FExpDa<'a>>, Vec<FExpDa<'a>>),
     Negative(Box<FExpDa<'a>>),
+    /// ## Requirements
     /// Requires [DurationInequalities](crate::types::Requirement::DurationInequalities).
     Duration,
     FExp(FExp<'a>),

--- a/src/types/f_exp_t.rs
+++ b/src/types/f_exp_t.rs
@@ -4,7 +4,12 @@ use crate::types::FExp;
 
 /// An f-exp-t.
 ///
-/// Requires [NumericFluents](crate::types::Requirement::NumericFluents).
+/// ## Requirements
+/// Requires [ContinuousEffects](crate::types::Requirement::ContinuousEffects) and
+/// [NumericFluents](crate::types::Requirement::NumericFluents).
+///
+/// ## Usage
+/// Used by [`TimedEffect`](crate::TimedEffect).
 #[derive(Debug, Clone, PartialEq)]
 pub enum FExpT<'a> {
     Now,

--- a/src/types/f_head.rs
+++ b/src/types/f_head.rs
@@ -3,9 +3,16 @@
 use crate::types::{FunctionSymbol, Term};
 
 /// A function declaration.
+///
+/// ## Requirements
+/// Requires [NumericFluents](crate::types::Requirement::NumericFluents).
+///
+/// ## Usage
+/// Used by [`FExp`](crate::FExp), [`PEffect`](crate::PEffect), [`TimedEffect`](crate::TimedEffect)
+/// and [`FAssignDa`](crate::FAssignDa).
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum FHead<'a> {
-    Simple(FunctionSymbol<'a>),
+    Simple(FunctionSymbol<'a>), // TODO: Unify with `WithTerms`?
     WithTerms(FunctionSymbol<'a>, Vec<Term<'a>>),
 }
 

--- a/src/types/function_symbols.rs
+++ b/src/types/function_symbols.rs
@@ -4,6 +4,10 @@ use crate::types::Name;
 use std::ops::Deref;
 
 /// A function symbol name.
+///
+/// ## Usage
+/// Used by [`FunctionTerm`](crate::FunctionTerm), [`FHead`](crate::FHead),
+/// [`BasicFunctionTerm`](crate::BasicFunctionTerm) and [`MetricFExp`](crate::MetricFExp).
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Default)]
 pub struct FunctionSymbol<'a>(Name<'a>);
 

--- a/src/types/function_term.rs
+++ b/src/types/function_term.rs
@@ -4,6 +4,12 @@ use crate::types::term::Term;
 use crate::types::FunctionSymbol;
 
 /// A function term.
+///
+/// ## Requirements
+/// Requires [ObjectFluents](crate::Requirement::ObjectFluents).
+///
+/// ## Usage
+/// Used by [`Term`], and [`PEffect`](crate::PEffect).
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct FunctionTerm<'a>(FunctionSymbol<'a>, Vec<Term<'a>>);
 

--- a/src/types/function_type.rs
+++ b/src/types/function_type.rs
@@ -4,6 +4,15 @@ use crate::types::{PrimitiveType, Type};
 use std::ops::Deref;
 
 /// A function type.
+///
+/// ## Requirements
+/// Requires [Fluents](crate::Requirement::Fluents), as well as either
+/// [NumericFluents](crate::Requirement::NumericFluents) for the default `number` type, or
+/// [ObjectFluents](crate::Requirement::ObjectFluents) and [Typing](crate::Requirement::Typing)
+/// for an arbitrary type.
+///
+/// ## Usage
+/// Used by [`FunctionTyped`](crate::FunctionTyped) in [`FunctionTypedList`](crate::FunctionTypedList).
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct FunctionType<'a>(Type<'a>);
 

--- a/src/types/function_typed.rs
+++ b/src/types/function_typed.rs
@@ -5,6 +5,12 @@ use crate::types::Type;
 use std::ops::Deref;
 
 /// A typed function element.
+///
+/// ## Requirements
+/// Requires [Fluents](crate::Requirement::Fluents), as well as the same requirements as [`FunctionType`].
+///
+/// ## Usage
+/// Used by [`FunctionTypedList`](crate::FunctionTypedList).
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct FunctionTyped<'a, O>(O, FunctionType<'a>);
 

--- a/src/types/function_typed_list.rs
+++ b/src/types/function_typed_list.rs
@@ -18,6 +18,15 @@ use std::ops::Deref;
 /// assert_eq!(tl[0].value_ref(), &Name::from("location"));
 /// assert_eq!(tl[1].value_ref(), &Name::from("physob"));
 /// ```
+///
+/// ## Requirements
+/// Requires [Fluents](crate::Requirement::Fluents) and either
+/// [NumericFluents](crate::Requirement::NumericFluents) for the default `number` type, or
+/// [ObjectFluents](crate::Requirement::ObjectFluents) and [Typing](crate::Requirement::Typing)
+/// for an arbitrary type.
+///
+/// ## Usage
+/// Used by [`Functions`](crate::Functions).
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct FunctionTypedList<'a, T>(Vec<FunctionTyped<'a, T>>);
 

--- a/src/types/functions.rs
+++ b/src/types/functions.rs
@@ -4,6 +4,12 @@ use crate::types::{AtomicFunctionSkeleton, FunctionTyped, FunctionTypedList};
 use std::ops::Deref;
 
 /// A set of functions.
+///
+/// ## Requirements
+/// Requires [Fluents](crate::Requirement::Fluents).
+///
+/// ## Usage
+/// Used by [`Domain`](crate::Domain).
 #[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct Functions<'a>(FunctionTypedList<'a, AtomicFunctionSkeleton<'a>>);
 

--- a/src/types/gd.rs
+++ b/src/types/gd.rs
@@ -4,22 +4,34 @@ use crate::types::TermLiteral;
 use crate::types::{AtomicFormula, FComp, Term, TypedVariables};
 
 /// A goal definition.
+///
+/// ## Usage
+/// Used by [`GD`] itself, as well as [`PreferenceGD`](crate::PreferenceGD), [`CEffect`](crate::CEffect),
+/// [`TimedGD`](crate::TimedGD), [`DerivedPredicate`](crate::DerivedPredicate) and
+/// [`Con2GD`](crate::Con2GD).
 #[derive(Debug, Clone, PartialEq)]
 pub enum GoalDefinition<'a> {
     AtomicFormula(AtomicFormula<'a, Term<'a>>),
+    /// ## Requirements
     /// Requires [NegativePreconditions](crate::types::Requirement::NegativePreconditions).
     Literal(TermLiteral<'a>),
     And(Vec<GoalDefinition<'a>>),
+    /// ## Requirements
     /// Requires [DisjunctivePreconditions](crate::types::Requirement::DisjunctivePreconditions).
     Or(Vec<GoalDefinition<'a>>),
+    /// ## Requirements
     /// Requires [DisjunctivePreconditions](crate::types::Requirement::DisjunctivePreconditions).
     Not(Box<GoalDefinition<'a>>),
+    /// ## Requirements
     /// Requires [DisjunctivePreconditions](crate::types::Requirement::DisjunctivePreconditions).
     Imply(Box<GoalDefinition<'a>>, Box<GoalDefinition<'a>>),
+    /// ## Requirements
     /// Requires [ExistentialPreconditions](crate::types::Requirement::ExistentialPreconditions).
     Exists(TypedVariables<'a>, Box<GoalDefinition<'a>>),
+    /// ## Requirements
     /// Requires [UniversalPreconditions](crate::types::Requirement::UniversalPreconditions).
     ForAll(TypedVariables<'a>, Box<GoalDefinition<'a>>),
+    /// ## Requirements
     /// Requires [NumericFluents](crate::types::Requirement::NumericFluents).
     FComp(FComp<'a>),
 }

--- a/src/types/goal_def.rs
+++ b/src/types/goal_def.rs
@@ -4,6 +4,9 @@ use crate::types::PreGD;
 use std::ops::Deref;
 
 /// A problem goal definition; wraps a [`PreGD`].
+///
+/// ## Usage
+/// Used by [`Problem`](crate::Problem).
 #[derive(Debug, Clone, PartialEq)]
 pub struct GoalDef<'a>(PreGD<'a>);
 

--- a/src/types/init_el.rs
+++ b/src/types/init_el.rs
@@ -2,13 +2,18 @@
 
 use crate::types::{BasicFunctionTerm, Name, NameLiteral, Number};
 
+/// ## Usage
+/// Used by [`InitElements`](crate::InitElements) in [`Problem`](crate::Problem).
 #[derive(Debug, Clone, PartialEq)]
 pub enum InitElement<'a> {
     Literal(NameLiteral<'a>),
+    /// ## Requirements
     /// Requires [TimedInitialLiterals](crate::types::Requirement::TimedInitialLiterals).
     At(Number, NameLiteral<'a>),
+    /// ## Requirements
     /// Requires [NumericFluents](crate::types::Requirement::NumericFluents).
     IsValue(BasicFunctionTerm<'a>, Number),
+    /// ## Requirements
     /// Requires [ObjectFluents](crate::types::Requirement::ObjectFluents).
     IsObject(BasicFunctionTerm<'a>, Name<'a>),
 }

--- a/src/types/init_els.rs
+++ b/src/types/init_els.rs
@@ -4,6 +4,9 @@ use crate::types::InitElement;
 use std::ops::Deref;
 
 /// A wrapper around a list of [`InitElement`] values.
+///
+/// ## Usage
+/// Used by [`Problem`](crate::Problem).
 #[derive(Debug, Clone, PartialEq)]
 pub struct InitElements<'a>(Vec<InitElement<'a>>);
 

--- a/src/types/interval.rs
+++ b/src/types/interval.rs
@@ -3,6 +3,9 @@
 use std::fmt::{Display, Formatter};
 
 /// An interval used in [TimedGD::Over](crate::types::TimedGD::Over).
+///
+/// ## Usage
+/// Used by [`TimedGD`](crate::TimedGD).
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum Interval {
     /// The condition must be true during the entire plan.

--- a/src/types/length_spec.rs
+++ b/src/types/length_spec.rs
@@ -1,6 +1,9 @@
 //! Contains the [`LengthSpec`] type.
 
 /// Deprecated since PDDL 2.1.
+///
+/// ## Usage
+/// Used by [`Problem`](crate::Problem).
 #[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct LengthSpec {
     serial: Option<u64>,

--- a/src/types/literal.rs
+++ b/src/types/literal.rs
@@ -3,6 +3,9 @@
 use crate::types::AtomicFormula;
 
 /// An [`AtomicFormula`] or its negated value.
+///
+/// ## Usage
+/// Used by [`GoalDefinition`](crate::GoalDefinition) and [`InitElement`](crate::InitElement).
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Literal<'a, T> {
     AtomicFormula(AtomicFormula<'a, T>),

--- a/src/types/metric_f_exp.rs
+++ b/src/types/metric_f_exp.rs
@@ -3,6 +3,12 @@
 use crate::types::{BinaryOp, FunctionSymbol, MultiOp, Name, Number, PreferenceName};
 
 /// A metric function expression.
+///
+/// ## Requirements
+/// Requires [NumericFluents](crate::Requirement::NumericFluents).
+///
+/// ## Usage
+/// Used by [`MetricSpec`](crate::MetricSpec).
 #[derive(Debug, Clone, PartialEq)]
 pub enum MetricFExp<'a> {
     BinaryOp(BinaryOp, Box<Self>, Box<Self>),
@@ -11,6 +17,7 @@ pub enum MetricFExp<'a> {
     Number(Number),
     Function(FunctionSymbol<'a>, Vec<Name<'a>>),
     TotalTime,
+    /// ## Requirements
     /// Requires [Preferences](crate::types::Requirement::Preferences).
     IsViolated(PreferenceName<'a>),
 }

--- a/src/types/metric_spec.rs
+++ b/src/types/metric_spec.rs
@@ -3,6 +3,7 @@
 use crate::types::{MetricFExp, Optimization};
 
 /// A metric specification.
+/// ## Requirements
 /// Requires [NumericFluents](crate::types::Requirement::NumericFluents).
 #[derive(Debug, Clone, PartialEq)]
 pub struct MetricSpec<'a> {

--- a/src/types/multi_op.rs
+++ b/src/types/multi_op.rs
@@ -3,6 +3,10 @@
 use std::fmt::{Display, Formatter};
 
 /// An operation with multiple operands.
+///
+/// ## Usage
+/// Used by [`MetricFExp`](crate::MetricFExp) and [`FExpDa`](crate::FExpDa).
+/// Implicitly used by [`BinaryOp`](crate::BinaryOp).
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum MultiOp {
     Multiplication,

--- a/src/types/name.rs
+++ b/src/types/name.rs
@@ -4,6 +4,14 @@ use crate::types::{PrimitiveType, ToTyped, Type, Typed};
 use std::ops::Deref;
 
 /// A name.
+///
+/// ## Usage
+/// Used by [`Domain`](crate::Domain), [`InitElement`](crate::InitElement),
+/// [`BasicFunctionTerm`](crate::BasicFunctionTerm), [`MetricFExp`](crate::MetricFExp),
+/// [`PrimitiveType`](PrimitiveType), [`Predicate`](crate::Predicate), [`Variable`](crate::Variable),
+/// [`FunctionSymbol`](crate::FunctionSymbol), [`ActionSymbol`](crate::ActionSymbol),
+/// [`PreferenceName`](crate::PreferenceName), [`Term`](crate::Term),
+/// [`DurativeActionSymbol`](crate::DurativeActionSymbol) and [`Objects`](crate::Objects).
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Default)]
 pub struct Name<'a>(&'a str);
 

--- a/src/types/number.rs
+++ b/src/types/number.rs
@@ -24,6 +24,10 @@ type UnderlyingType = f32;
 /// assert!(Number::try_new(f32::NAN).is_err());
 /// assert!(panic::catch_unwind(|| Number::from(f32::NAN)).is_err());
 /// ```
+///
+/// ## Usage
+/// Used by [`InitElement`](crate::InitElement), [`ConGD`](crate::ConGD),
+/// [`MetricFExp`](crate::MetricFExp) and [`DurationValue`](crate::DurationValue).
 #[derive(Debug, Copy, Clone, Default)]
 pub struct Number(UnderlyingType);
 

--- a/src/types/objects.rs
+++ b/src/types/objects.rs
@@ -4,10 +4,14 @@ use crate::types::{Name, Typed, TypedNames};
 use std::ops::Deref;
 
 /// A list of objects.
+///
+/// ## Usage
+/// Used by [`Problem`](crate::Problem).
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
 pub struct Objects<'a>(TypedNames<'a>);
 
 impl<'a> Objects<'a> {
+    // TODO: Convert to const again that takes `TypedNames` directly.
     pub fn new<I: IntoIterator<Item = Typed<'a, Name<'a>>>>(objects: I) -> Self {
         Self(objects.into_iter().collect())
     }

--- a/src/types/optimization.rs
+++ b/src/types/optimization.rs
@@ -3,6 +3,12 @@
 use std::fmt::{Display, Formatter};
 
 /// An optimization instruction.
+///
+/// ## Requirements
+/// Requires [NumericFluents](crate::Requirement::NumericFluents).
+///
+/// ## Usage
+/// Used by [`MetricSpec`](crate::MetricSpec).
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum Optimization {
     /// The associated metric should be minimized.

--- a/src/types/p_effect.rs
+++ b/src/types/p_effect.rs
@@ -4,12 +4,17 @@ use crate::types::{AssignOp, AtomicFormula, FExp, FHead, FunctionTerm, Term};
 
 /// A p-effect. Occurs as part of a [`CEffect`](crate::types::CEffect) (within an [`Effect`](crate::types::Effect))
 /// or a [`ConditionalEffect`](crate::types::ConditionalEffect).
+///
+/// ## Usage
+/// Used by [`CEffect`](crate::CEffect) and [`ConditionalEffect`](crate::ConditionalEffect).
 #[derive(Debug, Clone, PartialEq)]
 pub enum PEffect<'a> {
     AtomicFormula(AtomicFormula<'a, Term<'a>>),
     NotAtomicFormula(AtomicFormula<'a, Term<'a>>),
+    /// ## Requirements
     /// Requires [NumericFluents](crate::types::Requirement::NumericFluents).
     AssignNumericFluent(AssignOp, FHead<'a>, FExp<'a>),
+    /// ## Requirements
     /// Requires [ObjectFluents](crate::types::Requirement::ObjectFluents).
     AssignObjectFluent(FunctionTerm<'a>, Option<Term<'a>>),
 }

--- a/src/types/pre_gd.rs
+++ b/src/types/pre_gd.rs
@@ -4,10 +4,19 @@ use crate::types::TypedVariables;
 use crate::types::{Preference, PreferenceGD};
 
 /// A precondition goal definition.
+///
+/// ## Usage
+/// Used by [`PreGD`] itself, as well as [`ActionDefinition`](crate::ActionDefinition).
 #[derive(Debug, Clone, PartialEq)]
+// TODO: Rename to PreconditionGoalDefinition
 pub enum PreGD<'a> {
-    Preference(PreferenceGD<'a>),
+    // TODO: Unify with base type; should always be a vector; count can be zero.
     And(Vec<PreGD<'a>>),
+    /// ## Requirements
+    /// None per se: this branch may expand into [`PreferenceGD::Goal`](PreferenceGD::Goal),
+    /// which has no requirements.
+    Preference(PreferenceGD<'a>),
+    /// ## Requirements
     /// Requires [UniversalPreconditions](crate::types::Requirement::UniversalPreconditions).
     Forall(TypedVariables<'a>, Box<PreGD<'a>>),
 }

--- a/src/types/predicate.rs
+++ b/src/types/predicate.rs
@@ -4,6 +4,9 @@ use crate::types::Name;
 use std::ops::Deref;
 
 /// A predicate name.
+///
+/// ## Usage
+/// Used by [`AtomicFormulaSkeleton`](crate::AtomicFormulaSkeleton) and [`AtomicFormula`](crate::AtomicFormula).
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Default)]
 pub struct Predicate<'a>(Name<'a>);
 

--- a/src/types/predicate_definitions.rs
+++ b/src/types/predicate_definitions.rs
@@ -4,6 +4,9 @@ use crate::types::AtomicFormulaSkeleton;
 use std::ops::Deref;
 
 /// A set of predicate definitions.
+///
+/// ## Usage
+/// Used by [`Domain`](crate::Domain).
 #[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct PredicateDefinitions<'a>(Vec<AtomicFormulaSkeleton<'a>>);
 

--- a/src/types/pref_con_gd.rs
+++ b/src/types/pref_con_gd.rs
@@ -2,11 +2,18 @@
 
 use crate::types::{ConGD, PreferenceName, TypedVariables};
 
+/// ## Requirements
+/// Requires [Constraints](crate::Requirement::Constraints).
+///
+/// ## Usage
+/// Used by [`PrefConGD`] itself, as well as [`ProblemConstraintsDef`](crate::ProblemConstraintsDef).
 #[derive(Debug, Clone, PartialEq)]
 pub enum PrefConGD<'a> {
-    And(Vec<PrefConGD<'a>>),
+    And(Vec<PrefConGD<'a>>), // TODO: Unify with base type. Should always be a vector.
+    /// ## Requirements
     /// Requires [UniversalPreconditions](crate::types::Requirement::UniversalPreconditions).
     Forall(TypedVariables<'a>, Box<PrefConGD<'a>>),
+    /// ## Requirements
     /// Requires [Preferences](crate::types::Requirement::Preferences).
     Preference(Option<PreferenceName<'a>>, ConGD<'a>),
     Goal(ConGD<'a>),

--- a/src/types/pref_gd.rs
+++ b/src/types/pref_gd.rs
@@ -3,9 +3,14 @@
 use crate::types::{GoalDefinition, Preference};
 
 /// A preferred goal definition.
+///
+/// ## Usage
+/// Used by [`PreGD`](crate::PreGD).
 #[derive(Debug, Clone, PartialEq)]
 pub enum PreferenceGD<'a> {
     Goal(GoalDefinition<'a>),
+    /// ## Requirements
+    /// Requires [Preferences](crate::Requirement::Preferences).
     Preference(Preference<'a>),
 }
 

--- a/src/types/pref_name.rs
+++ b/src/types/pref_name.rs
@@ -4,6 +4,10 @@ use crate::types::Name;
 use std::ops::Deref;
 
 /// A name of a preference.
+///
+/// ## Usage
+/// Used by [`PrefGD`](crate::PreferenceGD), [`PrefTimedGD`](crate::PrefTimedGD),
+/// [`PrefConGD`](crate::PrefConGD) and [`MetricFExp`](crate::MetricFExp).
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct PreferenceName<'a>(Name<'a>);
 

--- a/src/types/pref_timed_gd.rs
+++ b/src/types/pref_timed_gd.rs
@@ -3,9 +3,13 @@
 use crate::types::{PreferenceName, TimedGD};
 
 /// A (preferred) timed goal definition.
+///
+/// ## Usage
+/// Used by [`DurativeActionGoalDefinition`](crate::DurativeActionGoalDefinition).
 #[derive(Debug, Clone, PartialEq)]
 pub enum PrefTimedGD<'a> {
     Required(TimedGD<'a>),
+    /// ## Requirements
     /// Requires [Preferences](crate::types::Requirement::Preferences).
     Preference(Option<PreferenceName<'a>>, TimedGD<'a>),
 }

--- a/src/types/preference.rs
+++ b/src/types/preference.rs
@@ -3,8 +3,14 @@
 use crate::types::{GoalDefinition, PreferenceName};
 
 /// A preference.
+///
+/// ## Requirements
+/// Requires [Preferences](crate::Requirement::Preferences).
+///
+/// ## Usage
+/// Used by [`PreferenceGD`](crate::PreferenceGD).
 #[derive(Debug, Clone, PartialEq)]
-pub struct Preference<'a>(Option<PreferenceName<'a>>, GoalDefinition<'a>);
+pub struct Preference<'a>(Option<PreferenceName<'a>>, GoalDefinition<'a>); // TODO: A similar type is used for PrefConGD
 
 impl<'a> Preference<'a> {
     pub const fn new(name: Option<PreferenceName<'a>>, gd: GoalDefinition<'a>) -> Self {
@@ -19,6 +25,10 @@ impl<'a> Preference<'a> {
     /// Gets the goal definition.
     pub fn goal(&self) -> &GoalDefinition<'a> {
         &self.1
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.1.is_empty()
     }
 }
 

--- a/src/types/problem.rs
+++ b/src/types/problem.rs
@@ -6,6 +6,9 @@ use crate::types::{
 };
 
 /// A domain-specific problem declaration.
+///
+/// ## Usages
+/// This is the top-level type of a problem description within a [`Domain`](crate::Domain).
 #[derive(Debug, Clone, PartialEq)]
 pub struct Problem<'a> {
     name: Name<'a>,
@@ -14,8 +17,10 @@ pub struct Problem<'a> {
     objects: Objects<'a>,
     init: InitElements<'a>,
     goal: GoalDef<'a>,
+    /// ## Requirements
     /// Requires [Constraints](crate::types::Requirement::Constraints).
     constraints: ProblemConstraintsDef<'a>,
+    /// ## Requirements
     /// Requires [NumericFluents](crate::types::Requirement::NumericFluents).
     metric_spec: Option<MetricSpec<'a>>,
     /// Deprecated since PDDL 2.1.
@@ -128,12 +133,14 @@ impl<'a> Problem<'a> {
     }
 
     /// Returns the optional constraints of the problem.
+    /// ## Requirements
     /// Requires [Constraints](crate::types::Requirement::Constraints).
     pub const fn constraints(&self) -> &PrefConGD<'a> {
         &self.constraints.value()
     }
 
     /// Returns the optional metric specification of the problem.
+    /// ## Requirements
     /// Requires [NumericFluents](crate::types::Requirement::NumericFluents).
     pub const fn metric_spec(&self) -> &Option<MetricSpec<'a>> {
         &self.metric_spec

--- a/src/types/problem_constraints_def.rs
+++ b/src/types/problem_constraints_def.rs
@@ -4,6 +4,8 @@ use crate::types::PrefConGD;
 use std::ops::Deref;
 
 /// A problem constraints definition; wraps a [`PrefConGD`].
+///
+/// ## Requirements
 /// Requires [Constraints](crate::types::Requirement::Constraints).
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct ProblemConstraintsDef<'a>(PrefConGD<'a>);

--- a/src/types/requirement.rs
+++ b/src/types/requirement.rs
@@ -5,6 +5,9 @@ use std::fmt::{Display, Formatter};
 
 /// Domain requirements.
 ///
+/// ## Usage
+/// Used by [`Requirements`](crate::Requirements).
+///
 /// ## Notes
 /// Some requirements imply others; some are abbreviations for common sets
 /// of requirements. If a domain stipulates no requirements, it is assumed

--- a/src/types/requirements.rs
+++ b/src/types/requirements.rs
@@ -6,6 +6,9 @@ use std::ops::Deref;
 
 /// A set of domain requirements.
 ///
+/// ## Usage
+/// Used by [`Domain`](crate::Domain) and [`Problem`](crate::Problem).
+///
 /// ## Example
 /// ```
 /// # use pddl::{Requirement, Requirements};

--- a/src/types/simple_duration_constraint.rs
+++ b/src/types/simple_duration_constraint.rs
@@ -3,6 +3,9 @@
 use crate::types::{DOp, DurationValue, TimeSpecifier};
 
 /// A simple duration constraint.
+///
+/// ## Usage
+/// Used by [`SimpleDurationConstraint`] itself, as well as [`DurationConstraint`](crate::DurationConstraint).
 #[derive(Debug, Clone, PartialEq)]
 pub enum SimpleDurationConstraint<'a> {
     /// A comparison operation against a duration value.

--- a/src/types/structure_def.rs
+++ b/src/types/structure_def.rs
@@ -3,11 +3,16 @@
 use crate::types::{ActionDefinition, DerivedPredicate, DurativeActionDefinition};
 
 /// A domain structure definition.
+///
+/// ## Usage
+/// Used by [`StructureDefs`](crate::StructureDefs) in [`Domain`](crate::Domain).
 #[derive(Debug, Clone, PartialEq)]
 pub enum StructureDef<'a> {
     Action(ActionDefinition<'a>),
+    /// ## Requirements
     /// Requires [DurativeActions](crate::types::Requirement::DurativeActions).
     DurativeAction(DurativeActionDefinition<'a>),
+    /// ## Requirements
     /// Requires [DerivedPredicates](crate::types::Requirement::DerivedPredicates).
     Derived(DerivedPredicate<'a>),
 }

--- a/src/types/structure_defs.rs
+++ b/src/types/structure_defs.rs
@@ -4,6 +4,9 @@ use crate::types::StructureDef;
 use std::ops::Deref;
 
 /// A set of structure definitions.
+///
+/// ## Usage
+/// Used by [`Domain`](crate::Domain).
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct StructureDefs<'a>(Vec<StructureDef<'a>>);
 

--- a/src/types/term.rs
+++ b/src/types/term.rs
@@ -3,6 +3,10 @@ use crate::types::Name;
 use crate::types::Variable;
 
 /// A term, i.e. a [`Name`], [`Variable`] or [`FunctionTerm`].
+///
+/// ## Usage
+/// Used by [`GoalDefinition`](crate::GoalDefinition), [`FunctionTerm`](FunctionTerm),
+/// [`FHead`](crate::FHead), [`PEffect`](crate::PEffect) and [`InitElement`](crate::InitElement).
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Term<'a> {
     Name(Name<'a>),

--- a/src/types/time_specifier.rs
+++ b/src/types/time_specifier.rs
@@ -3,6 +3,9 @@
 use std::fmt::{Display, Formatter};
 
 /// A time specifier used in e.g. [TimedGD::At](crate::types::TimedGD::At) and [TimedEffect](crate::types::TimedEffect).
+///
+/// ## Usage
+/// Used by [`TimedGD`](crate::TimedGD) and [`TimedEffect`](crate::TimedEffect).
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum TimeSpecifier {
     /// The condition or effect holds or applies at the beginning of a plan.

--- a/src/types/timed_effect.rs
+++ b/src/types/timed_effect.rs
@@ -16,11 +16,16 @@ use crate::types::{AssignOpT, ConditionalEffect, FAssignDa, FExpT, FHead, TimeSp
 ///
 /// Instead you would set it to true at the start, using an `at start` and set it to false at
 /// the end using `at end`.
+///
+/// ## Usage
+/// Used by [`DurativeActionEffect`](crate::DurativeActionEffect).
 #[derive(Debug, Clone, PartialEq)]
 pub enum TimedEffect<'a> {
     Conditional(TimeSpecifier, ConditionalEffect<'a>),
+    /// ## Requirements
     /// Requires [NumericFluents](crate::types::Requirement::NumericFluents).
     NumericFluent(TimeSpecifier, FAssignDa<'a>),
+    /// ## Requirements
     /// Requires [ContinuousEffects](crate::types::Requirement::ContinuousEffects) and
     /// [NumericFluents](crate::types::Requirement::NumericFluents).
     ContinuousEffect(AssignOpT, FHead<'a>, FExpT<'a>),

--- a/src/types/timed_gd.rs
+++ b/src/types/timed_gd.rs
@@ -1,6 +1,9 @@
 use crate::types::{GoalDefinition, Interval, TimeSpecifier};
 
 /// A timed goal definition.
+///
+/// ## Usage
+/// Used by [`PrefTimedGD`](crate::PrefTimedGD).
 #[derive(Debug, Clone, PartialEq)]
 pub enum TimedGD<'a> {
     /// ## `at start`

--- a/src/types/timeless.rs
+++ b/src/types/timeless.rs
@@ -4,6 +4,16 @@ use crate::types::NameLiteral;
 use std::ops::Deref;
 
 /// A timeless predicate.
+///
+/// A timeless predicate is a predicate which is always true and cannot be changed by any action
+/// in the domain. Under the “closed world” assumption, anything not specified as true
+/// is considered false and timeless predicates are one possibility of addressing this.
+///
+/// ## PDDL Version
+/// This is a PDDL 1.2 construct. It was removed in later versions of PDDL.
+///
+/// ## Usage
+/// Used by [`Domain`](crate::Domain).
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
 pub struct Timeless<'a>(Vec<NameLiteral<'a>>);
 

--- a/src/types/type.rs
+++ b/src/types/type.rs
@@ -11,10 +11,23 @@ pub const TYPE_OBJECT: PrimitiveType<'static> = PrimitiveType(Name::new("object"
 pub const TYPE_NUMBER: PrimitiveType<'static> = PrimitiveType(Name::new("number"));
 
 /// A primitive type.
+///
+/// ## Requirements
+/// Requires [Typing](crate::Requirement::Typing).
+///
+/// ## Usage
+/// Used by [`Type`].
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Default)]
 pub struct PrimitiveType<'a>(Name<'a>);
 
 /// A type selection from `<primitive-type> | (either <primitive-type>)`.
+///
+/// ## Requirements
+/// Requires [Typing](crate::Requirement::Typing).
+///
+/// ## Usage
+/// Used by [`Typed`](crate::Typed) in [`TypedList`](crate::TypedList),
+/// [`FunctionType`](crate::FunctionType).
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Type<'a> {
     /// The type is exactly this named type.

--- a/src/types/typed.rs
+++ b/src/types/typed.rs
@@ -4,6 +4,9 @@ use crate::types::{PrimitiveType, Type};
 use std::ops::Deref;
 
 /// A typed element.
+///
+/// ## Usage
+/// Used by [`TypedList`](crate::TypedList).
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Typed<'a, O>(O, Type<'a>);
 

--- a/src/types/typed_list.rs
+++ b/src/types/typed_list.rs
@@ -15,6 +15,15 @@ use std::ops::Deref;
 /// assert_eq!(tl[0].value(), &Name::from("location"));
 /// assert_eq!(tl[1].value(), &Name::from("physob"));
 /// ```
+///
+/// ## Usage
+/// Used by [`Types`](crate::Types) and [`Constants`](crate::Constants) in [`Domain`](crate::Domain),
+/// [`AtomicFormulaSkeleton`](crate::AtomicFormulaSkeleton), [`AtomicFunctionSkeleton`](crate::AtomicFunctionSkeleton),
+/// [`ActionDefinition`](crate::ActionDefinition), [`PreGD`](crate::PreGD),
+/// [`GoalDefinition`](crate::GoalDefinition), [`CEffect`](crate::CEffect),
+/// [`DurativeActionDefinition`](crate::DurativeActionDefinition), [`DurativeActionEffect`](crate::DurativeActionEffect),
+/// [`Objects`](crate::Objects) in [`Problem`](crate::Problem), [`PrefConGD`](crate::PrefConGD) and
+/// [`ConGD`](crate::ConGD).
 #[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct TypedList<'a, T>(Vec<Typed<'a, T>>);
 

--- a/src/types/types.rs
+++ b/src/types/types.rs
@@ -4,6 +4,9 @@ use crate::types::TypedNames;
 use std::ops::Deref;
 
 /// A set of types.
+///
+/// ## Usage
+/// Used by [`Domain`](crate::Domain).
 #[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct Types<'a>(TypedNames<'a>);
 

--- a/src/types/variable.rs
+++ b/src/types/variable.rs
@@ -4,6 +4,14 @@ use crate::types::{Name, PrimitiveType, ToTyped, Type, Typed};
 use std::ops::Deref;
 
 /// A variable name.
+///
+/// ## Usage
+/// Used by [`AtomicFormulaSkeleton`](crate::AtomicFormulaSkeleton),
+/// [`AtomicFunctionSkeleton`](crate::AtomicFunctionSkeleton), [`ActionDefinition`](crate::ActionDefinition),
+/// [`PreGD`](crate::PreGD), [`GoalDefinition`](crate::GoalDefinition),
+/// [`Term`](crate::Term), [`CEffect`](crate::CEffect), [`DurativeActionDefinition`](crate::DurativeActionDefinition),
+/// [`DurativeActionGoalDefinition`](crate::DurativeActionGoalDefinition), [`DurativeActionEffect`](crate::DurativeActionEffect),
+/// [`PrefConGD`](crate::PrefConGD) and [`ConGD`](crate::ConGD).
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Default)]
 pub struct Variable<'a>(Name<'a>);
 


### PR DESCRIPTION
This now adds, for each domain and problem type, a reference to all other types using it. In theory
this can be derived automatically in documentation generators and "see references" IDE implementations,
but this may provide a slightly easier way to navigate - provided it's not outdated in ten minutes.