### PR TITLE
Improve requirement readability

### DIFF
--- a/src/types/atomic_function_skeleton.rs
+++ b/src/types/atomic_function_skeleton.rs
@@ -26,7 +26,7 @@ use crate::types::{FunctionSymbol, TypedVariables, Variable};
 /// ([DurativeActionDefinition](crate::types::DurativeActionDefinition)).
 ///
 /// There are a number of supported effects for numeric fluents, e.g.
-/// [BinaryOp](crate::types::BinaryOp) and [`AssignOp`](crate::types::AssignOp).
+/// [`BinaryOp`](crate::types::BinaryOp) and [`AssignOp`](crate::types::AssignOp).
 ///
 /// ## Usage
 /// Used by [`Functions`](crate::Functions).

--- a/src/types/c_effect.rs
+++ b/src/types/c_effect.rs
@@ -11,10 +11,10 @@ use crate::types::{ConditionalEffect, Effect, GoalDefinition, PEffect};
 pub enum CEffect<'a> {
     Effect(PEffect<'a>),
     /// ## Requirements
-    /// Requires [ConditionalEffects](crate::types::Requirement::ConditionalEffects).
+    /// Requires [Conditional Effects](crate::Requirement::ConditionalEffects).
     Forall(TypedVariables<'a>, Box<Effect<'a>>),
     /// ## Requirements
-    /// Requires [ConditionalEffects](crate::types::Requirement::ConditionalEffects).
+    /// Requires [Conditional Effects](crate::Requirement::ConditionalEffects).
     When(GoalDefinition<'a>, ConditionalEffect<'a>),
 }
 

--- a/src/types/d_op.rs
+++ b/src/types/d_op.rs
@@ -8,10 +8,10 @@ use std::fmt::{Display, Formatter};
 pub enum DOp {
     Equal,
     /// ## Requirements
-    /// Requires [DurationInequalities](crate::types::Requirement::DurationInequalities);
+    /// Requires [Duration Inequalities](crate::Requirement::DurationInequalities);
     GreaterOrEqual,
     /// ## Requirements
-    /// Requires [DurationInequalities](crate::types::Requirement::DurationInequalities);
+    /// Requires [Duration Inequalities](crate::Requirement::DurationInequalities);
     LessThanOrEqual,
 }
 

--- a/src/types/d_value.rs
+++ b/src/types/d_value.rs
@@ -12,7 +12,7 @@ pub enum DurationValue<'a> {
     Number(Number),
     /// A function expression that produces the duration value.
     /// ## Requirements
-    /// Requires [NumericFluents](crate::types::Requirement::NumericFluents).
+    /// Requires [Numeric Fluents](crate::Requirement::NumericFluents).
     FExp(FExp<'a>),
 }
 

--- a/src/types/d_value.rs
+++ b/src/types/d_value.rs
@@ -2,7 +2,7 @@
 
 use crate::types::{FExp, Number};
 
-/// A duration value, either a [Number] or an [FExp](FExp).
+/// A duration value, either a [`Number`] or an [`FExp`](FExp).
 ///
 /// ## Usage
 /// Used by [`SimpleDurationConstraint`](crate::SimpleDurationConstraint).

