### PR TITLE
Remove PreconditionGoalDefinitions::And variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changelog
 
 - The `PreGD` type was renamed to `PreconditionGoalDefinition`.
+- The `PreconditionGoalDefinition::And` variant was removed and replaced with the `PreconditionGoalDefinitions` type.
 
 ## [0.0.3] - 2023-05-03
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@
 //! assert_eq!(problem.domain(), &"briefcase-world".into());
 //! assert!(problem.requirements().is_empty());
 //! assert_eq!(problem.init().len(), 9);
-//! assert!(matches! { problem.goal(), pddl::PreconditionGoalDefinition::And(_) });
+//! assert_eq!(problem.goal().len(), 3);
 //! ```
 
 // only enables the `doc_cfg` feature when

--- a/src/parsers/action_def.rs
+++ b/src/parsers/action_def.rs
@@ -13,7 +13,7 @@ use nom::IResult;
 ///
 /// ## Example
 /// ```
-/// # use pddl::{ActionDefinition, ActionSymbol, AtomicFormula, CEffect, Effect, GoalDefinition, Name, PEffect, Predicate, PreferenceGD, PreconditionGoalDefinition, Term, ToTyped, TypedList, Variable};
+/// # use pddl::{ActionDefinition, ActionSymbol, AtomicFormula, CEffect, Effect, GoalDefinition, Name, PEffect, Predicate, PreferenceGD, PreconditionGoalDefinitions, PreconditionGoalDefinition, Term, ToTyped, TypedList, Variable};
 /// # use pddl::parsers::parse_action_def;
 /// let input = r#"(:action take-out
 ///                     :parameters (?x - physob)
@@ -29,16 +29,18 @@ use nom::IResult;
 ///         TypedList::from_iter([
 ///             Variable::from_str("x").to_typed("physob")
 ///         ]),
-///         Some(PreconditionGoalDefinition::Preference(PreferenceGD::from_gd(
-///             GoalDefinition::new_not(
-///                 GoalDefinition::AtomicFormula(
-///                     AtomicFormula::new_equality(
-///                         Term::Variable(Variable::from_str("x")),
-///                         Term::Name(Name::new("B"))
+///         PreconditionGoalDefinitions::from(
+///             PreconditionGoalDefinition::Preference(PreferenceGD::from_gd(
+///                 GoalDefinition::new_not(
+///                     GoalDefinition::AtomicFormula(
+///                         AtomicFormula::new_equality(
+///                             Term::Variable(Variable::from_str("x")),
+///                             Term::Name(Name::new("B"))
+///                         )
 ///                     )
 ///                 )
 ///             )
-///         ))),
+///         )),
 ///         Some(Effect::new(CEffect::new_p_effect(
 ///             PEffect::NotAtomicFormula(
 ///                 AtomicFormula::new_predicate(
@@ -74,7 +76,12 @@ pub fn parse_action_def(input: &str) -> IResult<&str, ActionDefinition> {
     );
 
     map(action_def, |(symbol, params, (preconditions, effects))| {
-        ActionDefinition::new(symbol, params, preconditions.flatten(), effects.flatten())
+        ActionDefinition::new(
+            symbol,
+            params,
+            preconditions.flatten().into(),
+            effects.flatten(),
+        )
     })(input)
 }
 

--- a/src/parsers/da_gd.rs
+++ b/src/parsers/da_gd.rs
@@ -14,7 +14,7 @@ use nom::IResult;
 /// ## Examples
 /// ```
 /// # use pddl::parsers::{parse_da_gd};
-/// # use pddl::{AtomicFormula, EqualityAtomicFormula, GoalDefinition, Literal, Preference, PreferenceName, PreferenceGD, PreconditionGoalDefinition, Term, Variable, DurativeActionGoalDefinition, PrefTimedGD, TimedGD, TimeSpecifier, Interval};
+/// # use pddl::{AtomicFormula, EqualityAtomicFormula, GoalDefinition, Literal, Preference, PreferenceName, PreferenceGD, Term, Variable, DurativeActionGoalDefinition, PrefTimedGD, TimedGD, TimeSpecifier, Interval};
 /// # use pddl::{Typed, TypedList};
 /// assert_eq!(parse_da_gd("(at start (= x y))"), Ok(("",
 ///     DurativeActionGoalDefinition::Timed(

