### PR TITLE
Add concrete types for CEffect variant values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,15 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Added `TryInto<PreconditionGoalDefinition>` for `PreconditionGoalDefinitions` to get
   the only element of the list if it is a one-element list, or `None`.
+- `TryInto` implementations were added for `CEffect` to allow deconstruction into
+  `PEffect`, `ForallCEffect` and `WhenCEffect`.
 
 ### Changed
 
 - The `PrefConGD::And` variant was removed and replaced with the `PrefConGDs` type.
 - The `Effect::All` and `Effect::Single` variants were removed and the `Effect` type
   was changed to a struct wrapping a vector `Effects`.
+- The `CEffect` variants were changed to wrap `ForallCEffect` and `WhenCEffect` types.
 
 ## [0.0.4] - 2023-05-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   was changed to a struct wrapping a vector `Effects`.
 - The `CEffect` variants were changed to wrap `ForallCEffect` and `WhenCEffect` types.
 
+### Fixed
+
+- Fixed an issue where `(and ...)` conditional effects would be accidentally parsed
+  into an atomic formula with predicate `and`.
+
 ## [0.0.4] - 2023-05-04
 
 ### Added

--- a/src/parsers/assign_op.rs
+++ b/src/parsers/assign_op.rs
@@ -19,6 +19,7 @@ use nom::IResult;
 pub fn parse_assign_op(input: &str) -> IResult<&str, AssignOp> {
     map_res(
         alt((
+            tag(names::CHANGE), // deprecated
             tag(names::ASSIGN),
             tag(names::SCALE_UP),
             tag(names::SCALE_DOWN),

--- a/src/parsers/c_effect.rs
+++ b/src/parsers/c_effect.rs
@@ -3,6 +3,7 @@
 use crate::parsers::{parens, prefix_expr, typed_list};
 use crate::parsers::{parse_cond_effect, parse_effect, parse_gd, parse_p_effect, parse_variable};
 use crate::types::CEffect;
+use crate::{ForallCEffect, WhenCEffect};
 use nom::branch::alt;
 use nom::character::complete::multispace1;
 use nom::combinator::map;
@@ -14,7 +15,7 @@ use nom::IResult;
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_c_effect;
-/// # use pddl::{AtomicFormula, CEffect, Effects, EqualityAtomicFormula, PEffect, Term, Variable};
+/// # use pddl::{AtomicFormula, CEffect, ConditionalEffect, Effects, EqualityAtomicFormula, GoalDefinition, PEffect, Predicate, Term, Variable};
 /// # use pddl::{Typed, TypedList};
 /// assert_eq!(parse_c_effect("(= x y)"), Ok(("",
 ///     CEffect::Effect(
@@ -53,10 +54,78 @@ use nom::IResult;
 ///         ))
 ///     )
 /// )));
+///
+/// let input = r#"(when
+///     (and (has-hot-chocolate ?p ?c) (has-marshmallows ?c))
+///     (and (person-is-happy ?p)))"#;
+/// assert_eq!(parse_c_effect(input), Ok(("",
+///     CEffect::new_when(
+///         GoalDefinition::new_and([
+///             GoalDefinition::new_atomic_formula(
+///                 AtomicFormula::new_predicate(
+///                     Predicate::new("has-hot-chocolate".into()),
+///                     [
+///                         Term::Variable("p".into()),
+///                         Term::Variable("c".into())
+///                     ]
+///                 )
+///             ),
+///             GoalDefinition::new_atomic_formula(
+///                 AtomicFormula::new_predicate(
+///                     Predicate::new("has-marshmallows".into()),
+///                     [
+///                         Term::Variable("c".into())
+///                     ]
+///                 )
+///             ),
+///         ]),
+///         ConditionalEffect::from_iter([
+///             PEffect::new(
+///                 AtomicFormula::new_predicate(
+///                     Predicate::new("person-is-happy".into()),
+///                     [
+///                         Term::Variable("p".into())
+///                     ]
+///                 )
+///             )
+///         ])
+///     )
+/// )));
 /// ```
 pub fn parse_c_effect(input: &str) -> IResult<&str, CEffect> {
     let p_effect = map(parse_p_effect, CEffect::from);
-    let forall = map(
+    let forall = map(parse_forall_c_effect, CEffect::from);
+    let when = map(parse_when_c_effect, CEffect::from);
+
+    alt((forall, when, p_effect))(input)
+}
+
+/// Parser that parses [`ForallCEffect`] values.
+///
+/// ## Example
+/// ```
+/// # use pddl::parsers::parse_forall_c_effect;
+/// # use pddl::{AtomicFormula, CEffect, Effects, EqualityAtomicFormula, ForallCEffect, PEffect, Term, Variable};
+/// # use pddl::{Typed, TypedList};
+/// assert_eq!(parse_forall_c_effect("(forall (?a ?b) (= ?a ?b))"), Ok(("",
+///     ForallCEffect::new(
+///         TypedList::from_iter([
+///             Typed::new_object(Variable::from_str("a")),
+///             Typed::new_object(Variable::from_str("b")),
+///         ]),
+///         Effects::new(CEffect::Effect(
+///             PEffect::AtomicFormula(AtomicFormula::Equality(
+///                 EqualityAtomicFormula::new(
+///                     Term::Variable("a".into()),
+///                     Term::Variable("b".into()))
+///                 )
+///             )
+///         ))
+///     )
+/// )));
+/// ```
+pub fn parse_forall_c_effect(input: &str) -> IResult<&str, ForallCEffect> {
+    map(
         prefix_expr(
             "forall",
             tuple((
@@ -64,17 +133,63 @@ pub fn parse_c_effect(input: &str) -> IResult<&str, CEffect> {
                 preceded(multispace1, parse_effect),
             )),
         ),
-        CEffect::from,
-    );
-    let when = map(
+        ForallCEffect::from,
+    )(input)
+}
+
+/// Parser that parses c-effects.
+///
+/// ## Example
+/// ```
+/// # use pddl::parsers::parse_when_c_effect;
+/// # use pddl::{AtomicFormula, CEffect, ConditionalEffect, Effects, EqualityAtomicFormula, GoalDefinition, PEffect, Predicate, Term, Variable, WhenCEffect};
+/// # use pddl::{Typed, TypedList};
+/// let input = r#"(when
+///     (and (has-hot-chocolate ?p ?c) (has-marshmallows ?c))
+///     (and (person-is-happy ?p)))"#;
+///
+/// assert_eq!(parse_when_c_effect(input), Ok(("",
+///     WhenCEffect::new(
+///         GoalDefinition::new_and([
+///             GoalDefinition::new_atomic_formula(
+///                 AtomicFormula::new_predicate(
+///                     Predicate::new("has-hot-chocolate".into()),
+///                     [
+///                         Term::Variable("p".into()),
+///                         Term::Variable("c".into())
+///                     ]
+///                 )
+///             ),
+///             GoalDefinition::new_atomic_formula(
+///                 AtomicFormula::new_predicate(
+///                     Predicate::new("has-marshmallows".into()),
+///                     [
+///                         Term::Variable("c".into())
+///                     ]
+///                 )
+///             ),
+///         ]),
+///         ConditionalEffect::from_iter([
+///             PEffect::new(
+///                 AtomicFormula::new_predicate(
+///                     Predicate::new("person-is-happy".into()),
+///                     [
+///                         Term::Variable("p".into())
+///                     ]
+///                 )
+///             )
+///         ])
+///     )
+/// )));
+/// ```
+pub fn parse_when_c_effect(input: &str) -> IResult<&str, WhenCEffect> {
+    map(
         prefix_expr(
             "when",
             tuple((parse_gd, preceded(multispace1, parse_cond_effect))),
         ),
-        CEffect::from,
-    );
-
-    alt((forall, when, p_effect))(input)
+        WhenCEffect::from,
+    )(input)
 }
 
 impl<'a> crate::parsers::Parser<'a> for CEffect<'a> {
@@ -83,5 +198,23 @@ impl<'a> crate::parsers::Parser<'a> for CEffect<'a> {
     /// See [`parse_c_effect`].
     fn parse(input: &'a str) -> IResult<&str, Self::Item> {
         parse_c_effect(input)
+    }
+}
+
+impl<'a> crate::parsers::Parser<'a> for ForallCEffect<'a> {
+    type Item = ForallCEffect<'a>;
+
+    /// See [`parse_forall_c_effect`].
+    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+        parse_forall_c_effect(input)
+    }
+}
+
+impl<'a> crate::parsers::Parser<'a> for WhenCEffect<'a> {
+    type Item = WhenCEffect<'a>;
+
+    /// See [`parse_when_c_effect`].
+    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+        parse_when_c_effect(input)
     }
 }