--- a/src/types/da_def.rs
+++ b/src/types/da_def.rs
@@ -9,10 +9,10 @@ use crate::types::{
 /// of time to complete. The amount of time is expressible as either a value or as
 /// an inequality (allow for both fixed duration and ranged duration actions).
 ///
-/// Similar to traditional actions ([ActionDefinition](crate::types::ActionDefinition))
+/// Similar to traditional actions ([`ActionDefinition`](crate::types::ActionDefinition))
 /// we have conditions and effects, but it should be noted that the keyword in
-/// durative actions is [condition](DurativeActionDefinition::condition), not
-/// [precondition](crate::types::ActionDefinition::precondition).
+/// durative actions is [`condition`](DurativeActionDefinition::condition), not
+/// [`precondition`](crate::types::ActionDefinition::precondition).
 ///
 /// This semantic change is designed to represent that a durative action may not just
 /// condition when the action starts, but may have conditions which need to be true

--- a/src/types/da_effect.rs
+++ b/src/types/da_effect.rs
@@ -3,7 +3,7 @@
 use crate::types::TypedVariables;
 use crate::types::{DurativeActionGoalDefinition, TimedEffect};
 
-/// A durative action effect used in [DurativeActionDefinition](crate::types::DurativeActionDefinition).
+/// A durative action effect used in [`DurativeActionDefinition`](crate::types::DurativeActionDefinition).
 ///
 /// ## Usage
 /// Used by [`DurativeActionDefinition`](crate::DurativeActionDefinition).

--- a/src/types/da_effect.rs
+++ b/src/types/da_effect.rs
@@ -13,10 +13,10 @@ pub enum DurativeActionEffect<'a> {
     /// Conjunction: All effects apply (i.e. a and b and c ..).
     All(Vec<DurativeActionEffect<'a>>),
     /// ## Requirements
-    /// Requires [ConditionalEffects](crate::types::Requirement::ConditionalEffects).
+    /// Requires [Conditional Effects](crate::Requirement::ConditionalEffects).
     Forall(TypedVariables<'a>, Box<DurativeActionEffect<'a>>),
     /// ## Requirements
-    /// Requires [ConditionalEffects](crate::types::Requirement::ConditionalEffects).
+    /// Requires [Conditional Effects](crate::Requirement::ConditionalEffects).
     When(DurativeActionGoalDefinition<'a>, TimedEffect<'a>),
 }
 

--- a/src/types/da_gd.rs
+++ b/src/types/da_gd.rs
@@ -13,7 +13,7 @@ pub enum DurativeActionGoalDefinition<'a> {
     Timed(PrefTimedGD<'a>),
     And(Vec<DurativeActionGoalDefinition<'a>>),
     /// ## Requirements
-    /// Requires [UniversalPreconditions](crate::types::Requirement::UniversalPreconditions).
+    /// Requires [Universal Preconditions](crate::Requirement::UniversalPreconditions).
     Forall(TypedVariables<'a>, Box<DurativeActionGoalDefinition<'a>>),
 }
 

--- a/src/types/domain.rs
+++ b/src/types/domain.rs
@@ -17,15 +17,15 @@ pub struct Domain<'a> {
     extends: Vec<Name<'a>>,
     requirements: Requirements,
     /// ## Requirements
-    /// Requires [Typing](crate::types::Requirement::Typing).
+    /// Requires [Typing](crate::Requirement::Typing).
     types: Types<'a>,
     constants: Constants<'a>,
     predicates: PredicateDefinitions<'a>,
     /// ## Requirements
-    /// Requires [Fluents](crate::types::Requirement::Fluents).
+    /// Requires [Fluents](crate::Requirement::Fluents).
     functions: Functions<'a>,
     /// ## Requirements
-    /// Requires [Constraints](crate::types::Requirement::Constraints).
+    /// Requires [Constraints](crate::Requirement::Constraints).
     constraints: DomainConstraintsDef<'a>,
     // TODO: PDDL 1.2 - deprecated?
     timeless: Timeless<'a>,
@@ -110,14 +110,14 @@ impl<'a> Domain<'a> {
     }
 
     /// Returns the optional domain requirements.
-    /// If no requirements were specified by the domain, [Strips](crate::types::Requirement::Strips) is implied.
+    /// If no requirements were specified by the domain, [STRIPS](crate::Requirement::Strips) is implied.
     pub const fn requirements(&self) -> &Requirements {
         &self.requirements
     }
 
     /// Returns the optional type declarations.
     /// ## Requirements
-    /// Requires [Typing](crate::types::Requirement::Typing).
+    /// Requires [Typing](crate::Requirement::Typing).
     pub const fn types(&self) -> &Types<'a> {
         &self.types
     }

--- a/src/types/domain_constraints_def.rs
+++ b/src/types/domain_constraints_def.rs
@@ -6,7 +6,7 @@ use std::ops::Deref;
 /// A domain constraints definition; wraps a [`ConGD`].
 ///
 /// ## Requirements
-/// Requires [Constraints](crate::types::Requirement::Constraints).
+/// Requires [Constraints](crate::Requirement::Constraints).
 ///
 /// ## Usage
 /// Used by [`Domain`](crate::Domain).

--- a/src/types/duration_constraint.rs
+++ b/src/types/duration_constraint.rs
@@ -9,7 +9,7 @@ use crate::types::SimpleDurationConstraint;
 pub enum DurationConstraint<'a> {
     Single(SimpleDurationConstraint<'a>),
     /// ## Requirements
-    /// Requires [DurationInequalities](crate::types::Requirement::DurationInequalities).
+    /// Requires [Duration Inequalities](crate::Requirement::DurationInequalities).
     All(Vec<SimpleDurationConstraint<'a>>),
 }
 

--- a/src/types/f_exp.rs
+++ b/src/types/f_exp.rs
@@ -5,7 +5,7 @@ use crate::types::{BinaryOp, FHead, MultiOp, Number};
 /// A function/fluent expression used e.g. in a [`DurationValue`](crate::types::DurationValue).
 ///
 /// ## Requirements
-/// Requires [NumericFluents](crate::types::Requirement::NumericFluents).
+/// Requires [Numeric Fluents](crate::Requirement::NumericFluents).
 ///
 /// ## Usage
 /// Used by [`FExp`] itself, as well as [`PEffect`](crate::PEffect), [`DurationValue`](crate::DurationValue),

--- a/src/types/f_exp_da.rs
+++ b/src/types/f_exp_da.rs
@@ -11,7 +11,7 @@ pub enum FExpDa<'a> {
     MultiOp(MultiOp, Box<FExpDa<'a>>, Vec<FExpDa<'a>>),
     Negative(Box<FExpDa<'a>>),
     /// ## Requirements
-    /// Requires [DurationInequalities](crate::types::Requirement::DurationInequalities).
+    /// Requires [Duration Inequalities](crate::Requirement::DurationInequalities).
     Duration,
     FExp(FExp<'a>),
 }

--- a/src/types/f_exp_t.rs
+++ b/src/types/f_exp_t.rs
@@ -5,8 +5,8 @@ use crate::types::FExp;
 /// An f-exp-t.
 ///
 /// ## Requirements
-/// Requires [ContinuousEffects](crate::types::Requirement::ContinuousEffects) and
-/// [NumericFluents](crate::types::Requirement::NumericFluents).
+/// Requires [Continuous Effects](crate::Requirement::ContinuousEffects) and
+/// [Numeric Fluents](crate::Requirement::NumericFluents).
 ///
 /// ## Usage
 /// Used by [`TimedEffect`](crate::TimedEffect).

--- a/src/types/f_head.rs
+++ b/src/types/f_head.rs
@@ -5,7 +5,7 @@ use crate::types::{FunctionSymbol, Term};
 /// A function declaration.
 ///
 /// ## Requirements
-/// Requires [NumericFluents](crate::types::Requirement::NumericFluents).
+/// Requires [Numeric Fluents](crate::Requirement::NumericFluents).
 ///
 /// ## Usage
 /// Used by [`FExp`](crate::FExp), [`PEffect`](crate::PEffect), [`TimedEffect`](crate::TimedEffect)

--- a/src/types/function_term.rs
+++ b/src/types/function_term.rs
@@ -6,7 +6,7 @@ use crate::types::FunctionSymbol;
 /// A function term.
 ///
 /// ## Requirements
-/// Requires [ObjectFluents](crate::Requirement::ObjectFluents).
+/// Requires [Object Fluents](crate::Requirement::ObjectFluents).
 ///
 /// ## Usage
 /// Used by [`Term`], and [`PEffect`](crate::PEffect).

--- a/src/types/function_type.rs
+++ b/src/types/function_type.rs
@@ -7,8 +7,8 @@ use std::ops::Deref;
 ///
 /// ## Requirements
 /// Requires [Fluents](crate::Requirement::Fluents), as well as either
-/// [NumericFluents](crate::Requirement::NumericFluents) for the default `number` type, or
-/// [ObjectFluents](crate::Requirement::ObjectFluents) and [Typing](crate::Requirement::Typing)
+/// [Numeric Fluents](crate::Requirement::NumericFluents) for the default `number` type, or
+/// [Object Fluents](crate::Requirement::ObjectFluents) and [Typing](crate::Requirement::Typing)
 /// for an arbitrary type.
 ///
 /// ## Usage

--- a/src/types/function_typed_list.rs
+++ b/src/types/function_typed_list.rs
@@ -21,8 +21,8 @@ use std::ops::Deref;
 ///
 /// ## Requirements
 /// Requires [Fluents](crate::Requirement::Fluents) and either
-/// [NumericFluents](crate::Requirement::NumericFluents) for the default `number` type, or
-/// [ObjectFluents](crate::Requirement::ObjectFluents) and [Typing](crate::Requirement::Typing)
+/// [Numeric Fluents](crate::Requirement::NumericFluents) for the default `number` type, or
+/// [Object Fluents](crate::Requirement::ObjectFluents) and [Typing](crate::Requirement::Typing)
 /// for an arbitrary type.
 ///
 /// ## Usage

--- a/src/types/gd.rs
+++ b/src/types/gd.rs
@@ -13,26 +13,26 @@ use crate::types::{AtomicFormula, FComp, Term, TypedVariables};
 pub enum GoalDefinition<'a> {
     AtomicFormula(AtomicFormula<'a, Term<'a>>),
     /// ## Requirements
-    /// Requires [NegativePreconditions](crate::types::Requirement::NegativePreconditions).
+    /// Requires [Negative Preconditions](crate::Requirement::NegativePreconditions).
     Literal(TermLiteral<'a>),
     And(Vec<GoalDefinition<'a>>),
     /// ## Requirements
-    /// Requires [DisjunctivePreconditions](crate::types::Requirement::DisjunctivePreconditions).
+    /// Requires [Disjunctive Preconditions](crate::Requirement::DisjunctivePreconditions).
     Or(Vec<GoalDefinition<'a>>),
     /// ## Requirements
-    /// Requires [DisjunctivePreconditions](crate::types::Requirement::DisjunctivePreconditions).
+    /// Requires [Disjunctive Preconditions](crate::Requirement::DisjunctivePreconditions).
     Not(Box<GoalDefinition<'a>>),
     /// ## Requirements
-    /// Requires [DisjunctivePreconditions](crate::types::Requirement::DisjunctivePreconditions).
+    /// Requires [Disjunctive Preconditions](crate::Requirement::DisjunctivePreconditions).
     Imply(Box<GoalDefinition<'a>>, Box<GoalDefinition<'a>>),
     /// ## Requirements
-    /// Requires [ExistentialPreconditions](crate::types::Requirement::ExistentialPreconditions).
+    /// Requires [Existential Preconditions](crate::Requirement::ExistentialPreconditions).
     Exists(TypedVariables<'a>, Box<GoalDefinition<'a>>),
     /// ## Requirements
-    /// Requires [UniversalPreconditions](crate::types::Requirement::UniversalPreconditions).
+    /// Requires [Universal Preconditions](crate::Requirement::UniversalPreconditions).
     ForAll(TypedVariables<'a>, Box<GoalDefinition<'a>>),
     /// ## Requirements
-    /// Requires [NumericFluents](crate::types::Requirement::NumericFluents).
+    /// Requires [Numeric Fluents](crate::Requirement::NumericFluents).
     FComp(FComp<'a>),
 }
 

--- a/src/types/init_el.rs
+++ b/src/types/init_el.rs
@@ -8,13 +8,13 @@ use crate::types::{BasicFunctionTerm, Name, NameLiteral, Number};
 pub enum InitElement<'a> {
     Literal(NameLiteral<'a>),
     /// ## Requirements
-    /// Requires [TimedInitialLiterals](crate::types::Requirement::TimedInitialLiterals).
+    /// Requires [Timed Initial Literals](crate::Requirement::TimedInitialLiterals).
     At(Number, NameLiteral<'a>),
     /// ## Requirements
-    /// Requires [NumericFluents](crate::types::Requirement::NumericFluents).
+    /// Requires [Numeric Fluents](crate::Requirement::NumericFluents).
     IsValue(BasicFunctionTerm<'a>, Number),
     /// ## Requirements
-    /// Requires [ObjectFluents](crate::types::Requirement::ObjectFluents).
+    /// Requires [Object Fluents](crate::Requirement::ObjectFluents).
     IsObject(BasicFunctionTerm<'a>, Name<'a>),
 }
 

--- a/src/types/interval.rs
+++ b/src/types/interval.rs
@@ -2,7 +2,7 @@
 
 use std::fmt::{Display, Formatter};
 
-/// An interval used in [TimedGD::Over](crate::types::TimedGD::Over).
+/// An interval used in [`TimedGD::Over`](crate::types::TimedGD::Over).
 ///
 /// ## Usage
 /// Used by [`TimedGD`](crate::TimedGD).

--- a/src/types/metric_f_exp.rs
+++ b/src/types/metric_f_exp.rs
@@ -5,7 +5,7 @@ use crate::types::{BinaryOp, FunctionSymbol, MultiOp, Name, Number, PreferenceNa
 /// A metric function expression.
 ///
 /// ## Requirements
-/// Requires [NumericFluents](crate::Requirement::NumericFluents).
+/// Requires [Numeric Fluents](crate::Requirement::NumericFluents).
 ///
 /// ## Usage
 /// Used by [`MetricSpec`](crate::MetricSpec).
@@ -18,7 +18,7 @@ pub enum MetricFExp<'a> {
     Function(FunctionSymbol<'a>, Vec<Name<'a>>),
     TotalTime,
     /// ## Requirements
-    /// Requires [Preferences](crate::types::Requirement::Preferences).
+    /// Requires [Preferences](crate::Requirement::Preferences).
     IsViolated(PreferenceName<'a>),
 }
 

--- a/src/types/metric_spec.rs
+++ b/src/types/metric_spec.rs
@@ -3,8 +3,9 @@
 use crate::types::{MetricFExp, Optimization};
 
 /// A metric specification.
+///
 /// ## Requirements
-/// Requires [NumericFluents](crate::types::Requirement::NumericFluents).
+/// Requires [Numeric Fluents](crate::Requirement::NumericFluents).
 #[derive(Debug, Clone, PartialEq)]
 pub struct MetricSpec<'a> {
     optimization: Optimization,

--- a/src/types/optimization.rs
+++ b/src/types/optimization.rs
@@ -5,7 +5,7 @@ use std::fmt::{Display, Formatter};
 /// An optimization instruction.
 ///
 /// ## Requirements
-/// Requires [NumericFluents](crate::Requirement::NumericFluents).
+/// Requires [Numeric Fluents](crate::Requirement::NumericFluents).
 ///
 /// ## Usage
 /// Used by [`MetricSpec`](crate::MetricSpec).

--- a/src/types/p_effect.rs
+++ b/src/types/p_effect.rs
@@ -12,10 +12,10 @@ pub enum PEffect<'a> {
     AtomicFormula(AtomicFormula<'a, Term<'a>>),
     NotAtomicFormula(AtomicFormula<'a, Term<'a>>),
     /// ## Requirements
-    /// Requires [NumericFluents](crate::types::Requirement::NumericFluents).
+    /// Requires [Numeric Fluents](crate::Requirement::NumericFluents).
     AssignNumericFluent(AssignOp, FHead<'a>, FExp<'a>),
     /// ## Requirements
-    /// Requires [ObjectFluents](crate::types::Requirement::ObjectFluents).
+    /// Requires [Object Fluents](crate::Requirement::ObjectFluents).
     AssignObjectFluent(FunctionTerm<'a>, Option<Term<'a>>),
 }
 

--- a/src/types/pre_gd.rs
+++ b/src/types/pre_gd.rs
@@ -17,7 +17,7 @@ pub enum PreGD<'a> {
     /// which has no requirements.
     Preference(PreferenceGD<'a>),
     /// ## Requirements
-    /// Requires [UniversalPreconditions](crate::types::Requirement::UniversalPreconditions).
+    /// Requires [Universal Preconditions](crate::Requirement::UniversalPreconditions).
     Forall(TypedVariables<'a>, Box<PreGD<'a>>),
 }
 

--- a/src/types/pref_con_gd.rs
+++ b/src/types/pref_con_gd.rs
@@ -11,10 +11,10 @@ use crate::types::{ConGD, PreferenceName, TypedVariables};
 pub enum PrefConGD<'a> {
     And(Vec<PrefConGD<'a>>), // TODO: Unify with base type. Should always be a vector.
     /// ## Requirements
-    /// Requires [UniversalPreconditions](crate::types::Requirement::UniversalPreconditions).
+    /// Requires [Universal Preconditions](crate::Requirement::UniversalPreconditions).
     Forall(TypedVariables<'a>, Box<PrefConGD<'a>>),
     /// ## Requirements
-    /// Requires [Preferences](crate::types::Requirement::Preferences).
+    /// Requires [Preferences](crate::Requirement::Preferences).
     Preference(Option<PreferenceName<'a>>, ConGD<'a>),
     Goal(ConGD<'a>),
 }

--- a/src/types/pref_timed_gd.rs
+++ b/src/types/pref_timed_gd.rs
@@ -10,7 +10,7 @@ use crate::types::{PreferenceName, TimedGD};
 pub enum PrefTimedGD<'a> {
     Required(TimedGD<'a>),
     /// ## Requirements
-    /// Requires [Preferences](crate::types::Requirement::Preferences).
+    /// Requires [Preferences](crate::Requirement::Preferences).
     Preference(Option<PreferenceName<'a>>, TimedGD<'a>),
 }
 

--- a/src/types/problem.rs
+++ b/src/types/problem.rs
@@ -18,10 +18,10 @@ pub struct Problem<'a> {
     init: InitElements<'a>,
     goal: GoalDef<'a>,
     /// ## Requirements
-    /// Requires [Constraints](crate::types::Requirement::Constraints).
+    /// Requires [Constraints](crate::Requirement::Constraints).
     constraints: ProblemConstraintsDef<'a>,
     /// ## Requirements
-    /// Requires [NumericFluents](crate::types::Requirement::NumericFluents).
+    /// Requires [Numeric Fluents](crate::Requirement::NumericFluents).
     metric_spec: Option<MetricSpec<'a>>,
     /// Deprecated since PDDL 2.1.
     length_spec: Option<LengthSpec>,
@@ -134,14 +134,14 @@ impl<'a> Problem<'a> {
 
     /// Returns the optional constraints of the problem.
     /// ## Requirements
-    /// Requires [Constraints](crate::types::Requirement::Constraints).
+    /// Requires [Constraints](crate::Requirement::Constraints).
     pub const fn constraints(&self) -> &PrefConGD<'a> {
         &self.constraints.value()
     }
 
     /// Returns the optional metric specification of the problem.
     /// ## Requirements
-    /// Requires [NumericFluents](crate::types::Requirement::NumericFluents).
+    /// Requires [Numeric Fluents](crate::Requirement::NumericFluents).
     pub const fn metric_spec(&self) -> &Option<MetricSpec<'a>> {
         &self.metric_spec
     }

--- a/src/types/problem_constraints_def.rs
+++ b/src/types/problem_constraints_def.rs
@@ -6,7 +6,7 @@ use std::ops::Deref;
 /// A problem constraints definition; wraps a [`PrefConGD`].
 ///
 /// ## Requirements
-/// Requires [Constraints](crate::types::Requirement::Constraints).
+/// Requires [Constraints](crate::Requirement::Constraints).
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct ProblemConstraintsDef<'a>(PrefConGD<'a>);
 

--- a/src/types/requirement.rs
+++ b/src/types/requirement.rs
@@ -11,7 +11,7 @@ use std::fmt::{Display, Formatter};
 /// ## Notes
 /// Some requirements imply others; some are abbreviations for common sets
 /// of requirements. If a domain stipulates no requirements, it is assumed
-/// to declare a requirement for [`Strips`](Self::Strips).
+/// to declare a requirement for [`STRIPS`](Self::Strips).
 ///
 /// ## References
 /// - "Complete BNF description of PDDL 3.1 (completely corrected)", Daniel L. Kovacs (`dkovacs@mit.bme.hu`).

--- a/src/types/structure_def.rs
+++ b/src/types/structure_def.rs
@@ -10,10 +10,10 @@ use crate::types::{ActionDefinition, DerivedPredicate, DurativeActionDefinition}
 pub enum StructureDef<'a> {
     Action(ActionDefinition<'a>),
     /// ## Requirements
-    /// Requires [DurativeActions](crate::types::Requirement::DurativeActions).
+    /// Requires [Durative Actions](crate::Requirement::DurativeActions).
     DurativeAction(DurativeActionDefinition<'a>),
     /// ## Requirements
-    /// Requires [DerivedPredicates](crate::types::Requirement::DerivedPredicates).
+    /// Requires [Derived Predicates](crate::Requirement::DerivedPredicates).
     Derived(DerivedPredicate<'a>),
 }
 

--- a/src/types/time_specifier.rs
+++ b/src/types/time_specifier.rs
@@ -2,7 +2,7 @@
 
 use std::fmt::{Display, Formatter};
 
-/// A time specifier used in e.g. [TimedGD::At](crate::types::TimedGD::At) and [TimedEffect](crate::types::TimedEffect).
+/// A time specifier used in e.g. [`TimedGD::At`](crate::types::TimedGD::At) and [`TimedEffect`](crate::types::TimedEffect).
 ///
 /// ## Usage
 /// Used by [`TimedGD`](crate::TimedGD) and [`TimedEffect`](crate::TimedEffect).

--- a/src/types/timed_effect.rs
+++ b/src/types/timed_effect.rs
@@ -23,11 +23,11 @@ use crate::types::{AssignOpT, ConditionalEffect, FAssignDa, FExpT, FHead, TimeSp
 pub enum TimedEffect<'a> {
     Conditional(TimeSpecifier, ConditionalEffect<'a>),
     /// ## Requirements
-    /// Requires [NumericFluents](crate::types::Requirement::NumericFluents).
+    /// Requires [Numeric Fluents](crate::Requirement::NumericFluents).
     NumericFluent(TimeSpecifier, FAssignDa<'a>),
     /// ## Requirements
-    /// Requires [ContinuousEffects](crate::types::Requirement::ContinuousEffects) and
-    /// [NumericFluents](crate::types::Requirement::NumericFluents).
+    /// Requires [Continuous Effects](crate::Requirement::ContinuousEffects) and
+    /// [Numeric Fluents](crate::Requirement::NumericFluents).
     ContinuousEffect(AssignOpT, FHead<'a>, FExpT<'a>),
 }
 

--- a/src/types/timed_effect.rs
+++ b/src/types/timed_effect.rs
@@ -2,7 +2,7 @@
 
 use crate::types::{AssignOpT, ConditionalEffect, FAssignDa, FExpT, FHead, TimeSpecifier};
 
-/// A timed effect, either conditional, continuous or derived from a fluent, e.g. [DurativeActionEffect](crate::types::DurativeActionEffect).
+/// A timed effect, either conditional, continuous or derived from a fluent, e.g. [`DurativeActionEffect`](crate::types::DurativeActionEffect).
 ///
 /// An effect is a condition which is made true when an action is applied.
 /// Note that the effect is always more restrictive than an action and typically only


### PR DESCRIPTION
This represents requirement links as `Numeric Fluents` instead of `NumericFluents` and simplifies some of the type references from `crate::types::Requirement` to `crate::Requirement`.

In addition, some missing backticks were added for non-requirement type references.