--- a/src/parsers/goal_def.rs
+++ b/src/parsers/goal_def.rs
@@ -13,7 +13,7 @@ use nom::IResult;
 /// # use pddl::{AtomicFormula, GoalDef, GoalDefinition, PreferenceGD, PreconditionGoalDefinition, Term};
 /// let input = "(:goal (= x y))";
 /// assert_eq!(parse_problem_goal_def(input), Ok(("",
-///     GoalDef::new(
+///     GoalDef::from(
 ///         PreconditionGoalDefinition::Preference(
 ///             PreferenceGD::Goal(
 ///                 GoalDefinition::AtomicFormula(

--- a/src/parsers/problem.rs
+++ b/src/parsers/problem.rs
@@ -34,7 +34,7 @@ use nom::IResult;
 /// assert_eq!(problem.domain(), &Name::new("briefcase-world"));
 /// assert!(problem.requirements().is_empty());
 /// assert_eq!(problem.init().len(), 9);
-/// assert!(matches! { problem.goal(), PreconditionGoalDefinition::And(_) });
+/// assert_eq!(problem.goal().len(), 3);
 /// ```
 pub fn parse_problem(input: &str) -> IResult<&str, Problem> {
     map(

--- a/src/parsers/structure_def.rs
+++ b/src/parsers/structure_def.rs
@@ -28,7 +28,7 @@ use nom::IResult;
 ///         TypedList::from_iter([
 ///             Variable::from("x").to_typed("physob")
 ///         ]),
-///         Some(PreconditionGoalDefinition::Preference(PreferenceGD::from_gd(
+///         PreconditionGoalDefinition::Preference(PreferenceGD::from_gd(
 ///             GoalDefinition::new_not(
 ///                 GoalDefinition::new_atomic_formula(
 ///                     AtomicFormula::new_equality(
@@ -37,7 +37,7 @@ use nom::IResult;
 ///                     )
 ///                 )
 ///             )
-///         ))),
+///         )).into(),
 ///         Some(Effect::new(CEffect::new_p_effect(
 ///             PEffect::NotAtomicFormula(
 ///                 AtomicFormula::new_predicate(

--- a/src/parsers/structure_def.rs
+++ b/src/parsers/structure_def.rs
@@ -12,7 +12,7 @@ use nom::IResult;
 ///
 /// ```
 /// # use pddl::parsers::{parse_structure_def};
-/// # use pddl::{ActionDefinition, ActionSymbol, AtomicFormula, CEffect, Effect, GoalDefinition, Literal, PEffect, Predicate, Preference, PreferenceGD, PreconditionGoalDefinition, StructureDef, Term, Variable};
+/// # use pddl::{ActionDefinition, ActionSymbol, AtomicFormula, CEffect, Effect, GoalDefinition, Literal, PEffect, Predicate, Preference, PreferenceGD, PreconditionGoalDefinitions, StructureDef, Term, Variable};
 /// # use pddl::{Name, ToTyped, TypedList};
 /// let input = r#"(:action take-out
 ///                     :parameters (?x - physob)
@@ -28,7 +28,7 @@ use nom::IResult;
 ///         TypedList::from_iter([
 ///             Variable::from("x").to_typed("physob")
 ///         ]),
-///         PreconditionGoalDefinition::Preference(PreferenceGD::from_gd(
+///         PreconditionGoalDefinitions::new_preference(PreferenceGD::from_gd(
 ///             GoalDefinition::new_not(
 ///                 GoalDefinition::new_atomic_formula(
 ///                     AtomicFormula::new_equality(
@@ -37,7 +37,7 @@ use nom::IResult;
 ///                     )
 ///                 )
 ///             )
-///         )).into(),
+///         )),
 ///         Some(Effect::new(CEffect::new_p_effect(
 ///             PEffect::NotAtomicFormula(
 ///                 AtomicFormula::new_predicate(

--- a/src/types/action_definition.rs
+++ b/src/types/action_definition.rs
@@ -1,7 +1,8 @@
 //! Contains action definitions via the [`ActionDefinition`] type.
 
 use crate::types::TypedVariables;
-use crate::types::{ActionSymbol, Effect, PreconditionGoalDefinition};
+use crate::types::{ActionSymbol, Effect};
+use crate::PreconditionGoalDefinitions;
 
 /// An action definition.
 ///
@@ -11,7 +12,7 @@ use crate::types::{ActionSymbol, Effect, PreconditionGoalDefinition};
 pub struct ActionDefinition<'a> {
     symbol: ActionSymbol<'a>,
     parameters: TypedVariables<'a>,
-    precondition: Option<PreconditionGoalDefinition<'a>>,
+    precondition: PreconditionGoalDefinitions<'a>,
     effect: Option<Effect<'a>>,
 }
 
@@ -19,7 +20,7 @@ impl<'a> ActionDefinition<'a> {
     pub const fn new(
         symbol: ActionSymbol<'a>,
         parameters: TypedVariables<'a>,
-        precondition: Option<PreconditionGoalDefinition<'a>>,
+        precondition: PreconditionGoalDefinitions<'a>,
         effect: Option<Effect<'a>>,
     ) -> Self {
         Self {
@@ -38,7 +39,7 @@ impl<'a> ActionDefinition<'a> {
         &self.parameters
     }
 
-    pub const fn precondition(&self) -> &Option<PreconditionGoalDefinition<'a>> {
+    pub const fn precondition(&self) -> &PreconditionGoalDefinitions<'a> {
         &self.precondition
     }
 

--- a/src/types/goal_def.rs
+++ b/src/types/goal_def.rs
@@ -40,6 +40,12 @@ impl<'a> From<PreconditionGoalDefinition<'a>> for GoalDef<'a> {
     }
 }
 
+impl<'a> FromIterator<PreconditionGoalDefinition<'a>> for GoalDef<'a> {
+    fn from_iter<T: IntoIterator<Item = PreconditionGoalDefinition<'a>>>(iter: T) -> Self {
+        GoalDef::new(PreconditionGoalDefinitions::from_iter(iter))
+    }
+}
+
 impl<'a> Deref for GoalDef<'a> {
     type Target = PreconditionGoalDefinitions<'a>;
 

--- a/src/types/goal_def.rs
+++ b/src/types/goal_def.rs
@@ -1,6 +1,7 @@
 //! Contains the [`GoalDef`] type.
 
-use crate::types::PreconditionGoalDefinition;
+use crate::types::pre_gd::PreconditionGoalDefinitions;
+use crate::PreconditionGoalDefinition;
 use std::ops::Deref;
 
 /// A problem goal definition; wraps a [`PreconditionGoalDefinition`].
@@ -8,41 +9,47 @@ use std::ops::Deref;
 /// ## Usage
 /// Used by [`Problem`](crate::Problem).
 #[derive(Debug, Clone, PartialEq)]
-pub struct GoalDef<'a>(PreconditionGoalDefinition<'a>);
+pub struct GoalDef<'a>(PreconditionGoalDefinitions<'a>);
 
 impl<'a> GoalDef<'a> {
-    pub const fn new(gd: PreconditionGoalDefinition<'a>) -> Self {
+    pub const fn new(gd: PreconditionGoalDefinitions<'a>) -> Self {
         Self(gd)
     }
 
     /// Gets the value.
-    pub const fn value(&self) -> &PreconditionGoalDefinition<'a> {
+    pub const fn value(&self) -> &PreconditionGoalDefinitions<'a> {
         &self.0
     }
 }
 