--- a/src/parsers/cond_effect.rs
+++ b/src/parsers/cond_effect.rs
@@ -48,7 +48,7 @@ pub fn parse_cond_effect(input: &str) -> IResult<&str, ConditionalEffect> {
         ConditionalEffect::from,
     );
 
-    alt((exactly, all))(input)
+    alt((all, exactly))(input)
 }
 
 impl<'a> crate::parsers::Parser<'a> for ConditionalEffect<'a> {

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -94,7 +94,7 @@ pub use atomic_function_skeleton::parse_atomic_function_skeleton;
 pub use basic_function_term::parse_basic_function_term;
 pub use binary_comp::parse_binary_comp;
 pub use binary_op::parse_binary_op;
-pub use c_effect::parse_c_effect;
+pub use c_effect::{parse_c_effect, parse_forall_c_effect, parse_when_c_effect};
 pub use con_gd::parse_con_gd;
 pub use cond_effect::parse_cond_effect;
 pub use constants_def::parse_constants_def;

--- a/src/types/assign_op.rs
+++ b/src/types/assign_op.rs
@@ -21,6 +21,8 @@ pub enum AssignOp {
     /// ```
     Assign,
     /// A scale up effect increases the value of the numeric variable by the given scale factor.
+    /// This resembles the C-style operator `+=`.
+    ///
     /// ```pddl
     /// (scale-up (battery-level ?r) 2)
     /// ```
@@ -31,6 +33,8 @@ pub enum AssignOp {
     /// ```
     ScaleUp,
     /// A scale down effect decreases the value of the numeric variable by the given scale factor.
+    /// This resembles the C-style operator `-=`.
+    ///
     /// ```pddl
     /// (scale-down (battery-level ?r) 2)
     /// ```
@@ -41,6 +45,8 @@ pub enum AssignOp {
     /// ```
     ScaleDown,
     /// An increase effect increases the value of a numeric variable by the given amount.
+    /// This resembles the C-style operator `*=`.
+    ///
     /// ```pddl
     /// (increase (battery-level ?r) 10)
     /// ```
@@ -51,6 +57,8 @@ pub enum AssignOp {
     /// ```
     Increase,
     /// A decrease effect decreases the value of a numeric variable by the given amount.
+    /// This resembles the C-style operator `/=`.
+    ///
     /// ```pddl
     /// (decrease (battery-level ?r) 10)
     /// ```
@@ -63,6 +71,8 @@ pub enum AssignOp {
 }
 
 pub mod names {
+    /// [`CHANGE`] is a deprecated name for [`ASSIGN`].
+    pub const CHANGE: &'static str = "change";
     pub const ASSIGN: &'static str = "assign";
     pub const SCALE_UP: &'static str = "scale-up";
     pub const SCALE_DOWN: &'static str = "scale-down";
@@ -87,6 +97,7 @@ impl TryFrom<&str> for AssignOp {
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         match value {
+            names::CHANGE => Ok(AssignOp::Assign),
             names::ASSIGN => Ok(AssignOp::Assign),
             names::SCALE_UP => Ok(AssignOp::ScaleUp),
             names::SCALE_DOWN => Ok(AssignOp::ScaleDown),

--- a/src/types/c_effect.rs
+++ b/src/types/c_effect.rs
@@ -9,32 +9,98 @@ use crate::types::{ConditionalEffect, Effects, GoalDefinition, PEffect};
 /// Used by [`Effect`](Effects).
 #[derive(Debug, Clone, PartialEq)]
 pub enum CEffect<'a> {
+    /// A regular effect.
     Effect(PEffect<'a>),
+    /// A universal affect that is conditioned by variables.
+    ///
     /// ## Requirements
     /// Requires [Conditional Effects](crate::Requirement::ConditionalEffects).
-    Forall(TypedVariables<'a>, Box<Effects<'a>>),
+    Forall(ForallCEffect<'a>),
+    /// A conditional effect that applies only if a given
+    /// precondition holds true.
+    ///
     /// ## Requirements
     /// Requires [Conditional Effects](crate::Requirement::ConditionalEffects).
-    When(GoalDefinition<'a>, ConditionalEffect<'a>),
+    When(WhenCEffect<'a>),
+}
+
+/// Applies the specified effects for all listed variables.
+///
+/// ## Requirements
+/// Requires [Conditional Effects](crate::Requirement::ConditionalEffects).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ForallCEffect<'a> {
+    /// The (possibly empty) set of variables constraining the effects.
+    pub variables: TypedVariables<'a>,
+    /// The effects to apply.
+    pub effects: Effects<'a>,
+}
+
+impl<'a> ForallCEffect<'a> {
+    /// Creates a new [`ForallCEffect`] value.
+    pub const fn new(variables: TypedVariables<'a>, effects: Effects<'a>) -> Self {
+        ForallCEffect { variables, effects }
+    }
+}
+
+/// Applies the specified effects for all listed variables.
+///
+/// ## Requirements
+/// Requires [Conditional Effects](crate::Requirement::ConditionalEffects).
+#[derive(Debug, Clone, PartialEq)]
+pub struct WhenCEffect<'a> {
+    /// The antecedent. This needs to be true for the effect to apply.
+    pub condition: GoalDefinition<'a>,
+    /// The consequent. This is the effect that applies when the condition is true.
+    pub effect: ConditionalEffect<'a>,
+}
+
+impl<'a> WhenCEffect<'a> {
+    /// Creates a new [`WhenCEffect`] value.
+    pub const fn new(condition: GoalDefinition<'a>, effect: ConditionalEffect<'a>) -> Self {
+        WhenCEffect { condition, effect }
+    }
 }
 
 impl<'a> CEffect<'a> {
+    /// Crates a new effect.
     pub const fn new_p_effect(effect: PEffect<'a>) -> Self {
         Self::Effect(effect)
     }
 
-    pub fn new_forall(variables: TypedVariables<'a>, effect: Effects<'a>) -> Self {
-        Self::Forall(variables, Box::new(effect))
+    /// Creates a new universal effect that applies to all
+    /// the specified variables.
+    ///
+    /// ## Requirements
+    /// Requires [Conditional Effects](crate::Requirement::ConditionalEffects).
+    pub const fn new_forall(variables: TypedVariables<'a>, effect: Effects<'a>) -> Self {
+        Self::Forall(ForallCEffect::new(variables, effect))
     }
 
-    pub const fn new_when(gd: GoalDefinition<'a>, effect: ConditionalEffect<'a>) -> Self {
-        Self::When(gd, effect)
+    /// Creates a new conditional effect.
+    ///
+    /// ## Requirements
+    /// Requires [Conditional Effects](crate::Requirement::ConditionalEffects).
+    pub const fn new_when(condition: GoalDefinition<'a>, effect: ConditionalEffect<'a>) -> Self {
+        Self::When(WhenCEffect::new(condition, effect))
     }
 }
 
 impl<'a> From<PEffect<'a>> for CEffect<'a> {
     fn from(value: PEffect<'a>) -> Self {
         CEffect::new_p_effect(value)
+    }
+}
+
+impl<'a> From<ForallCEffect<'a>> for CEffect<'a> {
+    fn from(value: ForallCEffect<'a>) -> Self {
+        CEffect::Forall(value)
+    }
+}
+
+impl<'a> From<WhenCEffect<'a>> for CEffect<'a> {
+    fn from(value: WhenCEffect<'a>) -> Self {
+        CEffect::When(value)
     }
 }
 
@@ -47,5 +113,41 @@ impl<'a> From<(TypedVariables<'a>, Effects<'a>)> for CEffect<'a> {
 impl<'a> From<(GoalDefinition<'a>, ConditionalEffect<'a>)> for CEffect<'a> {
     fn from(value: (GoalDefinition<'a>, ConditionalEffect<'a>)) -> Self {
         CEffect::new_when(value.0, value.1)
+    }
+}
+
+impl<'a> TryInto<PEffect<'a>> for CEffect<'a> {
+    type Error = ();
+
+    fn try_into(self) -> Result<PEffect<'a>, Self::Error> {
+        match self {
+            CEffect::Effect(x) => Ok(x),
+            CEffect::Forall(_) => Err(()),
+            CEffect::When(_) => Err(()),
+        }
+    }
+}
+
+impl<'a> TryInto<WhenCEffect<'a>> for CEffect<'a> {
+    type Error = ();
+
+    fn try_into(self) -> Result<WhenCEffect<'a>, Self::Error> {
+        match self {
+            CEffect::Effect(_) => Err(()),
+            CEffect::Forall(_) => Err(()),
+            CEffect::When(x) => Ok(x),
+        }
+    }
+}
+
+impl<'a> TryInto<ForallCEffect<'a>> for CEffect<'a> {
+    type Error = ();
+
+    fn try_into(self) -> Result<ForallCEffect<'a>, Self::Error> {
+        match self {
+            CEffect::Effect(_) => Err(()),
+            CEffect::Forall(x) => Ok(x),
+            CEffect::When(_) => Err(()),
+        }
     }
 }

--- a/src/types/c_effect.rs
+++ b/src/types/c_effect.rs
@@ -104,15 +104,15 @@ impl<'a> From<WhenCEffect<'a>> for CEffect<'a> {
     }
 }
 
