### PR TITLE
Add into_iter for types with Single/All variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added `IntoIterator` implementations for `ConditionalEffect`, `DurationConstraint`
+  and `Effect` that flatten the `Single` and `All` variants into a single iterator.
+  In all these cases, the `(and ...)` representation allows for a cardinality of
+  zero, one or many, which makes `x` and `(and x)` identical.
+
 ## [0.0.3] - 2023-05-03
 
 ### Internal

--- a/src/parsers/duration_constraint.rs
+++ b/src/parsers/duration_constraint.rs
@@ -19,7 +19,7 @@ use nom::IResult;
 ///
 /// let input = "(= ?duration 5)";
 /// assert_eq!(parse_duration_constraint(input), Ok(("",
-///     Some(DurationConstraint::new_simple(
+///     Some(DurationConstraint::new(
 ///         SimpleDurationConstraint::Op(
 ///             DOp::Equal,
 ///             DurationValue::Number(5.into())
@@ -29,7 +29,7 @@ use nom::IResult;
 ///
 /// let input = "(at end (<= ?duration 1.23))";
 /// assert_eq!(parse_duration_constraint(input), Ok(("",
-///     Some(DurationConstraint::new_simple(
+///     Some(DurationConstraint::new(
 ///         SimpleDurationConstraint::new_at(
 ///             TimeSpecifier::End,
 ///             SimpleDurationConstraint::Op(

--- a/src/types/duration_constraint.rs
+++ b/src/types/duration_constraint.rs
@@ -1,51 +1,90 @@
 //! Contains duration constraints via the [`DurationConstraint`] type.
 
+use crate::types::iterators::FlatteningIntoIterator;
 use crate::types::SimpleDurationConstraint;
 
 /// ## Usage
 /// Used by [`DurativeActionDefinition`](crate::DurativeActionDefinition).
 #[derive(Debug, Clone, PartialEq)]
 pub enum DurationConstraint<'a> {