-impl<'a> PartialEq<PreconditionGoalDefinition<'a>> for GoalDef<'a> {
-    fn eq(&self, other: &PreconditionGoalDefinition<'a>) -> bool {
+impl<'a> PartialEq<PreconditionGoalDefinitions<'a>> for GoalDef<'a> {
+    fn eq(&self, other: &PreconditionGoalDefinitions<'a>) -> bool {
         self.0.eq(other)
+    }
+}
+
+impl<'a> From<PreconditionGoalDefinitions<'a>> for GoalDef<'a> {
+    fn from(value: PreconditionGoalDefinitions<'a>) -> Self {
+        Self::new(value)
     }
 }
 
 impl<'a> From<PreconditionGoalDefinition<'a>> for GoalDef<'a> {
     fn from(value: PreconditionGoalDefinition<'a>) -> Self {
-        Self::new(value)
+        Self::new(PreconditionGoalDefinitions::from(value))
     }
 }
 
 impl<'a> Deref for GoalDef<'a> {
-    type Target = PreconditionGoalDefinition<'a>;
+    type Target = PreconditionGoalDefinitions<'a>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<'a> Into<PreconditionGoalDefinition<'a>> for GoalDef<'a> {
-    fn into(self) -> PreconditionGoalDefinition<'a> {
+impl<'a> Into<PreconditionGoalDefinitions<'a>> for GoalDef<'a> {
+    fn into(self) -> PreconditionGoalDefinitions<'a> {
         self.0
     }
 }