-impl<'a> From<(TypedVariables<'a>, Effects<'a>)> for CEffect<'a> {
+impl<'a> From<(TypedVariables<'a>, Effects<'a>)> for ForallCEffect<'a> {
     fn from(value: (TypedVariables<'a>, Effects<'a>)) -> Self {
-        CEffect::new_forall(value.0, value.1)
+        ForallCEffect::new(value.0, value.1)
     }
 }
 
-impl<'a> From<(GoalDefinition<'a>, ConditionalEffect<'a>)> for CEffect<'a> {
+impl<'a> From<(GoalDefinition<'a>, ConditionalEffect<'a>)> for WhenCEffect<'a> {
     fn from(value: (GoalDefinition<'a>, ConditionalEffect<'a>)) -> Self {
-        CEffect::new_when(value.0, value.1)
+        WhenCEffect::new(value.0, value.1)
     }
 }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -89,7 +89,7 @@ pub use atomic_function_skeleton::AtomicFunctionSkeleton;
 pub use basic_function_term::BasicFunctionTerm;
 pub use binary_comp::BinaryComp;
 pub use binary_op::BinaryOp;
-pub use c_effect::CEffect;
+pub use c_effect::{CEffect, ForallCEffect, WhenCEffect};
 pub use con_gd::{Con2GD, ConGD};
 pub use conditional_effect::ConditionalEffect;
 pub use constants::Constants;


### PR DESCRIPTION
This simplifies handling of `CEffect` values by introducing the `WhenCEffect` and `ForallCEffect` types. 

In addition, a bug in conditional effects parsing was fixed that would mistake the `(and ...)` combinator for an atomic formula with predicate `and`.