-    Simple(SimpleDurationConstraint<'a>),
+    Single(SimpleDurationConstraint<'a>),
     /// ## Requirements
     /// Requires [DurationInequalities](crate::types::Requirement::DurationInequalities).
-    And(Vec<SimpleDurationConstraint<'a>>),
+    All(Vec<SimpleDurationConstraint<'a>>),
+}
+
+impl<'a> IntoIterator for DurationConstraint<'a> {
+    type Item = SimpleDurationConstraint<'a>;
+    type IntoIter = FlatteningIntoIterator<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self {
+            DurationConstraint::Single(item) => FlatteningIntoIterator::new(item),
+            DurationConstraint::All(vec) => FlatteningIntoIterator::new_vec(vec),
+        }
+    }
 }
 
 impl<'a> DurationConstraint<'a> {
-    pub const fn new_simple(constraint: SimpleDurationConstraint<'a>) -> Self {
-        Self::Simple(constraint)
+    pub const fn new(constraint: SimpleDurationConstraint<'a>) -> Self {
+        Self::Single(constraint)
     }
 
     pub fn new_all<I: IntoIterator<Item = SimpleDurationConstraint<'a>>>(constraints: I) -> Self {
         let vec: Vec<_> = constraints.into_iter().collect();
         debug_assert!(!vec.is_empty());
-        Self::And(vec)
+        Self::All(vec)
     }
 
     pub fn len(&self) -> usize {
         match self {
-            DurationConstraint::Simple(_) => 1,
-            DurationConstraint::And(cs) => cs.len(),
+            DurationConstraint::Single(_) => 1,
+            DurationConstraint::All(cs) => cs.len(),
         }
     }
 
     pub fn is_empty(&self) -> bool {
         match self {
-            DurationConstraint::Simple(_) => false,
-            DurationConstraint::And(xs) => xs.is_empty(),
+            DurationConstraint::Single(_) => false,
+            DurationConstraint::All(xs) => xs.is_empty(),
         }
     }
 }
 
 impl<'a> From<SimpleDurationConstraint<'a>> for DurationConstraint<'a> {
     fn from(value: SimpleDurationConstraint<'a>) -> Self {
-        DurationConstraint::new_simple(value)
+        DurationConstraint::new(value)
     }
 }
 
 impl<'a> FromIterator<SimpleDurationConstraint<'a>> for DurationConstraint<'a> {
     fn from_iter<T: IntoIterator<Item = SimpleDurationConstraint<'a>>>(iter: T) -> Self {
         DurationConstraint::new_all(iter)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Parser;
+
+    #[test]
+    fn flatten_with_single_element_works() {
+        let (_, dc_a) = SimpleDurationConstraint::parse("(>= ?duration 1.23)").unwrap();
+
+        let mut iter = DurationConstraint::new(dc_a).into_iter();
+        assert!(iter.next().is_some());
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn flatten_with_many_elements_works() {
+        let (_, dc_a) = SimpleDurationConstraint::parse("(>= ?duration 1.23)").unwrap();
+        let (_, dc_b) = SimpleDurationConstraint::parse("(at end (<= ?duration 1.23))").unwrap();
+
+        let mut iter = DurationConstraint::from_iter([dc_a, dc_b]).into_iter();
+        assert!(iter.next().is_some());
+        assert!(iter.next().is_some());
+        assert!(iter.next().is_none());
     }
 }

--- a/src/types/effect.rs
+++ b/src/types/effect.rs
@@ -1,5 +1,6 @@
 //! Contains effects via the [`Effect`] type.
 
+use crate::types::iterators::FlatteningIntoIterator;
 use crate::types::CEffect;
 
 /// An effect. Occurs e.g. in a [`ActionDefinition`](crate::types::ActionDefinition).
@@ -12,6 +13,18 @@ pub enum Effect<'a> {
     Single(CEffect<'a>), // TODO: Unify with `All` variant; this is just a single-element vector and according to spec, this vector may be empty.
     /// Conjunction: All effects apply (i.e. a and b and c ..).
     All(Vec<CEffect<'a>>),
+}
+
+impl<'a> IntoIterator for Effect<'a> {
+    type Item = CEffect<'a>;
+    type IntoIter = FlatteningIntoIterator<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self {
+            Effect::Single(item) => FlatteningIntoIterator::new(item),
+            Effect::All(vec) => FlatteningIntoIterator::new_vec(vec),
+        }
+    }
 }
 
 impl<'a> Effect<'a> {

--- a/src/types/iterators.rs
+++ b/src/types/iterators.rs
@@ -1,0 +1,45 @@
+//! Contains iterator types.
+
+use std::iter::once;
+use std::vec;
+
+/// An iterator that can represent instances with either
+/// one or many values, such as [`ConditionalEffect`](crate::ConditionalEffect),
+/// [`DurationConstraint`](crate::DurationConstraint),
+/// [`Effect`](crate::Effect) and others.
+pub enum FlatteningIntoIterator<T> {
+    /// The iterator is already empty (similar to [`std::iter::Empty`]).
+    Never,
+    /// The iterator will produce exactly one value (similar to [`std::iter::Once`]).
+    Once(std::iter::Once<T>),
+    /// The iterator will produce none, one or many values.
+    Vec(vec::IntoIter<T>),
+}
+
+impl<T> FlatteningIntoIterator<T> {
+    /// Creates an iterator that will create exactly one item.
+    pub fn new(item: T) -> Self {
+        Self::Once(once(item))
+    }
+
+    /// Creates an iterator that will create none, one or many values.
+    pub fn new_vec(vec: Vec<T>) -> Self {
+        if vec.is_empty() {
+            Self::Never
+        } else {
+            Self::Vec(vec.into_iter())
+        }
+    }
+}
+
+impl<T> Iterator for FlatteningIntoIterator<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Never => None,
+            Self::Once(ref mut iter) => iter.next(),
+            Self::Vec(ref mut iter) => iter.next(),
+        }
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -42,6 +42,7 @@ mod goal_def;
 mod init_el;
 mod init_els;
 pub(crate) mod interval;
+mod iterators;
 mod length_spec;
 mod literal;
 mod metric_f_exp;


### PR DESCRIPTION
This adds `IntoIterator` implementations for `ConditionalEffect`, `DurationConstraint` and `Effect` that flatten the `Single` and `All` variants into a single iterator. In all these cases, the `(and ...)` representation allows for a cardinality of zero, one or many, which makes `x` and `(and x)` identical.

In other words, zero, one or many elements could be expressed as follows:

- `(and)` for zero values,
- `(and x)` or simply `x` for one value,
- `(and x y)` for two values, etc.

As a result, the `Single` variant is only an artifact of the underlying PDDL language and could be removed in code. Adding the `IntoIterator` trait here is a first step in allowing for this.