--- a/src/types/goal_def.rs
+++ b/src/types/goal_def.rs
@@ -4,7 +4,7 @@ use crate::types::pre_gd::PreconditionGoalDefinitions;
 use crate::PreconditionGoalDefinition;
 use std::ops::Deref;
 
-/// A problem goal definition; wraps a [`PreconditionGoalDefinition`].
+/// A problem goal definition; wraps a [`PreconditionGoalDefinitions`].
 ///
 /// ## Usage
 /// Used by [`Problem`](crate::Problem).

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -131,7 +131,7 @@ pub use number::Number;
 pub use objects::Objects;
 pub use optimization::Optimization;
 pub use p_effect::PEffect;
-pub use pre_gd::PreconditionGoalDefinition;
+pub use pre_gd::{PreconditionGoalDefinition, PreconditionGoalDefinitions};
 pub use predicate::Predicate;
 pub use predicate_definitions::PredicateDefinitions;
 pub use pref_con_gd::PrefConGD;

--- a/src/types/pre_gd.rs
+++ b/src/types/pre_gd.rs
@@ -72,6 +72,15 @@ impl<'a> From<PreconditionGoalDefinition<'a>> for PreconditionGoalDefinitions<'a
     }
 }
 
+impl<'a> From<Option<PreconditionGoalDefinition<'a>>> for PreconditionGoalDefinitions<'a> {
+    fn from(value: Option<PreconditionGoalDefinition<'a>>) -> Self {
+        match value {
+            None => PreconditionGoalDefinitions::default(),
+            Some(value) => value.into(),
+        }
+    }
+}
+
 impl<'a> From<Option<PreconditionGoalDefinitions<'a>>> for PreconditionGoalDefinitions<'a> {
     fn from(value: Option<PreconditionGoalDefinitions<'a>>) -> Self {
         match value {

--- a/src/types/pre_gd.rs
+++ b/src/types/pre_gd.rs
@@ -2,33 +2,118 @@
 
 use crate::types::TypedVariables;
 use crate::types::{Preference, PreferenceGD};
+use std::ops::Deref;
+
+/// Zero, one or many precondition goal definitions.
+///
+/// ## Usage
+/// Used by [`GoalDef`](crate::GoalDef), as well as [`ActionDefinition`](crate::ActionDefinition).
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct PreconditionGoalDefinitions<'a>(Vec<PreconditionGoalDefinition<'a>>);
+
+impl<'a> PreconditionGoalDefinitions<'a> {
+    /// Constructs a new instance from the provided vector of values.
+    pub const fn new(values: Vec<PreconditionGoalDefinition<'a>>) -> Self {
+        Self(values)
+    }
+
+    /// Constructs a list containing a single [`PreconditionGoalDefinition::Preference`] variant.
+    pub fn new_preference(pref: PreferenceGD<'a>) -> Self {
+        PreconditionGoalDefinition::new_preference(pref).into()
+    }
+
+    /// Constructs a list containing a single [`PreconditionGoalDefinition::Forall`] variant.
+    pub fn new_forall(variables: TypedVariables<'a>, gd: PreconditionGoalDefinitions<'a>) -> Self {
+        PreconditionGoalDefinition::new_forall(variables, gd).into()
+    }
+
+    /// Returns `true` if the list contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns the number of elements in the list, also referred to
+    /// as its 'length'.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn iter(&'a self) -> std::slice::Iter<'a, PreconditionGoalDefinition<'a>> {
+        self.0.iter()
+    }
+}
+
+impl<'a> FromIterator<PreconditionGoalDefinition<'a>> for PreconditionGoalDefinitions<'a> {
+    fn from_iter<T: IntoIterator<Item = PreconditionGoalDefinition<'a>>>(iter: T) -> Self {
+        PreconditionGoalDefinitions::new(iter.into_iter().collect())
+    }
+}
+
+impl<'a> Deref for PreconditionGoalDefinitions<'a> {
+    type Target = [PreconditionGoalDefinition<'a>];
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_slice()
+    }
+}
+
+impl<'a> IntoIterator for PreconditionGoalDefinitions<'a> {
+    type Item = PreconditionGoalDefinition<'a>;
+    type IntoIter = std::vec::IntoIter<PreconditionGoalDefinition<'a>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a> From<PreconditionGoalDefinition<'a>> for PreconditionGoalDefinitions<'a> {
+    fn from(value: PreconditionGoalDefinition<'a>) -> Self {
+        PreconditionGoalDefinitions::new(vec![value])
+    }
+}
+
+impl<'a> From<Option<PreconditionGoalDefinitions<'a>>> for PreconditionGoalDefinitions<'a> {
+    fn from(value: Option<PreconditionGoalDefinitions<'a>>) -> Self {
+        match value {
+            None => PreconditionGoalDefinitions::default(),
+            Some(values) => values,
+        }
+    }
+}
+
+impl<'a> From<PreconditionGoalDefinitions<'a>> for Vec<PreconditionGoalDefinition<'a>> {
+    fn from(value: PreconditionGoalDefinitions<'a>) -> Self {
+        value.0
+    }
+}
 
 /// A precondition goal definition.
 ///
 /// ## Usage
-/// Used by [`PreconditionGoalDefinition`] itself, as well as [`ActionDefinition`](crate::ActionDefinition).
+/// Used by [`PreconditionGoalDefinitions`].
 #[derive(Debug, Clone, PartialEq)]
 pub enum PreconditionGoalDefinition<'a> {
-    // TODO: Unify with base type; should always be a vector; count can be zero.
-    And(Vec<PreconditionGoalDefinition<'a>>),
     /// ## Requirements
     /// None per se: this branch may expand into [`PreferenceGD::Goal`](PreferenceGD::Goal),
     /// which has no requirements.
     Preference(PreferenceGD<'a>),
     /// ## Requirements
     /// Requires [Universal Preconditions](crate::Requirement::UniversalPreconditions).
-    Forall(TypedVariables<'a>, Box<PreconditionGoalDefinition<'a>>),
+    Forall(TypedVariables<'a>, PreconditionGoalDefinitions<'a>),
 }
 
 impl<'a> PreconditionGoalDefinition<'a> {
-    pub fn new_preference(pref: PreferenceGD<'a>) -> Self {
+    /// Constructs a new [`Preference`](Self::Preference) variant.
+    pub const fn new_preference(pref: PreferenceGD<'a>) -> Self {
         Self::Preference(pref)
     }
-    pub fn new_and<I: IntoIterator<Item = PreconditionGoalDefinition<'a>>>(prefs: I) -> Self {
-        Self::And(prefs.into_iter().collect())
-    }
-    pub fn new_forall(variables: TypedVariables<'a>, gd: PreconditionGoalDefinition<'a>) -> Self {
-        Self::Forall(variables, Box::new(gd))
+
+    /// Constructs a new [`Forall`](Self::Forall) variant.
+    pub const fn new_forall(
+        variables: TypedVariables<'a>,
+        gd: PreconditionGoalDefinitions<'a>,
+    ) -> Self {
+        Self::Forall(variables, gd)
     }
 }
 

--- a/src/types/problem.rs
+++ b/src/types/problem.rs
@@ -1,9 +1,10 @@
 //! Contains the [`Problem`] type.
 
 use crate::types::{
-    GoalDef, InitElements, LengthSpec, MetricSpec, Name, Objects, PreconditionGoalDefinition,
-    PrefConGD, ProblemConstraintsDef, Requirements,
+    GoalDef, InitElements, LengthSpec, MetricSpec, Name, Objects, PrefConGD, ProblemConstraintsDef,
+    Requirements,
 };
+use crate::PreconditionGoalDefinitions;
 
 /// A domain-specific problem declaration.
 ///
@@ -128,7 +129,7 @@ impl<'a> Problem<'a> {
     }
 
     /// Returns the goal statement of the problem.
-    pub const fn goal(&self) -> &PreconditionGoalDefinition<'a> {
+    pub const fn goal(&self) -> &PreconditionGoalDefinitions<'a> {
         &self.goal.value()
     }
 

--- a/tests/briefcase_world.rs
+++ b/tests/briefcase_world.rs
@@ -70,30 +70,31 @@ fn parse_problem_works() {
     assert_eq!(problem.domain(), &"briefcase-world".into());
     assert!(problem.requirements().is_empty());
     assert_eq!(problem.init().len(), 9);
-    assert!(matches! { problem.goal(), PreconditionGoalDefinition::And(_) });
+    assert_eq!(problem.goal().len(), 3);
 
-    match problem.goal() {
-        PreconditionGoalDefinition::Preference(pref) => match pref {
-            PreferenceGD::Goal(goal) => match goal {
-                GoalDefinition::AtomicFormula(af) => match af {
-                    AtomicFormula::Equality(_) => {}
-                    AtomicFormula::Predicate(_) => {}
+    for goal in problem.goal().iter() {
+        match goal {
+            PreconditionGoalDefinition::Preference(pref) => match pref {
+                PreferenceGD::Goal(goal) => match goal {
+                    GoalDefinition::AtomicFormula(af) => match af {
+                        AtomicFormula::Equality(_) => {}
+                        AtomicFormula::Predicate(_) => {}
+                    },
+                    GoalDefinition::Literal(literal) => match literal {
+                        TermLiteral::AtomicFormula(_) => {}
+                        TermLiteral::NotAtomicFormula(_) => {}
+                    },
+                    GoalDefinition::And(_) => {}
+                    GoalDefinition::Or(_) => {}
+                    GoalDefinition::Not(_) => {}
+                    GoalDefinition::Imply(_, _) => {}
+                    GoalDefinition::Exists(_, _) => {}
+                    GoalDefinition::ForAll(_, _) => {}
+                    GoalDefinition::FComp(_) => {}
                 },
-                GoalDefinition::Literal(literal) => match literal {
-                    TermLiteral::AtomicFormula(_) => {}
-                    TermLiteral::NotAtomicFormula(_) => {}
-                },
-                GoalDefinition::And(_) => {}
-                GoalDefinition::Or(_) => {}
-                GoalDefinition::Not(_) => {}
-                GoalDefinition::Imply(_, _) => {}
-                GoalDefinition::Exists(_, _) => {}
-                GoalDefinition::ForAll(_, _) => {}
-                GoalDefinition::FComp(_) => {}
+                PreferenceGD::Preference(_) => {}
             },
-            PreferenceGD::Preference(_) => {}
-        },
-        PreconditionGoalDefinition::And(_) => {}
-        PreconditionGoalDefinition::Forall(_, _) => {}
+            PreconditionGoalDefinition::Forall(_, _) => {}
+        }
     }
 }


### PR DESCRIPTION
This replaces the `PreconditionGoalDefinition::And` variant with the `PreconditionGoalDefinitions` type. 

While it makes things a little bit harder to read, it removes the need for an `Option<PreconditionGoalDefinition>` type. This could previously lead to confusing situations such as `Some(PreconditionGoalDefinition::And([]))` being the same as `None`.