### PR TITLE
Use Located Spans and nom Greedy Errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - The parser now uses [nom-greedyerror](https://github.com/dalance/nom-greedyerror) and 
   [nom_locate](https://github.com/fflorent/nom_locate) to improve error handling.
 - The `Parser` trait now takes an `T: Into<Span<'a>>` argument.
+- All parser methods now take an `T: Into<Span<'a>>` argument.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the only element of the list if it is a one-element list, or `None`.
 - `TryInto` implementations were added for `CEffect` to allow deconstruction into
   `PEffect`, `ForallCEffect` and `WhenCEffect`.
+- Added the `Parser::from_str` method that performs a `Parse::parse` but discards
+  the remaining unparsed text.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - The `Effect::All` and `Effect::Single` variants were removed and the `Effect` type
   was changed to a struct wrapping a vector `Effects`.
 - The `CEffect` variants were changed to wrap `ForallCEffect` and `WhenCEffect` types.
+- The parser now uses [nom-greedyerror](https://github.com/dalance/nom-greedyerror) and 
+  [nom_locate](https://github.com/fflorent/nom_locate) to improve error handling.
+- The `Parser` trait now takes an `T: Into<Span<'a>>` argument.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,12 @@ rust-version = "1.68.0"
 
 [features]
 default = ["parser"]
-parser = ["dep:nom"]
+parser = ["dep:nom", "dep:nom-greedyerror", "dep:nom_locate"]
 
 [dependencies]
 nom = { version = "7.1.3", optional = true }
+nom-greedyerror = { version = "0.5.0", optional = true }
+nom_locate = { version = "4.1.0", optional = true }
 thiserror = "1.0.40"
 
 [package.metadata.docs.rs]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,8 +49,8 @@
 //!     )
 //!     "#;
 //!
-//! let (_, domain) = Domain::parse(BRIEFCASE_WORLD).unwrap();
-//! let (_, problem) = Problem::parse(BRIEFCASE_WORLD_PROBLEM).unwrap();
+//! let (_, domain) = Domain::parse(BRIEFCASE_WORLD.into()).unwrap();
+//! let (_, problem) = Problem::parse(BRIEFCASE_WORLD_PROBLEM.into()).unwrap();
 //!
 //! // All elements were parsed.
 //! assert_eq!(domain.name(), &"briefcase-world".into());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,8 +49,8 @@
 //!     )
 //!     "#;
 //!
-//! let (_, domain) = Domain::parse(BRIEFCASE_WORLD.into()).unwrap();
-//! let (_, problem) = Problem::parse(BRIEFCASE_WORLD_PROBLEM.into()).unwrap();
+//! let (_, domain) = Domain::parse(BRIEFCASE_WORLD).unwrap();
+//! let (_, problem) = Problem::parse(BRIEFCASE_WORLD_PROBLEM).unwrap();
 //!
 //! // All elements were parsed.
 //! assert_eq!(domain.name(), &"briefcase-world".into());

--- a/src/parsers/action_def.rs
+++ b/src/parsers/action_def.rs
@@ -51,7 +51,7 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 /// ```
-pub fn parse_action_def<'a>(input: Span<'a>) -> ParseResult<'a, ActionDefinition> {
+pub fn parse_action_def<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, ActionDefinition<'a>> {
     let precondition = preceded(
         tag(":precondition"),
         preceded(multispace1, empty_or(parse_pre_gd)),
@@ -81,7 +81,7 @@ pub fn parse_action_def<'a>(input: Span<'a>) -> ParseResult<'a, ActionDefinition
             preconditions.flatten().into(),
             effects.flatten(),
         )
-    })(input)
+    })(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for ActionDefinition<'a> {

--- a/src/parsers/action_def.rs
+++ b/src/parsers/action_def.rs
@@ -89,6 +89,6 @@ impl<'a> crate::parsers::Parser<'a> for ActionDefinition<'a> {
 
     /// See [`parse_action_def`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_action_def(input.into())
+        parse_action_def(input)
     }
 }

--- a/src/parsers/action_def.rs
+++ b/src/parsers/action_def.rs
@@ -1,29 +1,28 @@
 //! Provides parsers for action definitions.
 
-use crate::parsers::{empty_or, parens, prefix_expr, typed_list, ws};
+use crate::parsers::{empty_or, parens, prefix_expr, typed_list, ws, ParseResult, Span};
 use crate::parsers::{parse_action_symbol, parse_effect, parse_pre_gd, parse_variable};
 use crate::types::ActionDefinition;
 use nom::bytes::complete::tag;
 use nom::character::complete::multispace1;
 use nom::combinator::{map, opt};
 use nom::sequence::{preceded, tuple};
-use nom::IResult;
 
 /// Parses an action definition.
 ///
 /// ## Example
 /// ```
 /// # use pddl::{ActionDefinition, ActionSymbol, AtomicFormula, CEffect, Effects, GoalDefinition, Name, PEffect, Predicate, PreferenceGD, PreconditionGoalDefinitions, PreconditionGoalDefinition, Term, ToTyped, TypedList, Variable};
-/// # use pddl::parsers::parse_action_def;
+/// # use pddl::parsers::{parse_action_def, Span, UnwrapValue};
 /// let input = r#"(:action take-out
 ///                     :parameters (?x - physob)
 ///                     :precondition (not (= ?x B))
 ///                     :effect (not (in ?x))
 ///                 )"#;
 ///
-/// let action = parse_action_def(input);
+/// let action = parse_action_def(Span::new(input));
 ///
-/// assert_eq!(action, Ok(("",
+/// assert!(action.is_value(
 ///     ActionDefinition::new(
 ///         ActionSymbol::from_str("take-out"),
 ///         TypedList::from_iter([
@@ -50,9 +49,9 @@ use nom::IResult;
 ///             )
 ///         )))
 ///     )
-/// )));
+/// ));
 /// ```
-pub fn parse_action_def(input: &str) -> IResult<&str, ActionDefinition> {
+pub fn parse_action_def<'a>(input: Span<'a>) -> ParseResult<'a, ActionDefinition> {
     let precondition = preceded(
         tag(":precondition"),
         preceded(multispace1, empty_or(parse_pre_gd)),
@@ -89,7 +88,7 @@ impl<'a> crate::parsers::Parser<'a> for ActionDefinition<'a> {
     type Item = ActionDefinition<'a>;
 
     /// See [`parse_action_def`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_action_def(input)
     }
 }

--- a/src/parsers/action_def.rs
+++ b/src/parsers/action_def.rs
@@ -88,7 +88,7 @@ impl<'a> crate::parsers::Parser<'a> for ActionDefinition<'a> {
     type Item = ActionDefinition<'a>;
 
     /// See [`parse_action_def`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_action_def(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_action_def(input.into())
     }
 }

--- a/src/parsers/action_def.rs
+++ b/src/parsers/action_def.rs
@@ -51,7 +51,7 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 /// ```
-pub fn parse_action_def<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, ActionDefinition<'a>> {
+pub fn parse_action_def<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, ActionDefinition> {
     let precondition = preceded(
         tag(":precondition"),
         preceded(multispace1, empty_or(parse_pre_gd)),
@@ -84,11 +84,11 @@ pub fn parse_action_def<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Acti
     })(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for ActionDefinition<'a> {
-    type Item = ActionDefinition<'a>;
+impl crate::parsers::Parser for ActionDefinition {
+    type Item = ActionDefinition;
 
     /// See [`parse_action_def`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_action_def(input)
     }
 }

--- a/src/parsers/action_symbol.rs
+++ b/src/parsers/action_symbol.rs
@@ -20,15 +20,15 @@ use nom::combinator::map;
 /// assert!(parse_action_symbol(Span::new("0124")).is_err());
 /// assert!(parse_action_symbol(Span::new("-1")).is_err());
 ///```
-pub fn parse_action_symbol<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, ActionSymbol<'a>> {
+pub fn parse_action_symbol<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, ActionSymbol> {
     map(parse_name, ActionSymbol::new)(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for ActionSymbol<'a> {
-    type Item = ActionSymbol<'a>;
+impl crate::parsers::Parser for ActionSymbol {
+    type Item = ActionSymbol;
 
     /// See [`parse_action_symbol`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_action_symbol(input)
     }
 }

--- a/src/parsers/action_symbol.rs
+++ b/src/parsers/action_symbol.rs
@@ -29,6 +29,6 @@ impl<'a> crate::parsers::Parser<'a> for ActionSymbol<'a> {
 
     /// See [`parse_action_symbol`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_action_symbol(input.into())
+        parse_action_symbol(input)
     }
 }

--- a/src/parsers/action_symbol.rs
+++ b/src/parsers/action_symbol.rs
@@ -1,35 +1,34 @@
 //! Provides parsers for action symbols.
 
-use crate::parsers::parse_name;
+use crate::parsers::{parse_name, ParseResult, Span};
 use crate::types::ActionSymbol;
-use nom::IResult;
+use nom::combinator::map;
 
 /// Parses a function symbol, i.e. `<name>`.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_action_symbol;
-/// assert_eq!(parse_action_symbol("abcde"), Ok(("", "abcde".into())));
-/// assert_eq!(parse_action_symbol("a-1_2"), Ok(("", "a-1_2".into())));
-/// assert_eq!(parse_action_symbol("Z01"), Ok(("", "Z01".into())));
-/// assert_eq!(parse_action_symbol("x-_-_"), Ok(("", "x-_-_".into())));
+/// # use pddl::parsers::{parse_action_symbol, Span, UnwrapValue};
+/// assert!(parse_action_symbol(Span::new("abcde")).is_value("abcde".into()));
+/// assert!(parse_action_symbol(Span::new("a-1_2")).is_value("a-1_2".into()));
+/// assert!(parse_action_symbol(Span::new("Z01")).is_value("Z01".into()));
+/// assert!(parse_action_symbol(Span::new("x-_-_")).is_value("x-_-_".into()));
 ///
-/// assert!(parse_action_symbol("").is_err());
-/// assert!(parse_action_symbol(".").is_err());
-/// assert!(parse_action_symbol("-abc").is_err());
-/// assert!(parse_action_symbol("0124").is_err());
-/// assert!(parse_action_symbol("-1").is_err());
+/// assert!(parse_action_symbol(Span::new("")).is_err());
+/// assert!(parse_action_symbol(Span::new(".")).is_err());
+/// assert!(parse_action_symbol(Span::new("-abc")).is_err());
+/// assert!(parse_action_symbol(Span::new("0124")).is_err());
+/// assert!(parse_action_symbol(Span::new("-1")).is_err());
 ///```
-pub fn parse_action_symbol(input: &str) -> IResult<&str, ActionSymbol> {
-    let (remaining, name) = parse_name(input)?;
-    Ok((remaining, name.into()))
+pub fn parse_action_symbol<'a>(input: Span<'a>) -> ParseResult<'a, ActionSymbol> {
+    map(parse_name, ActionSymbol::new)(input)
 }
 
 impl<'a> crate::parsers::Parser<'a> for ActionSymbol<'a> {
     type Item = ActionSymbol<'a>;
 
     /// See [`parse_action_symbol`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_action_symbol(input)
     }
 }

--- a/src/parsers/action_symbol.rs
+++ b/src/parsers/action_symbol.rs
@@ -20,8 +20,8 @@ use nom::combinator::map;
 /// assert!(parse_action_symbol(Span::new("0124")).is_err());
 /// assert!(parse_action_symbol(Span::new("-1")).is_err());
 ///```
-pub fn parse_action_symbol<'a>(input: Span<'a>) -> ParseResult<'a, ActionSymbol> {
-    map(parse_name, ActionSymbol::new)(input)
+pub fn parse_action_symbol<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, ActionSymbol<'a>> {
+    map(parse_name, ActionSymbol::new)(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for ActionSymbol<'a> {

--- a/src/parsers/action_symbol.rs
+++ b/src/parsers/action_symbol.rs
@@ -28,7 +28,7 @@ impl<'a> crate::parsers::Parser<'a> for ActionSymbol<'a> {
     type Item = ActionSymbol<'a>;
 
     /// See [`parse_action_symbol`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_action_symbol(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_action_symbol(input.into())
     }
 }

--- a/src/parsers/assign_op.rs
+++ b/src/parsers/assign_op.rs
@@ -30,11 +30,11 @@ pub fn parse_assign_op<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Assig
     )(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for AssignOp {
+impl crate::parsers::Parser for AssignOp {
     type Item = AssignOp;
 
     /// See [`parse_assign_op`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_assign_op(input)
     }
 }

--- a/src/parsers/assign_op.rs
+++ b/src/parsers/assign_op.rs
@@ -16,7 +16,7 @@ use nom::combinator::map;
 /// assert!(parse_assign_op(Span::new("assign")).is_value(AssignOp::Assign));
 /// assert!(parse_assign_op(Span::new("scale-up")).is_value(AssignOp::ScaleUp));
 ///```
-pub fn parse_assign_op(input: Span) -> ParseResult<AssignOp> {
+pub fn parse_assign_op<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, AssignOp> {
     map(
         alt((
             tag(names::CHANGE), // deprecated
@@ -27,7 +27,7 @@ pub fn parse_assign_op(input: Span) -> ParseResult<AssignOp> {
             tag(names::DECREASE),
         )),
         |x: Span| AssignOp::try_from(*x.fragment()).expect("unhandled variant"),
-    )(input)
+    )(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for AssignOp {

--- a/src/parsers/assign_op.rs
+++ b/src/parsers/assign_op.rs
@@ -34,7 +34,7 @@ impl<'a> crate::parsers::Parser<'a> for AssignOp {
     type Item = AssignOp;
 
     /// See [`parse_assign_op`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_assign_op(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_assign_op(input.into())
     }
 }

--- a/src/parsers/assign_op.rs
+++ b/src/parsers/assign_op.rs
@@ -35,6 +35,6 @@ impl<'a> crate::parsers::Parser<'a> for AssignOp {
 
     /// See [`parse_assign_op`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_assign_op(input.into())
+        parse_assign_op(input)
     }
 }

--- a/src/parsers/assign_op_t.rs
+++ b/src/parsers/assign_op_t.rs
@@ -16,11 +16,11 @@ use nom::combinator::map;
 /// assert!(parse_assign_op_t(Span::new("increase")).is_value(AssignOpT::Increase));
 /// assert!(parse_assign_op_t(Span::new("decrease")).is_value(AssignOpT::Decrease));
 ///```
-pub fn parse_assign_op_t(input: Span) -> ParseResult<AssignOpT> {
+pub fn parse_assign_op_t<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, AssignOpT> {
     map(
         alt((tag(names::INCREASE), tag(names::DECREASE))),
         |x: Span| AssignOpT::try_from(*x.fragment()).expect("unhandled variant"),
-    )(input)
+    )(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for AssignOpT {

--- a/src/parsers/assign_op_t.rs
+++ b/src/parsers/assign_op_t.rs
@@ -28,6 +28,6 @@ impl<'a> crate::parsers::Parser<'a> for AssignOpT {
 
     /// See [`parse_assign_op_t`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_assign_op_t(input.into())
+        parse_assign_op_t(input)
     }
 }

--- a/src/parsers/assign_op_t.rs
+++ b/src/parsers/assign_op_t.rs
@@ -23,11 +23,11 @@ pub fn parse_assign_op_t<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Ass
     )(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for AssignOpT {
+impl crate::parsers::Parser for AssignOpT {
     type Item = AssignOpT;
 
     /// See [`parse_assign_op_t`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_assign_op_t(input)
     }
 }

--- a/src/parsers/assign_op_t.rs
+++ b/src/parsers/assign_op_t.rs
@@ -27,7 +27,7 @@ impl<'a> crate::parsers::Parser<'a> for AssignOpT {
     type Item = AssignOpT;
 
     /// See [`parse_assign_op_t`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_assign_op_t(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_assign_op_t(input.into())
     }
 }

--- a/src/parsers/assign_op_t.rs
+++ b/src/parsers/assign_op_t.rs
@@ -1,25 +1,25 @@
 //! Provides parsers for assignment operations.
 
+use crate::parsers::{ParseResult, Span};
 use crate::types::assign_op_t::names;
 use crate::types::AssignOpT;
 use nom::branch::alt;
 use nom::bytes::complete::tag;
-use nom::combinator::map_res;
-use nom::IResult;
+use nom::combinator::map;
 
 /// Parses an assignment operation, i.e. `increase | decrease`.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_assign_op_t;
+/// # use pddl::parsers::{parse_assign_op_t, Span, UnwrapValue};
 /// # use pddl::{AssignOpT};
-/// assert_eq!(parse_assign_op_t("increase"), Ok(("", AssignOpT::Increase)));
-/// assert_eq!(parse_assign_op_t("decrease"), Ok(("", AssignOpT::Decrease)));
+/// assert!(parse_assign_op_t(Span::new("increase")).is_value(AssignOpT::Increase));
+/// assert!(parse_assign_op_t(Span::new("decrease")).is_value(AssignOpT::Decrease));
 ///```
-pub fn parse_assign_op_t(input: &str) -> IResult<&str, AssignOpT> {
-    map_res(
+pub fn parse_assign_op_t(input: Span) -> ParseResult<AssignOpT> {
+    map(
         alt((tag(names::INCREASE), tag(names::DECREASE))),
-        AssignOpT::try_from,
+        |x: Span| AssignOpT::try_from(*x.fragment()).expect("unhandled variant"),
     )(input)
 }
 
@@ -27,7 +27,7 @@ impl<'a> crate::parsers::Parser<'a> for AssignOpT {
     type Item = AssignOpT;
 
     /// See [`parse_assign_op_t`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_assign_op_t(input)
     }
 }

--- a/src/parsers/atomic_formula.rs
+++ b/src/parsers/atomic_formula.rs
@@ -1,35 +1,33 @@
 //! Provides parsers for atomic formulae.
 
-use crate::parsers::parse_predicate;
 use crate::parsers::{parens, space_separated_list0, ws};
+use crate::parsers::{parse_predicate, ParseResult, Span};
 use crate::types::AtomicFormula;
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::character::complete::{char, multispace1};
 use nom::combinator::map;
 use nom::sequence::{delimited, preceded, tuple};
-use nom::IResult;
 
 /// Parses an atomic formula, i.e. `(<predicate> t*) | (= t t)`.
 ///
 /// ## Example
 /// ```
 /// # use nom::character::complete::alpha1;
-/// # use pddl::parsers::atomic_formula;
-/// # use pddl::parsers::parse_name;
+/// # use pddl::parsers::{atomic_formula, Span, parse_name, UnwrapValue};
 /// # use pddl::{AtomicFormula, EqualityAtomicFormula, PredicateAtomicFormula, Predicate};
-/// assert_eq!(atomic_formula(parse_name)("(= x y)"), Ok(("",
+/// assert!(atomic_formula(parse_name)(Span::new("(= x y)")).is_value(
 ///     AtomicFormula::Equality(EqualityAtomicFormula::new("x".into(), "y".into()))
-/// )));
-/// assert_eq!(atomic_formula(parse_name)("(move a b)"), Ok(("",
+/// ));
+/// assert!(atomic_formula(parse_name)(Span::new("(move a b)")).is_value(
 ///     AtomicFormula::Predicate(PredicateAtomicFormula::new(Predicate::from("move"), vec!["a".into(), "b".into()]))
-/// )));
+/// ));
 /// ```
 pub fn atomic_formula<'a, F, O>(
     inner: F,
-) -> impl FnMut(&'a str) -> IResult<&'a str, AtomicFormula<O>>
+) -> impl FnMut(Span<'a>) -> ParseResult<'a, AtomicFormula<O>>
 where
-    F: Clone + FnMut(&'a str) -> IResult<&'a str, O>,
+    F: Clone + FnMut(Span<'a>) -> ParseResult<'a, O>,
 {
     let equality = map(
         delimited(
@@ -59,6 +57,6 @@ mod tests {
     #[test]
     fn it_works() {
         let input = "(can-move ?from-waypoint ?to-waypoint)";
-        let (_, _effect) = atomic_formula(parse_term)(input).unwrap();
+        let (_, _effect) = atomic_formula(parse_term)(Span::new(input)).unwrap();
     }
 }

--- a/src/parsers/atomic_formula_skeleton.rs
+++ b/src/parsers/atomic_formula_skeleton.rs
@@ -33,7 +33,7 @@ impl<'a> crate::parsers::Parser<'a> for AtomicFormulaSkeleton<'a> {
     type Item = AtomicFormulaSkeleton<'a>;
 
     /// See [`parse_atomic_formula_skeleton`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_atomic_formula_skeleton(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_atomic_formula_skeleton(input.into())
     }
 }

--- a/src/parsers/atomic_formula_skeleton.rs
+++ b/src/parsers/atomic_formula_skeleton.rs
@@ -1,29 +1,28 @@
 //! Provides parsers for atomic formula skeletons.
 
-use crate::parsers::{parens, typed_list, ws};
+use crate::parsers::{parens, typed_list, ws, ParseResult, Span};
 use crate::parsers::{parse_predicate, parse_variable};
 use crate::types::AtomicFormulaSkeleton;
 use nom::combinator::map;
 use nom::sequence::tuple;
-use nom::IResult;
 
 /// Parser that parses an atomic formula skeleton, i.e. `(<predicate> <typed list (variable)>)`.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_atomic_formula_skeleton;
+/// # use pddl::parsers::{parse_atomic_formula_skeleton, Span, UnwrapValue};
 /// # use pddl::{Variable, AtomicFormulaSkeleton, Predicate};
 /// # use pddl::{ToTyped, TypedList};
-/// assert_eq!(parse_atomic_formula_skeleton("(at ?x - physob ?y - location)"), Ok(("",
+/// assert!(parse_atomic_formula_skeleton(Span::new("(at ?x - physob ?y - location)")).is_value(
 ///     AtomicFormulaSkeleton::new(
 ///         Predicate::from("at"),
 ///         TypedList::from_iter([
 ///             Variable::from("x").to_typed("physob"),
 ///             Variable::from("y").to_typed("location")
 ///         ]))
-/// )));
+/// ));
 /// ```
-pub fn parse_atomic_formula_skeleton(input: &str) -> IResult<&str, AtomicFormulaSkeleton> {
+pub fn parse_atomic_formula_skeleton(input: Span) -> ParseResult<AtomicFormulaSkeleton> {
     map(
         parens(tuple((parse_predicate, ws(typed_list(parse_variable))))),
         |tuple| AtomicFormulaSkeleton::from(tuple),
@@ -34,7 +33,7 @@ impl<'a> crate::parsers::Parser<'a> for AtomicFormulaSkeleton<'a> {
     type Item = AtomicFormulaSkeleton<'a>;
 
     /// See [`parse_atomic_formula_skeleton`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_atomic_formula_skeleton(input)
     }
 }

--- a/src/parsers/atomic_formula_skeleton.rs
+++ b/src/parsers/atomic_formula_skeleton.rs
@@ -36,6 +36,6 @@ impl<'a> crate::parsers::Parser<'a> for AtomicFormulaSkeleton<'a> {
 
     /// See [`parse_atomic_formula_skeleton`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_atomic_formula_skeleton(input.into())
+        parse_atomic_formula_skeleton(input)
     }
 }

--- a/src/parsers/atomic_formula_skeleton.rs
+++ b/src/parsers/atomic_formula_skeleton.rs
@@ -22,11 +22,13 @@ use nom::sequence::tuple;
 ///         ]))
 /// ));
 /// ```
-pub fn parse_atomic_formula_skeleton(input: Span) -> ParseResult<AtomicFormulaSkeleton> {
+pub fn parse_atomic_formula_skeleton<'a, T: Into<Span<'a>>>(
+    input: T,
+) -> ParseResult<'a, AtomicFormulaSkeleton<'a>> {
     map(
         parens(tuple((parse_predicate, ws(typed_list(parse_variable))))),
         |tuple| AtomicFormulaSkeleton::from(tuple),
-    )(input)
+    )(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for AtomicFormulaSkeleton<'a> {

--- a/src/parsers/atomic_formula_skeleton.rs
+++ b/src/parsers/atomic_formula_skeleton.rs
@@ -24,18 +24,18 @@ use nom::sequence::tuple;
 /// ```
 pub fn parse_atomic_formula_skeleton<'a, T: Into<Span<'a>>>(
     input: T,
-) -> ParseResult<'a, AtomicFormulaSkeleton<'a>> {
+) -> ParseResult<'a, AtomicFormulaSkeleton> {
     map(
         parens(tuple((parse_predicate, ws(typed_list(parse_variable))))),
         |tuple| AtomicFormulaSkeleton::from(tuple),
     )(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for AtomicFormulaSkeleton<'a> {
-    type Item = AtomicFormulaSkeleton<'a>;
+impl crate::parsers::Parser for AtomicFormulaSkeleton {
+    type Item = AtomicFormulaSkeleton;
 
     /// See [`parse_atomic_formula_skeleton`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_atomic_formula_skeleton(input)
     }
 }

--- a/src/parsers/atomic_function_skeleton.rs
+++ b/src/parsers/atomic_function_skeleton.rs
@@ -23,7 +23,7 @@ use nom::sequence::tuple;
 /// ```
 pub fn parse_atomic_function_skeleton<'a, T: Into<Span<'a>>>(
     input: T,
-) -> ParseResult<'a, AtomicFunctionSkeleton<'a>> {
+) -> ParseResult<'a, AtomicFunctionSkeleton> {
     map(
         parens(tuple((
             parse_function_symbol,
@@ -33,11 +33,11 @@ pub fn parse_atomic_function_skeleton<'a, T: Into<Span<'a>>>(
     )(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for AtomicFunctionSkeleton<'a> {
-    type Item = AtomicFunctionSkeleton<'a>;
+impl crate::parsers::Parser for AtomicFunctionSkeleton {
+    type Item = AtomicFunctionSkeleton;
 
     /// See [`parse_atomic_function_skeleton`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_atomic_function_skeleton(input)
     }
 }

--- a/src/parsers/atomic_function_skeleton.rs
+++ b/src/parsers/atomic_function_skeleton.rs
@@ -1,28 +1,27 @@
 //! Provides parsers for atomic function skeletons.
 
-use crate::parsers::{parens, typed_list, ws};
+use crate::parsers::{parens, typed_list, ws, ParseResult, Span};
 use crate::parsers::{parse_function_symbol, parse_variable};
 use crate::types::AtomicFunctionSkeleton;
 use nom::combinator::map;
 use nom::sequence::tuple;
-use nom::IResult;
 
 /// Parser that parses an atomic function skeleton, i.e. `(<function-symbol> <typed list (variable)>)`.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_atomic_function_skeleton;
+/// # use pddl::parsers::{parse_atomic_function_skeleton, Span, UnwrapValue};
 /// # use pddl::{Variable, AtomicFunctionSkeleton, Predicate, FunctionSymbol};
 /// # use pddl::{ToTyped, TypedList};
-/// assert_eq!(parse_atomic_function_skeleton("(battery-amount ?r - rover)"), Ok(("",
+/// assert!(parse_atomic_function_skeleton(Span::new("(battery-amount ?r - rover)")).is_value(
 ///     AtomicFunctionSkeleton::new(
 ///         FunctionSymbol::from("battery-amount"),
 ///         TypedList::from_iter([
 ///             Variable::from("r").to_typed("rover")
 ///         ]))
-/// )));
+/// ));
 /// ```
-pub fn parse_atomic_function_skeleton(input: &str) -> IResult<&str, AtomicFunctionSkeleton> {
+pub fn parse_atomic_function_skeleton(input: Span) -> ParseResult<AtomicFunctionSkeleton> {
     map(
         parens(tuple((
             parse_function_symbol,
@@ -36,7 +35,7 @@ impl<'a> crate::parsers::Parser<'a> for AtomicFunctionSkeleton<'a> {
     type Item = AtomicFunctionSkeleton<'a>;
 
     /// See [`parse_atomic_function_skeleton`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_atomic_function_skeleton(input)
     }
 }

--- a/src/parsers/atomic_function_skeleton.rs
+++ b/src/parsers/atomic_function_skeleton.rs
@@ -35,7 +35,7 @@ impl<'a> crate::parsers::Parser<'a> for AtomicFunctionSkeleton<'a> {
     type Item = AtomicFunctionSkeleton<'a>;
 
     /// See [`parse_atomic_function_skeleton`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_atomic_function_skeleton(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_atomic_function_skeleton(input.into())
     }
 }

--- a/src/parsers/atomic_function_skeleton.rs
+++ b/src/parsers/atomic_function_skeleton.rs
@@ -21,14 +21,16 @@ use nom::sequence::tuple;
 ///         ]))
 /// ));
 /// ```
-pub fn parse_atomic_function_skeleton(input: Span) -> ParseResult<AtomicFunctionSkeleton> {
+pub fn parse_atomic_function_skeleton<'a, T: Into<Span<'a>>>(
+    input: T,
+) -> ParseResult<'a, AtomicFunctionSkeleton<'a>> {
     map(
         parens(tuple((
             parse_function_symbol,
             ws(typed_list(parse_variable)),
         ))),
         |tuple| AtomicFunctionSkeleton::from(tuple),
-    )(input)
+    )(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for AtomicFunctionSkeleton<'a> {

--- a/src/parsers/atomic_function_skeleton.rs
+++ b/src/parsers/atomic_function_skeleton.rs
@@ -38,6 +38,6 @@ impl<'a> crate::parsers::Parser<'a> for AtomicFunctionSkeleton<'a> {
 
     /// See [`parse_atomic_function_skeleton`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_atomic_function_skeleton(input.into())
+        parse_atomic_function_skeleton(input)
     }
 }

--- a/src/parsers/basic_function_term.rs
+++ b/src/parsers/basic_function_term.rs
@@ -42,7 +42,7 @@ impl<'a> crate::parsers::Parser<'a> for BasicFunctionTerm<'a> {
     type Item = BasicFunctionTerm<'a>;
 
     /// See [`parse_basic_function_term`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_basic_function_term(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_basic_function_term(input.into())
     }
 }

--- a/src/parsers/basic_function_term.rs
+++ b/src/parsers/basic_function_term.rs
@@ -26,7 +26,9 @@ use nom::sequence::tuple;
 ///     BasicFunctionTerm::new("abcde".into(), ["x".into(), "y".into(), "z".into()])
 /// ));
 ///```
-pub fn parse_basic_function_term(input: Span) -> ParseResult<BasicFunctionTerm> {
+pub fn parse_basic_function_term<'a, T: Into<Span<'a>>>(
+    input: T,
+) -> ParseResult<'a, BasicFunctionTerm<'a>> {
     let direct = map(parse_function_symbol, |s| BasicFunctionTerm::new(s, []));
     let named = map(
         parens(tuple((
@@ -35,7 +37,7 @@ pub fn parse_basic_function_term(input: Span) -> ParseResult<BasicFunctionTerm> 
         ))),
         |(s, ns)| BasicFunctionTerm::new(s, ns),
     );
-    alt((direct, named))(input)
+    alt((direct, named))(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for BasicFunctionTerm<'a> {

--- a/src/parsers/basic_function_term.rs
+++ b/src/parsers/basic_function_term.rs
@@ -28,7 +28,7 @@ use nom::sequence::tuple;
 ///```
 pub fn parse_basic_function_term<'a, T: Into<Span<'a>>>(
     input: T,
-) -> ParseResult<'a, BasicFunctionTerm<'a>> {
+) -> ParseResult<'a, BasicFunctionTerm> {
     let direct = map(parse_function_symbol, |s| BasicFunctionTerm::new(s, []));
     let named = map(
         parens(tuple((
@@ -40,11 +40,11 @@ pub fn parse_basic_function_term<'a, T: Into<Span<'a>>>(
     alt((direct, named))(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for BasicFunctionTerm<'a> {
-    type Item = BasicFunctionTerm<'a>;
+impl crate::parsers::Parser for BasicFunctionTerm {
+    type Item = BasicFunctionTerm;
 
     /// See [`parse_basic_function_term`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_basic_function_term(input)
     }
 }

--- a/src/parsers/basic_function_term.rs
+++ b/src/parsers/basic_function_term.rs
@@ -1,31 +1,32 @@
 //! Provides parsers for basic function terms.
 
-use crate::parsers::{parens, parse_function_symbol, parse_name, space_separated_list0, ws};
+use crate::parsers::{
+    parens, parse_function_symbol, parse_name, space_separated_list0, ws, ParseResult, Span,
+};
 use crate::types::BasicFunctionTerm;
 use nom::branch::alt;
 use nom::combinator::map;
 use nom::sequence::tuple;
-use nom::IResult;
 
 /// Parses a basic function term.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_basic_function_term;
+/// # use pddl::parsers::{parse_basic_function_term, UnwrapValue, Span};
 /// # use pddl::{BasicFunctionTerm, Term};
-/// assert_eq!(parse_basic_function_term("abcde"), Ok(("",
+/// assert!(parse_basic_function_term(Span::new("abcde")).is_value(
 ///     BasicFunctionTerm::new("abcde".into(), [])
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_basic_function_term("(abcde)"), Ok(("",
+/// assert!(parse_basic_function_term(Span::new("(abcde)")).is_value(
 ///     BasicFunctionTerm::new("abcde".into(), [])
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_basic_function_term("(abcde x y z)"), Ok(("",
+/// assert!(parse_basic_function_term(Span::new("(abcde x y z)")).is_value(
 ///     BasicFunctionTerm::new("abcde".into(), ["x".into(), "y".into(), "z".into()])
-/// )));
+/// ));
 ///```
-pub fn parse_basic_function_term(input: &str) -> IResult<&str, BasicFunctionTerm> {
+pub fn parse_basic_function_term(input: Span) -> ParseResult<BasicFunctionTerm> {
     let direct = map(parse_function_symbol, |s| BasicFunctionTerm::new(s, []));
     let named = map(
         parens(tuple((
@@ -41,7 +42,7 @@ impl<'a> crate::parsers::Parser<'a> for BasicFunctionTerm<'a> {
     type Item = BasicFunctionTerm<'a>;
 
     /// See [`parse_basic_function_term`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_basic_function_term(input)
     }
 }

--- a/src/parsers/basic_function_term.rs
+++ b/src/parsers/basic_function_term.rs
@@ -45,6 +45,6 @@ impl<'a> crate::parsers::Parser<'a> for BasicFunctionTerm<'a> {
 
     /// See [`parse_basic_function_term`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_basic_function_term(input.into())
+        parse_basic_function_term(input)
     }
 }

--- a/src/parsers/binary_comp.rs
+++ b/src/parsers/binary_comp.rs
@@ -18,7 +18,7 @@ use nom::combinator::map;
 /// assert!(parse_binary_comp(Span::new(">=")).is_value(BinaryComp::GreaterOrEqual));
 /// assert!(parse_binary_comp(Span::new("<=")).is_value(BinaryComp::LessThanOrEqual));
 ///```
-pub fn parse_binary_comp(input: Span) -> ParseResult<BinaryComp> {
+pub fn parse_binary_comp<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, BinaryComp> {
     map(
         alt((
             tag(names::GREATER_THAN_OR_EQUAL),
@@ -28,7 +28,7 @@ pub fn parse_binary_comp(input: Span) -> ParseResult<BinaryComp> {
             tag(names::LESS_THAN),
         )),
         |x: Span| BinaryComp::try_from(*x.fragment()).expect("unhandled variant"),
-    )(input)
+    )(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for BinaryComp {

--- a/src/parsers/binary_comp.rs
+++ b/src/parsers/binary_comp.rs
@@ -31,11 +31,11 @@ pub fn parse_binary_comp<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Bin
     )(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for BinaryComp {
+impl crate::parsers::Parser for BinaryComp {
     type Item = BinaryComp;
 
     /// See [`parse_binary_comp`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_binary_comp(input)
     }
 }

--- a/src/parsers/binary_comp.rs
+++ b/src/parsers/binary_comp.rs
@@ -1,25 +1,25 @@
 //! Provides parsers for binary comparison operations.
 
+use crate::parsers::{ParseResult, Span};
 use crate::types::{binary_comp::names, BinaryComp};
 use nom::branch::alt;
 use nom::bytes::complete::tag;
-use nom::combinator::map_res;
-use nom::IResult;
+use nom::combinator::map;
 
 /// Parses an assignment operation, i.e. `assign | scale-up | scale-down | increase | decrease`.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_binary_comp;
+/// # use pddl::parsers::{parse_binary_comp, Span, UnwrapValue};
 /// # use pddl::{AssignOp, BinaryComp};
-/// assert_eq!(parse_binary_comp(">"), Ok(("", BinaryComp::GreaterThan)));
-/// assert_eq!(parse_binary_comp("<"), Ok(("", BinaryComp::LessThan)));
-/// assert_eq!(parse_binary_comp("="), Ok(("", BinaryComp::Equal)));
-/// assert_eq!(parse_binary_comp(">="), Ok(("", BinaryComp::GreaterOrEqual)));
-/// assert_eq!(parse_binary_comp("<="), Ok(("", BinaryComp::LessThanOrEqual)));
+/// assert!(parse_binary_comp(Span::new(">")).is_value(BinaryComp::GreaterThan));
+/// assert!(parse_binary_comp(Span::new("<")).is_value(BinaryComp::LessThan));
+/// assert!(parse_binary_comp(Span::new("=")).is_value(BinaryComp::Equal));
+/// assert!(parse_binary_comp(Span::new(">=")).is_value(BinaryComp::GreaterOrEqual));
+/// assert!(parse_binary_comp(Span::new("<=")).is_value(BinaryComp::LessThanOrEqual));
 ///```
-pub fn parse_binary_comp(input: &str) -> IResult<&str, BinaryComp> {
-    map_res(
+pub fn parse_binary_comp(input: Span) -> ParseResult<BinaryComp> {
+    map(
         alt((
             tag(names::GREATER_THAN_OR_EQUAL),
             tag(names::LESS_THAN_OR_EQUAL),
@@ -27,7 +27,7 @@ pub fn parse_binary_comp(input: &str) -> IResult<&str, BinaryComp> {
             tag(names::GREATER_THAN),
             tag(names::LESS_THAN),
         )),
-        BinaryComp::try_from,
+        |x: Span| BinaryComp::try_from(*x.fragment()).expect("unhandled variant"),
     )(input)
 }
 
@@ -35,7 +35,7 @@ impl<'a> crate::parsers::Parser<'a> for BinaryComp {
     type Item = BinaryComp;
 
     /// See [`parse_binary_comp`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_binary_comp(input)
     }
 }

--- a/src/parsers/binary_comp.rs
+++ b/src/parsers/binary_comp.rs
@@ -35,7 +35,7 @@ impl<'a> crate::parsers::Parser<'a> for BinaryComp {
     type Item = BinaryComp;
 
     /// See [`parse_binary_comp`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_binary_comp(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_binary_comp(input.into())
     }
 }

--- a/src/parsers/binary_comp.rs
+++ b/src/parsers/binary_comp.rs
@@ -36,6 +36,6 @@ impl<'a> crate::parsers::Parser<'a> for BinaryComp {
 
     /// See [`parse_binary_comp`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_binary_comp(input.into())
+        parse_binary_comp(input)
     }
 }

--- a/src/parsers/binary_op.rs
+++ b/src/parsers/binary_op.rs
@@ -29,11 +29,11 @@ pub fn parse_binary_op<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Binar
     )(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for BinaryOp {
+impl crate::parsers::Parser for BinaryOp {
     type Item = BinaryOp;
 
     /// See [`parse_binary_op`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_binary_op(input)
     }
 }

--- a/src/parsers/binary_op.rs
+++ b/src/parsers/binary_op.rs
@@ -17,7 +17,7 @@ use nom::combinator::map;
 /// assert!(parse_binary_op(Span::new("-")).is_value(BinaryOp::Subtraction));
 /// assert!(parse_binary_op(Span::new("/")).is_value(BinaryOp::Division));
 ///```
-pub fn parse_binary_op(input: Span) -> ParseResult<BinaryOp> {
+pub fn parse_binary_op<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, BinaryOp> {
     map(
         alt((
             tag(names::MULTIPLICATION),
@@ -26,7 +26,7 @@ pub fn parse_binary_op(input: Span) -> ParseResult<BinaryOp> {
             tag(names::DIVISION),
         )),
         |x: Span| BinaryOp::try_from(*x.fragment()).expect("unhandled variant"),
-    )(input)
+    )(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for BinaryOp {

--- a/src/parsers/binary_op.rs
+++ b/src/parsers/binary_op.rs
@@ -1,31 +1,31 @@
 //! Provides parsers for binary-operand operations.
 
+use crate::parsers::{ParseResult, Span};
 use crate::types::{binary_op::names, BinaryOp};
 use nom::branch::alt;
 use nom::bytes::complete::tag;
-use nom::combinator::map_res;
-use nom::IResult;
+use nom::combinator::map;
 
 /// Parses a multi-operand operation, i.e. `* | + | - | /`.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_binary_op;
+/// # use pddl::parsers::{parse_binary_op, Span, UnwrapValue};
 /// # use pddl::{BinaryOp};
-/// assert_eq!(parse_binary_op("*"), Ok(("", BinaryOp::Multiplication)));
-/// assert_eq!(parse_binary_op("+"), Ok(("", BinaryOp::Addition)));
-/// assert_eq!(parse_binary_op("-"), Ok(("", BinaryOp::Subtraction)));
-/// assert_eq!(parse_binary_op("/"), Ok(("", BinaryOp::Division)));
+/// assert!(parse_binary_op(Span::new("*")).is_value(BinaryOp::Multiplication));
+/// assert!(parse_binary_op(Span::new("+")).is_value(BinaryOp::Addition));
+/// assert!(parse_binary_op(Span::new("-")).is_value(BinaryOp::Subtraction));
+/// assert!(parse_binary_op(Span::new("/")).is_value(BinaryOp::Division));
 ///```
-pub fn parse_binary_op(input: &str) -> IResult<&str, BinaryOp> {
-    map_res(
+pub fn parse_binary_op(input: Span) -> ParseResult<BinaryOp> {
+    map(
         alt((
             tag(names::MULTIPLICATION),
             tag(names::ADDITION),
             tag(names::SUBTRACTION),
             tag(names::DIVISION),
         )),
-        BinaryOp::try_from,
+        |x: Span| BinaryOp::try_from(*x.fragment()).expect("unhandled variant"),
     )(input)
 }
 
@@ -33,7 +33,7 @@ impl<'a> crate::parsers::Parser<'a> for BinaryOp {
     type Item = BinaryOp;
 
     /// See [`parse_binary_op`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_binary_op(input)
     }
 }

--- a/src/parsers/binary_op.rs
+++ b/src/parsers/binary_op.rs
@@ -34,6 +34,6 @@ impl<'a> crate::parsers::Parser<'a> for BinaryOp {
 
     /// See [`parse_binary_op`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_binary_op(input.into())
+        parse_binary_op(input)
     }
 }

--- a/src/parsers/binary_op.rs
+++ b/src/parsers/binary_op.rs
@@ -33,7 +33,7 @@ impl<'a> crate::parsers::Parser<'a> for BinaryOp {
     type Item = BinaryOp;
 
     /// See [`parse_binary_op`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_binary_op(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_binary_op(input.into())
     }
 }

--- a/src/parsers/c_effect.rs
+++ b/src/parsers/c_effect.rs
@@ -91,7 +91,7 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 /// ```
-pub fn parse_c_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, CEffect<'a>> {
+pub fn parse_c_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, CEffect> {
     let p_effect = map(parse_p_effect, CEffect::from);
     let forall = map(parse_forall_c_effect, CEffect::from);
     let when = map(parse_when_c_effect, CEffect::from);
@@ -123,9 +123,7 @@ pub fn parse_c_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, CEffec
 ///     )
 /// ));
 /// ```
-pub fn parse_forall_c_effect<'a, T: Into<Span<'a>>>(
-    input: T,
-) -> ParseResult<'a, ForallCEffect<'a>> {
+pub fn parse_forall_c_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, ForallCEffect> {
     map(
         prefix_expr(
             "forall",
@@ -183,7 +181,7 @@ pub fn parse_forall_c_effect<'a, T: Into<Span<'a>>>(
 ///     )
 /// ));
 /// ```
-pub fn parse_when_c_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, WhenCEffect<'a>> {
+pub fn parse_when_c_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, WhenCEffect> {
     map(
         prefix_expr(
             "when",
@@ -193,29 +191,29 @@ pub fn parse_when_c_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, W
     )(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for CEffect<'a> {
-    type Item = CEffect<'a>;
+impl crate::parsers::Parser for CEffect {
+    type Item = CEffect;
 
     /// See [`parse_c_effect`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_c_effect(input.into())
     }
 }
 
-impl<'a> crate::parsers::Parser<'a> for ForallCEffect<'a> {
-    type Item = ForallCEffect<'a>;
+impl crate::parsers::Parser for ForallCEffect {
+    type Item = ForallCEffect;
 
     /// See [`parse_forall_c_effect`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_forall_c_effect(input)
     }
 }
 
-impl<'a> crate::parsers::Parser<'a> for WhenCEffect<'a> {
-    type Item = WhenCEffect<'a>;
+impl crate::parsers::Parser for WhenCEffect {
+    type Item = WhenCEffect;
 
     /// See [`parse_when_c_effect`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_when_c_effect(input)
     }
 }

--- a/src/parsers/c_effect.rs
+++ b/src/parsers/c_effect.rs
@@ -91,12 +91,12 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 /// ```
-pub fn parse_c_effect<'a>(input: Span<'a>) -> ParseResult<'a, CEffect> {
+pub fn parse_c_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, CEffect<'a>> {
     let p_effect = map(parse_p_effect, CEffect::from);
     let forall = map(parse_forall_c_effect, CEffect::from);
     let when = map(parse_when_c_effect, CEffect::from);
 
-    alt((forall, when, p_effect))(input)
+    alt((forall, when, p_effect))(input.into())
 }
 
 /// Parser that parses [`ForallCEffect`] values.

--- a/src/parsers/c_effect.rs
+++ b/src/parsers/c_effect.rs
@@ -195,8 +195,8 @@ impl<'a> crate::parsers::Parser<'a> for CEffect<'a> {
     type Item = CEffect<'a>;
 
     /// See [`parse_c_effect`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_c_effect(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_c_effect(input.into())
     }
 }
 
@@ -204,8 +204,8 @@ impl<'a> crate::parsers::Parser<'a> for ForallCEffect<'a> {
     type Item = ForallCEffect<'a>;
 
     /// See [`parse_forall_c_effect`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_forall_c_effect(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_forall_c_effect(input.into())
     }
 }
 
@@ -213,7 +213,7 @@ impl<'a> crate::parsers::Parser<'a> for WhenCEffect<'a> {
     type Item = WhenCEffect<'a>;
 
     /// See [`parse_when_c_effect`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_when_c_effect(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_when_c_effect(input.into())
     }
 }

--- a/src/parsers/c_effect.rs
+++ b/src/parsers/c_effect.rs
@@ -1,6 +1,6 @@
 //! Provides parsers for c-effects.
 
-use crate::parsers::{parens, prefix_expr, typed_list};
+use crate::parsers::{parens, prefix_expr, typed_list, ParseResult, Span};
 use crate::parsers::{parse_cond_effect, parse_effect, parse_gd, parse_p_effect, parse_variable};
 use crate::types::CEffect;
 use crate::{ForallCEffect, WhenCEffect};
@@ -8,16 +8,15 @@ use nom::branch::alt;
 use nom::character::complete::multispace1;
 use nom::combinator::map;
 use nom::sequence::{preceded, tuple};
-use nom::IResult;
 
 /// Parser that parses c-effects.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_c_effect;
+/// # use pddl::parsers::{parse_c_effect, Span, UnwrapValue};
 /// # use pddl::{AtomicFormula, CEffect, ConditionalEffect, Effects, EqualityAtomicFormula, GoalDefinition, PEffect, Predicate, Term, Variable};
 /// # use pddl::{Typed, TypedList};
-/// assert_eq!(parse_c_effect("(= x y)"), Ok(("",
+/// assert!(parse_c_effect(Span::new("(= x y)")).is_value(
 ///     CEffect::Effect(
 ///         PEffect::AtomicFormula(AtomicFormula::Equality(
 ///             EqualityAtomicFormula::new(
@@ -26,8 +25,8 @@ use nom::IResult;
 ///             )
 ///         )
 ///     )
-/// )));
-/// assert_eq!(parse_c_effect("(not (= ?a B))"), Ok(("",
+/// ));
+/// assert!(parse_c_effect(Span::new("(not (= ?a B))")).is_value(
 ///     CEffect::Effect(
 ///         PEffect::NotAtomicFormula(AtomicFormula::Equality(
 ///             EqualityAtomicFormula::new(
@@ -36,9 +35,9 @@ use nom::IResult;
 ///             )
 ///         )
 ///     )
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_c_effect("(forall (?a ?b) (= ?a ?b))"), Ok(("",
+/// assert!(parse_c_effect(Span::new("(forall (?a ?b) (= ?a ?b))")).is_value(
 ///     CEffect::new_forall(
 ///         TypedList::from_iter([
 ///             Typed::new_object(Variable::from_str("a")),
@@ -53,12 +52,12 @@ use nom::IResult;
 ///             )
 ///         ))
 ///     )
-/// )));
+/// ));
 ///
 /// let input = r#"(when
 ///     (and (has-hot-chocolate ?p ?c) (has-marshmallows ?c))
 ///     (and (person-is-happy ?p)))"#;
-/// assert_eq!(parse_c_effect(input), Ok(("",
+/// assert!(parse_c_effect(Span::new(input)).is_value(
 ///     CEffect::new_when(
 ///         GoalDefinition::new_and([
 ///             GoalDefinition::new_atomic_formula(
@@ -90,9 +89,9 @@ use nom::IResult;
 ///             )
 ///         ])
 ///     )
-/// )));
+/// ));
 /// ```
-pub fn parse_c_effect(input: &str) -> IResult<&str, CEffect> {
+pub fn parse_c_effect<'a>(input: Span<'a>) -> ParseResult<'a, CEffect> {
     let p_effect = map(parse_p_effect, CEffect::from);
     let forall = map(parse_forall_c_effect, CEffect::from);
     let when = map(parse_when_c_effect, CEffect::from);
@@ -104,10 +103,10 @@ pub fn parse_c_effect(input: &str) -> IResult<&str, CEffect> {
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_forall_c_effect;
+/// # use pddl::parsers::{parse_forall_c_effect, preamble::*};
 /// # use pddl::{AtomicFormula, CEffect, Effects, EqualityAtomicFormula, ForallCEffect, PEffect, Term, Variable};
 /// # use pddl::{Typed, TypedList};
-/// assert_eq!(parse_forall_c_effect("(forall (?a ?b) (= ?a ?b))"), Ok(("",
+/// assert!(parse_forall_c_effect(Span::new("(forall (?a ?b) (= ?a ?b))")).is_value(
 ///     ForallCEffect::new(
 ///         TypedList::from_iter([
 ///             Typed::new_object(Variable::from_str("a")),
@@ -122,9 +121,9 @@ pub fn parse_c_effect(input: &str) -> IResult<&str, CEffect> {
 ///             )
 ///         ))
 ///     )
-/// )));
+/// ));
 /// ```
-pub fn parse_forall_c_effect(input: &str) -> IResult<&str, ForallCEffect> {
+pub fn parse_forall_c_effect<'a>(input: Span<'a>) -> ParseResult<'a, ForallCEffect> {
     map(
         prefix_expr(
             "forall",
@@ -141,14 +140,14 @@ pub fn parse_forall_c_effect(input: &str) -> IResult<&str, ForallCEffect> {
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_when_c_effect;
+/// # use pddl::parsers::{parse_when_c_effect, preamble::*};
 /// # use pddl::{AtomicFormula, CEffect, ConditionalEffect, Effects, EqualityAtomicFormula, GoalDefinition, PEffect, Predicate, Term, Variable, WhenCEffect};
 /// # use pddl::{Typed, TypedList};
 /// let input = r#"(when
 ///     (and (has-hot-chocolate ?p ?c) (has-marshmallows ?c))
 ///     (and (person-is-happy ?p)))"#;
 ///
-/// assert_eq!(parse_when_c_effect(input), Ok(("",
+/// assert!(parse_when_c_effect(Span::new(input)).is_value(
 ///     WhenCEffect::new(
 ///         GoalDefinition::new_and([
 ///             GoalDefinition::new_atomic_formula(
@@ -180,9 +179,9 @@ pub fn parse_forall_c_effect(input: &str) -> IResult<&str, ForallCEffect> {
 ///             )
 ///         ])
 ///     )
-/// )));
+/// ));
 /// ```
-pub fn parse_when_c_effect(input: &str) -> IResult<&str, WhenCEffect> {
+pub fn parse_when_c_effect<'a>(input: Span<'a>) -> ParseResult<'a, WhenCEffect> {
     map(
         prefix_expr(
             "when",
@@ -196,7 +195,7 @@ impl<'a> crate::parsers::Parser<'a> for CEffect<'a> {
     type Item = CEffect<'a>;
 
     /// See [`parse_c_effect`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_c_effect(input)
     }
 }
@@ -205,7 +204,7 @@ impl<'a> crate::parsers::Parser<'a> for ForallCEffect<'a> {
     type Item = ForallCEffect<'a>;
 
     /// See [`parse_forall_c_effect`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_forall_c_effect(input)
     }
 }
@@ -214,7 +213,7 @@ impl<'a> crate::parsers::Parser<'a> for WhenCEffect<'a> {
     type Item = WhenCEffect<'a>;
 
     /// See [`parse_when_c_effect`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_when_c_effect(input)
     }
 }

--- a/src/parsers/c_effect.rs
+++ b/src/parsers/c_effect.rs
@@ -123,7 +123,9 @@ pub fn parse_c_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, CEffec
 ///     )
 /// ));
 /// ```
-pub fn parse_forall_c_effect<'a>(input: Span<'a>) -> ParseResult<'a, ForallCEffect> {
+pub fn parse_forall_c_effect<'a, T: Into<Span<'a>>>(
+    input: T,
+) -> ParseResult<'a, ForallCEffect<'a>> {
     map(
         prefix_expr(
             "forall",
@@ -133,7 +135,7 @@ pub fn parse_forall_c_effect<'a>(input: Span<'a>) -> ParseResult<'a, ForallCEffe
             )),
         ),
         ForallCEffect::from,
-    )(input)
+    )(input.into())
 }
 
 /// Parser that parses c-effects.
@@ -181,14 +183,14 @@ pub fn parse_forall_c_effect<'a>(input: Span<'a>) -> ParseResult<'a, ForallCEffe
 ///     )
 /// ));
 /// ```
-pub fn parse_when_c_effect<'a>(input: Span<'a>) -> ParseResult<'a, WhenCEffect> {
+pub fn parse_when_c_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, WhenCEffect<'a>> {
     map(
         prefix_expr(
             "when",
             tuple((parse_gd, preceded(multispace1, parse_cond_effect))),
         ),
         WhenCEffect::from,
-    )(input)
+    )(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for CEffect<'a> {
@@ -205,7 +207,7 @@ impl<'a> crate::parsers::Parser<'a> for ForallCEffect<'a> {
 
     /// See [`parse_forall_c_effect`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_forall_c_effect(input.into())
+        parse_forall_c_effect(input)
     }
 }
 
@@ -214,6 +216,6 @@ impl<'a> crate::parsers::Parser<'a> for WhenCEffect<'a> {
 
     /// See [`parse_when_c_effect`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_when_c_effect(input.into())
+        parse_when_c_effect(input)
     }
 }

--- a/src/parsers/con_gd.rs
+++ b/src/parsers/con_gd.rs
@@ -257,12 +257,12 @@ pub fn parse_con_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, ConGD<'a
     ))(input.into())
 }
 
-fn parse_con2_gd(input: Span) -> ParseResult<Con2GD> {
+fn parse_con2_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Con2GD<'a>> {
     let gd = map(parse_gd, Con2GD::new_goal);
 
     // TODO: Add crate feature to allow this to be forbidden if unsupported by the application.
     let con_gd = map(parse_con_gd, Con2GD::new_nested);
-    alt((gd, con_gd))(input)
+    alt((gd, con_gd))(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for ConGD<'a> {
@@ -270,7 +270,7 @@ impl<'a> crate::parsers::Parser<'a> for ConGD<'a> {
 
     /// See [`parse_con_gd`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_con_gd(input.into())
+        parse_con_gd(input)
     }
 }
 
@@ -279,6 +279,6 @@ impl<'a> crate::parsers::Parser<'a> for Con2GD<'a> {
 
     /// See [`parse_con2_gd`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_con2_gd(input.into())
+        parse_con2_gd(input)
     }
 }

--- a/src/parsers/con_gd.rs
+++ b/src/parsers/con_gd.rs
@@ -157,7 +157,7 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 /// ```
-pub fn parse_con_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, ConGD<'a>> {
+pub fn parse_con_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, ConGD> {
     let and = map(
         prefix_expr("and", space_separated_list0(parse_con_gd)),
         ConGD::new_and,
@@ -257,7 +257,7 @@ pub fn parse_con_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, ConGD<'a
     ))(input.into())
 }
 
-fn parse_con2_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Con2GD<'a>> {
+fn parse_con2_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Con2GD> {
     let gd = map(parse_gd, Con2GD::new_goal);
 
     // TODO: Add crate feature to allow this to be forbidden if unsupported by the application.
@@ -265,20 +265,20 @@ fn parse_con2_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Con2GD<'a>>
     alt((gd, con_gd))(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for ConGD<'a> {
-    type Item = ConGD<'a>;
+impl crate::parsers::Parser for ConGD {
+    type Item = ConGD;
 
     /// See [`parse_con_gd`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_con_gd(input)
     }
 }
 
-impl<'a> crate::parsers::Parser<'a> for Con2GD<'a> {
-    type Item = Con2GD<'a>;
+impl crate::parsers::Parser for Con2GD {
+    type Item = Con2GD;
 
     /// See [`parse_con2_gd`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_con2_gd(input)
     }
 }

--- a/src/parsers/con_gd.rs
+++ b/src/parsers/con_gd.rs
@@ -36,18 +36,18 @@ use nom::sequence::{preceded, tuple};
 ///         )
 ///     );
 ///
-/// assert!(parse_con_gd("(and)".into()).is_value(
+/// assert!(parse_con_gd("(and)").is_value(
 ///     ConGD::new_and([])
 /// ));
 ///
-/// assert!(parse_con_gd("(and (at end (= x y)) (at end (not (= x z))))".into()).is_value(
+/// assert!(parse_con_gd("(and (at end (= x y)) (at end (not (= x z))))").is_value(
 ///     ConGD::new_and([
 ///         ConGD::new_at_end(gd_a.clone()),
 ///         ConGD::new_at_end(gd_b.clone()),
 ///     ])
 /// ));
 ///
-/// assert!(parse_con_gd("(forall (?x ?z) (sometime (= ?x ?z)))".into()).is_value(
+/// assert!(parse_con_gd("(forall (?x ?z) (sometime (= ?x ?z)))").is_value(
 ///     ConGD::new_forall(
 ///         TypedList::from_iter([
 ///             Variable::from("x").to_typed(Type::OBJECT),
@@ -67,44 +67,44 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 ///
-/// assert!(parse_con_gd("(at end (= x y))".into()).is_value(
+/// assert!(parse_con_gd("(at end (= x y))").is_value(
 ///     ConGD::AtEnd(gd_a.clone())
 /// ));
 ///
-/// assert!(parse_con_gd("(always (= x y))".into()).is_value(
+/// assert!(parse_con_gd("(always (= x y))").is_value(
 ///     ConGD::Always(Con2GD::new_goal(gd_a.clone()))
 /// ));
 ///
-/// assert!(parse_con_gd("(sometime (= x y))".into()).is_value(
+/// assert!(parse_con_gd("(sometime (= x y))").is_value(
 ///     ConGD::Sometime(Con2GD::new_goal(gd_a.clone()))
 /// ));
 ///
-/// assert!(parse_con_gd("(within 10 (= x y))".into()).is_value(
+/// assert!(parse_con_gd("(within 10 (= x y))").is_value(
 ///     ConGD::Within(
 ///         Number::from(10),
 ///         Con2GD::new_goal(gd_a.clone())
 ///     )
 /// ));
 ///
-/// assert!(parse_con_gd("(at-most-once (= x y))".into()).is_value(
+/// assert!(parse_con_gd("(at-most-once (= x y))").is_value(
 ///     ConGD::AtMostOnce(Con2GD::new_goal(gd_a.clone()))
 /// ));
 ///
-/// assert!(parse_con_gd("(sometime-after (= x y) (not (= x z)))".into()).is_value(
+/// assert!(parse_con_gd("(sometime-after (= x y) (not (= x z)))").is_value(
 ///     ConGD::SometimeAfter(
 ///         Con2GD::new_goal(gd_a.clone()),
 ///         Con2GD::new_goal(gd_b.clone())
 ///     )
 /// ));
 ///
-/// assert!(parse_con_gd("(sometime-before (= x y) (not (= x z)))".into()).is_value(
+/// assert!(parse_con_gd("(sometime-before (= x y) (not (= x z)))").is_value(
 ///     ConGD::SometimeBefore(
 ///         Con2GD::new_goal(gd_a.clone()),
 ///         Con2GD::new_goal(gd_b.clone())
 ///     )
 /// ));
 ///
-/// assert!(parse_con_gd("(always-within 10 (= x y) (not (= x z)))".into()).is_value(
+/// assert!(parse_con_gd("(always-within 10 (= x y) (not (= x z)))").is_value(
 ///     ConGD::AlwaysWithin(
 ///         Number::from(10),
 ///         Con2GD::new_goal(gd_a.clone()),
@@ -112,7 +112,7 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 ///
-/// assert!(parse_con_gd("(hold-during 10 20 (= x y))".into()).is_value(
+/// assert!(parse_con_gd("(hold-during 10 20 (= x y))").is_value(
 ///     ConGD::HoldDuring(
 ///         Number::from(10),
 ///         Number::from(20),
@@ -120,7 +120,7 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 ///
-/// assert!(parse_con_gd("(hold-after 10 (= x y))".into()).is_value(
+/// assert!(parse_con_gd("(hold-after 10 (= x y))").is_value(
 ///     ConGD::HoldAfter(
 ///         Number::from(10),
 ///         Con2GD::new_goal(gd_a.clone())
@@ -143,7 +143,7 @@ use nom::sequence::{preceded, tuple};
 /// #    );
 ///
 /// let input = "(within 10 (at-most-once (= x y)))";
-/// assert!(parse_con_gd(input.into()).is_value(
+/// assert!(parse_con_gd(input).is_value(
 ///     ConGD::new_within(
 ///         Number::from(10),
 ///         Con2GD::new_nested(
@@ -157,7 +157,7 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 /// ```
-pub fn parse_con_gd(input: Span) -> ParseResult<ConGD> {
+pub fn parse_con_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, ConGD<'a>> {
     let and = map(
         prefix_expr("and", space_separated_list0(parse_con_gd)),
         ConGD::new_and,
@@ -254,7 +254,7 @@ pub fn parse_con_gd(input: Span) -> ParseResult<ConGD> {
         always_within,
         hold_during,
         hold_after,
-    ))(input)
+    ))(input.into())
 }
 
 fn parse_con2_gd(input: Span) -> ParseResult<Con2GD> {

--- a/src/parsers/con_gd.rs
+++ b/src/parsers/con_gd.rs
@@ -269,8 +269,8 @@ impl<'a> crate::parsers::Parser<'a> for ConGD<'a> {
     type Item = ConGD<'a>;
 
     /// See [`parse_con_gd`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_con_gd(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_con_gd(input.into())
     }
 }
 
@@ -278,7 +278,7 @@ impl<'a> crate::parsers::Parser<'a> for Con2GD<'a> {
     type Item = Con2GD<'a>;
 
     /// See [`parse_con2_gd`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_con2_gd(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_con2_gd(input.into())
     }
 }

--- a/src/parsers/con_gd.rs
+++ b/src/parsers/con_gd.rs
@@ -2,19 +2,19 @@
 
 use crate::parsers::{
     parens, parse_gd, parse_number, parse_variable, prefix_expr, space_separated_list0, typed_list,
+    ParseResult, Span,
 };
 use crate::types::{Con2GD, ConGD};
 use nom::branch::alt;
 use nom::character::complete::multispace1;
 use nom::combinator::map;
 use nom::sequence::{preceded, tuple};
-use nom::IResult;
 
 /// Parses conditional goal definitions.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_con_gd;
+/// # use pddl::parsers::{parse_con_gd, preamble::*};
 /// # use pddl::{AtomicFormula, Con2GD, ConGD, GoalDefinition, Number, Term, ToTyped, Type, TypedList, Variable};
 /// // (= x y)
 /// let gd_a =
@@ -36,18 +36,18 @@ use nom::IResult;
 ///         )
 ///     );
 ///
-/// assert_eq!(parse_con_gd("(and)"), Ok(("",
+/// assert!(parse_con_gd("(and)".into()).is_value(
 ///     ConGD::new_and([])
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_con_gd("(and (at end (= x y)) (at end (not (= x z))))"), Ok(("",
+/// assert!(parse_con_gd("(and (at end (= x y)) (at end (not (= x z))))".into()).is_value(
 ///     ConGD::new_and([
 ///         ConGD::new_at_end(gd_a.clone()),
 ///         ConGD::new_at_end(gd_b.clone()),
 ///     ])
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_con_gd("(forall (?x ?z) (sometime (= ?x ?z)))"), Ok(("",
+/// assert!(parse_con_gd("(forall (?x ?z) (sometime (= ?x ?z)))".into()).is_value(
 ///     ConGD::new_forall(
 ///         TypedList::from_iter([
 ///             Variable::from("x").to_typed(Type::OBJECT),
@@ -65,73 +65,73 @@ use nom::IResult;
 ///             )
 ///         )
 ///     )
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_con_gd("(at end (= x y))"), Ok(("",
+/// assert!(parse_con_gd("(at end (= x y))".into()).is_value(
 ///     ConGD::AtEnd(gd_a.clone())
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_con_gd("(always (= x y))"), Ok(("",
+/// assert!(parse_con_gd("(always (= x y))".into()).is_value(
 ///     ConGD::Always(Con2GD::new_goal(gd_a.clone()))
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_con_gd("(sometime (= x y))"), Ok(("",
+/// assert!(parse_con_gd("(sometime (= x y))".into()).is_value(
 ///     ConGD::Sometime(Con2GD::new_goal(gd_a.clone()))
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_con_gd("(within 10 (= x y))"), Ok(("",
+/// assert!(parse_con_gd("(within 10 (= x y))".into()).is_value(
 ///     ConGD::Within(
 ///         Number::from(10),
 ///         Con2GD::new_goal(gd_a.clone())
 ///     )
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_con_gd("(at-most-once (= x y))"), Ok(("",
+/// assert!(parse_con_gd("(at-most-once (= x y))".into()).is_value(
 ///     ConGD::AtMostOnce(Con2GD::new_goal(gd_a.clone()))
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_con_gd("(sometime-after (= x y) (not (= x z)))"), Ok(("",
+/// assert!(parse_con_gd("(sometime-after (= x y) (not (= x z)))".into()).is_value(
 ///     ConGD::SometimeAfter(
 ///         Con2GD::new_goal(gd_a.clone()),
 ///         Con2GD::new_goal(gd_b.clone())
 ///     )
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_con_gd("(sometime-before (= x y) (not (= x z)))"), Ok(("",
+/// assert!(parse_con_gd("(sometime-before (= x y) (not (= x z)))".into()).is_value(
 ///     ConGD::SometimeBefore(
 ///         Con2GD::new_goal(gd_a.clone()),
 ///         Con2GD::new_goal(gd_b.clone())
 ///     )
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_con_gd("(always-within 10 (= x y) (not (= x z)))"), Ok(("",
+/// assert!(parse_con_gd("(always-within 10 (= x y) (not (= x z)))".into()).is_value(
 ///     ConGD::AlwaysWithin(
 ///         Number::from(10),
 ///         Con2GD::new_goal(gd_a.clone()),
 ///         Con2GD::new_goal(gd_b.clone())
 ///     )
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_con_gd("(hold-during 10 20 (= x y))"), Ok(("",
+/// assert!(parse_con_gd("(hold-during 10 20 (= x y))".into()).is_value(
 ///     ConGD::HoldDuring(
 ///         Number::from(10),
 ///         Number::from(20),
 ///         Con2GD::new_goal(gd_a.clone())
 ///     )
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_con_gd("(hold-after 10 (= x y))"), Ok(("",
+/// assert!(parse_con_gd("(hold-after 10 (= x y))".into()).is_value(
 ///     ConGD::HoldAfter(
 ///         Number::from(10),
 ///         Con2GD::new_goal(gd_a.clone())
 ///     )
-/// )));
+/// ));
 /// ```
 ///
 /// Conditional goal definitions can be nested:
 ///
 /// ```
-/// # use pddl::parsers::parse_con_gd;
+/// # use pddl::parsers::{parse_con_gd, preamble::*};
 /// # use pddl::{AtomicFormula, Con2GD, ConGD, GoalDefinition, Number, Term};
 /// # // (= x y)
 /// # let gd =
@@ -143,7 +143,7 @@ use nom::IResult;
 /// #    );
 ///
 /// let input = "(within 10 (at-most-once (= x y)))";
-/// assert_eq!(parse_con_gd(input), Ok(("",
+/// assert!(parse_con_gd(input.into()).is_value(
 ///     ConGD::new_within(
 ///         Number::from(10),
 ///         Con2GD::new_nested(
@@ -155,9 +155,9 @@ use nom::IResult;
 ///             )
 ///         )
 ///     )
-/// )));
+/// ));
 /// ```
-pub fn parse_con_gd(input: &str) -> IResult<&str, ConGD> {
+pub fn parse_con_gd(input: Span) -> ParseResult<ConGD> {
     let and = map(
         prefix_expr("and", space_separated_list0(parse_con_gd)),
         ConGD::new_and,
@@ -257,7 +257,7 @@ pub fn parse_con_gd(input: &str) -> IResult<&str, ConGD> {
     ))(input)
 }
 
-fn parse_con2_gd(input: &str) -> IResult<&str, Con2GD> {
+fn parse_con2_gd(input: Span) -> ParseResult<Con2GD> {
     let gd = map(parse_gd, Con2GD::new_goal);
 
     // TODO: Add crate feature to allow this to be forbidden if unsupported by the application.
@@ -269,7 +269,7 @@ impl<'a> crate::parsers::Parser<'a> for ConGD<'a> {
     type Item = ConGD<'a>;
 
     /// See [`parse_con_gd`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_con_gd(input)
     }
 }
@@ -278,7 +278,7 @@ impl<'a> crate::parsers::Parser<'a> for Con2GD<'a> {
     type Item = Con2GD<'a>;
 
     /// See [`parse_con2_gd`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_con2_gd(input)
     }
 }

--- a/src/parsers/cond_effect.rs
+++ b/src/parsers/cond_effect.rs
@@ -12,7 +12,7 @@ use nom::combinator::map;
 /// ```
 /// # use pddl::parsers::{parse_cond_effect, preamble::*};
 /// # use pddl::{AtomicFormula, CEffect, ConditionalEffect, EqualityAtomicFormula, PEffect, Term};
-/// assert!(parse_cond_effect("(= x y)".into()).is_value(
+/// assert!(parse_cond_effect("(= x y)").is_value(
 ///     ConditionalEffect::Single(
 ///         PEffect::AtomicFormula(AtomicFormula::Equality(
 ///             EqualityAtomicFormula::new(
@@ -23,7 +23,7 @@ use nom::combinator::map;
 ///     )
 /// ));
 ///
-/// assert!(parse_cond_effect("(and (= x y) (not (= ?a B)))".into()).is_value(
+/// assert!(parse_cond_effect("(and (= x y) (not (= ?a B)))").is_value(
 ///     ConditionalEffect::All(vec![
 ///         PEffect::AtomicFormula(AtomicFormula::Equality(
 ///             EqualityAtomicFormula::new(
@@ -40,14 +40,16 @@ use nom::combinator::map;
 ///     ])
 /// ));
 /// ```
-pub fn parse_cond_effect(input: Span) -> ParseResult<ConditionalEffect> {
+pub fn parse_cond_effect<'a, T: Into<Span<'a>>>(
+    input: T,
+) -> ParseResult<'a, ConditionalEffect<'a>> {
     let exactly = map(parse_p_effect, ConditionalEffect::from);
     let all = map(
         prefix_expr("and", space_separated_list0(parse_p_effect)),
         ConditionalEffect::from,
     );
 
-    alt((all, exactly))(input)
+    alt((all, exactly))(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for ConditionalEffect<'a> {

--- a/src/parsers/cond_effect.rs
+++ b/src/parsers/cond_effect.rs
@@ -1,19 +1,18 @@
 //! Provides parsers for conditional effects.
 
-use crate::parsers::parse_p_effect;
+use crate::parsers::{parse_p_effect, ParseResult, Span};
 use crate::parsers::{prefix_expr, space_separated_list0};
 use crate::types::ConditionalEffect;
 use nom::branch::alt;
 use nom::combinator::map;
-use nom::IResult;
 
 /// Parses conditional effects.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_cond_effect;
+/// # use pddl::parsers::{parse_cond_effect, preamble::*};
 /// # use pddl::{AtomicFormula, CEffect, ConditionalEffect, EqualityAtomicFormula, PEffect, Term};
-/// assert_eq!(parse_cond_effect("(= x y)"), Ok(("",
+/// assert!(parse_cond_effect("(= x y)".into()).is_value(
 ///     ConditionalEffect::Single(
 ///         PEffect::AtomicFormula(AtomicFormula::Equality(
 ///             EqualityAtomicFormula::new(
@@ -22,9 +21,9 @@ use nom::IResult;
 ///             )
 ///         )
 ///     )
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_cond_effect("(and (= x y) (not (= ?a B)))"), Ok(("",
+/// assert!(parse_cond_effect("(and (= x y) (not (= ?a B)))".into()).is_value(
 ///     ConditionalEffect::All(vec![
 ///         PEffect::AtomicFormula(AtomicFormula::Equality(
 ///             EqualityAtomicFormula::new(
@@ -39,9 +38,9 @@ use nom::IResult;
 ///             )
 ///         )
 ///     ])
-/// )));
+/// ));
 /// ```
-pub fn parse_cond_effect(input: &str) -> IResult<&str, ConditionalEffect> {
+pub fn parse_cond_effect(input: Span) -> ParseResult<ConditionalEffect> {
     let exactly = map(parse_p_effect, ConditionalEffect::from);
     let all = map(
         prefix_expr("and", space_separated_list0(parse_p_effect)),
@@ -55,7 +54,7 @@ impl<'a> crate::parsers::Parser<'a> for ConditionalEffect<'a> {
     type Item = ConditionalEffect<'a>;
 
     /// See [`parse_cond_effect`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_cond_effect(input)
     }
 }

--- a/src/parsers/cond_effect.rs
+++ b/src/parsers/cond_effect.rs
@@ -57,6 +57,6 @@ impl<'a> crate::parsers::Parser<'a> for ConditionalEffect<'a> {
 
     /// See [`parse_cond_effect`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_cond_effect(input.into())
+        parse_cond_effect(input)
     }
 }

--- a/src/parsers/cond_effect.rs
+++ b/src/parsers/cond_effect.rs
@@ -40,9 +40,7 @@ use nom::combinator::map;
 ///     ])
 /// ));
 /// ```
-pub fn parse_cond_effect<'a, T: Into<Span<'a>>>(
-    input: T,
-) -> ParseResult<'a, ConditionalEffect<'a>> {
+pub fn parse_cond_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, ConditionalEffect> {
     let exactly = map(parse_p_effect, ConditionalEffect::from);
     let all = map(
         prefix_expr("and", space_separated_list0(parse_p_effect)),
@@ -52,11 +50,11 @@ pub fn parse_cond_effect<'a, T: Into<Span<'a>>>(
     alt((all, exactly))(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for ConditionalEffect<'a> {
-    type Item = ConditionalEffect<'a>;
+impl crate::parsers::Parser for ConditionalEffect {
+    type Item = ConditionalEffect;
 
     /// See [`parse_cond_effect`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_cond_effect(input)
     }
 }

--- a/src/parsers/cond_effect.rs
+++ b/src/parsers/cond_effect.rs
@@ -54,7 +54,7 @@ impl<'a> crate::parsers::Parser<'a> for ConditionalEffect<'a> {
     type Item = ConditionalEffect<'a>;
 
     /// See [`parse_cond_effect`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_cond_effect(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_cond_effect(input.into())
     }
 }

--- a/src/parsers/constants_def.rs
+++ b/src/parsers/constants_def.rs
@@ -29,7 +29,7 @@ impl<'a> crate::parsers::Parser<'a> for Constants<'a> {
     type Item = Constants<'a>;
 
     /// See [`parse_constants_def`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_constants_def(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_constants_def(input.into())
     }
 }

--- a/src/parsers/constants_def.rs
+++ b/src/parsers/constants_def.rs
@@ -19,17 +19,17 @@ use nom::combinator::map;
 ///     ]))
 /// ));
 /// ```
-pub fn parse_constants_def<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Constants<'a>> {
+pub fn parse_constants_def<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Constants> {
     map(prefix_expr(":constants", typed_list(parse_name)), |vec| {
         Constants::new(vec)
     })(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for Constants<'a> {
-    type Item = Constants<'a>;
+impl crate::parsers::Parser for Constants {
+    type Item = Constants;
 
     /// See [`parse_constants_def`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_constants_def(input)
     }
 }

--- a/src/parsers/constants_def.rs
+++ b/src/parsers/constants_def.rs
@@ -30,6 +30,6 @@ impl<'a> crate::parsers::Parser<'a> for Constants<'a> {
 
     /// See [`parse_constants_def`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_constants_def(input.into())
+        parse_constants_def(input)
     }
 }

--- a/src/parsers/constants_def.rs
+++ b/src/parsers/constants_def.rs
@@ -1,26 +1,25 @@
 //! Provides parsers for constant definitions.
 
-use crate::parsers::{parse_name, prefix_expr, typed_list};
+use crate::parsers::{parse_name, prefix_expr, typed_list, ParseResult, Span};
 use crate::types::Constants;
 use nom::combinator::map;
-use nom::IResult;
 
 /// Parser that parses constant definitions, i.e. `(:constants <typed list (name)>)`.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_constants_def;
+/// # use pddl::parsers::{parse_constants_def, preamble::*};
 /// # use pddl::{Variable, AtomicFormulaSkeleton, Predicate, PredicateDefinitions, Constants, Name, ToTyped, TypedList};
 /// let input = "(:constants B P D - physob)";
-/// assert_eq!(parse_constants_def(input), Ok(("",
+/// assert!(parse_constants_def(input.into()).is_value(
 ///     Constants::new(TypedList::from_iter([
 ///         Name::from("B").to_typed("physob"),
 ///         Name::from("P").to_typed("physob"),
 ///         Name::from("D").to_typed("physob"),
 ///     ]))
-/// )));
+/// ));
 /// ```
-pub fn parse_constants_def(input: &str) -> IResult<&str, Constants> {
+pub fn parse_constants_def(input: Span) -> ParseResult<Constants> {
     map(prefix_expr(":constants", typed_list(parse_name)), |vec| {
         Constants::new(vec)
     })(input)
@@ -30,7 +29,7 @@ impl<'a> crate::parsers::Parser<'a> for Constants<'a> {
     type Item = Constants<'a>;
 
     /// See [`parse_constants_def`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_constants_def(input)
     }
 }

--- a/src/parsers/constants_def.rs
+++ b/src/parsers/constants_def.rs
@@ -11,7 +11,7 @@ use nom::combinator::map;
 /// # use pddl::parsers::{parse_constants_def, preamble::*};
 /// # use pddl::{Variable, AtomicFormulaSkeleton, Predicate, PredicateDefinitions, Constants, Name, ToTyped, TypedList};
 /// let input = "(:constants B P D - physob)";
-/// assert!(parse_constants_def(input.into()).is_value(
+/// assert!(parse_constants_def(input).is_value(
 ///     Constants::new(TypedList::from_iter([
 ///         Name::from("B").to_typed("physob"),
 ///         Name::from("P").to_typed("physob"),
@@ -19,10 +19,10 @@ use nom::combinator::map;
 ///     ]))
 /// ));
 /// ```
-pub fn parse_constants_def(input: Span) -> ParseResult<Constants> {
+pub fn parse_constants_def<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Constants<'a>> {
     map(prefix_expr(":constants", typed_list(parse_name)), |vec| {
         Constants::new(vec)
-    })(input)
+    })(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for Constants<'a> {

--- a/src/parsers/d_op.rs
+++ b/src/parsers/d_op.rs
@@ -12,11 +12,11 @@ use nom::combinator::map;
 /// ```
 /// # use pddl::parsers::{parse_d_op, preamble::*};
 /// # use pddl::{DOp};
-/// assert!(parse_d_op("<=".into()).is_value(DOp::LessThanOrEqual));
-/// assert!(parse_d_op(">=".into()).is_value(DOp::GreaterOrEqual));
-/// assert!(parse_d_op("=".into()).is_value(DOp::Equal));
+/// assert!(parse_d_op("<=").is_value(DOp::LessThanOrEqual));
+/// assert!(parse_d_op(">=").is_value(DOp::GreaterOrEqual));
+/// assert!(parse_d_op("=").is_value(DOp::Equal));
 ///```
-pub fn parse_d_op(input: Span) -> ParseResult<DOp> {
+pub fn parse_d_op<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, DOp> {
     // :duration-inequalities
     map(
         alt((
@@ -25,7 +25,7 @@ pub fn parse_d_op(input: Span) -> ParseResult<DOp> {
             tag(names::EQUAL),
         )),
         |x: Span| DOp::try_from(*x.fragment()).expect("unhandled variant"),
-    )(input)
+    )(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for DOp {

--- a/src/parsers/d_op.rs
+++ b/src/parsers/d_op.rs
@@ -1,30 +1,30 @@
 //! Provides parsers for durative operations.
 
+use crate::parsers::{ParseResult, Span};
 use crate::types::{d_op::names, DOp};
 use nom::branch::alt;
 use nom::bytes::complete::tag;
-use nom::combinator::map_res;
-use nom::IResult;
+use nom::combinator::map;
 
 /// Parses a durative operation, i.e. `<= | >= | =`.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_d_op;
+/// # use pddl::parsers::{parse_d_op, preamble::*};
 /// # use pddl::{DOp};
-/// assert_eq!(parse_d_op("<="), Ok(("", DOp::LessThanOrEqual)));
-/// assert_eq!(parse_d_op(">="), Ok(("", DOp::GreaterOrEqual)));
-/// assert_eq!(parse_d_op("="), Ok(("", DOp::Equal)));
+/// assert!(parse_d_op("<=".into()).is_value(DOp::LessThanOrEqual));
+/// assert!(parse_d_op(">=".into()).is_value(DOp::GreaterOrEqual));
+/// assert!(parse_d_op("=".into()).is_value(DOp::Equal));
 ///```
-pub fn parse_d_op(input: &str) -> IResult<&str, DOp> {
+pub fn parse_d_op(input: Span) -> ParseResult<DOp> {
     // :duration-inequalities
-    map_res(
+    map(
         alt((
             tag(names::LESS_THAN_OR_EQUAL),
             tag(names::GREATER_OR_EQUAL),
             tag(names::EQUAL),
         )),
-        DOp::try_from,
+        |x: Span| DOp::try_from(*x.fragment()).expect("unhandled variant"),
     )(input)
 }
 
@@ -32,7 +32,7 @@ impl<'a> crate::parsers::Parser<'a> for DOp {
     type Item = DOp;
 
     /// See [`parse_d_op`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_d_op(input)
     }
 }

--- a/src/parsers/d_op.rs
+++ b/src/parsers/d_op.rs
@@ -28,11 +28,11 @@ pub fn parse_d_op<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, DOp> {
     )(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for DOp {
+impl crate::parsers::Parser for DOp {
     type Item = DOp;
 
     /// See [`parse_d_op`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_d_op(input)
     }
 }

--- a/src/parsers/d_op.rs
+++ b/src/parsers/d_op.rs
@@ -33,6 +33,6 @@ impl<'a> crate::parsers::Parser<'a> for DOp {
 
     /// See [`parse_d_op`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_d_op(input.into())
+        parse_d_op(input)
     }
 }

--- a/src/parsers/d_op.rs
+++ b/src/parsers/d_op.rs
@@ -32,7 +32,7 @@ impl<'a> crate::parsers::Parser<'a> for DOp {
     type Item = DOp;
 
     /// See [`parse_d_op`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_d_op(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_d_op(input.into())
     }
 }

--- a/src/parsers/d_value.rs
+++ b/src/parsers/d_value.rs
@@ -1,29 +1,28 @@
 //! Provides parsers for d-values.
 
-use crate::parsers::parse_f_exp;
 use crate::parsers::parse_number;
+use crate::parsers::{parse_f_exp, ParseResult, Span};
 use crate::types::DurationValue;
 use nom::branch::alt;
 use nom::combinator::map;
-use nom::IResult;
 
 /// Parses a d-value.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_d_value;
+/// # use pddl::parsers::{parse_d_value, preamble::*};
 /// # use pddl::{BinaryOp, DurationValue, FExp, FHead, FunctionSymbol, MultiOp};
-/// assert_eq!(parse_d_value("1.23"), Ok(("",
+/// assert!(parse_d_value("1.23".into()).is_value(
 ///     DurationValue::new_number(1.23)
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_d_value("fun-sym"), Ok(("",
+/// assert!(parse_d_value("fun-sym".into()).is_value(
 ///     DurationValue::new_f_exp(
 ///         FExp::new_function(FHead::Simple("fun-sym".into()))
 ///     )
-/// )));
+/// ));
 ///```
-pub fn parse_d_value(input: &str) -> IResult<&str, DurationValue> {
+pub fn parse_d_value(input: Span) -> ParseResult<DurationValue> {
     let number = map(parse_number, DurationValue::new_number);
 
     // :numeric-fluents
@@ -36,7 +35,7 @@ impl<'a> crate::parsers::Parser<'a> for DurationValue<'a> {
     type Item = DurationValue<'a>;
 
     /// See [`parse_d_value`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_d_value(input)
     }
 }

--- a/src/parsers/d_value.rs
+++ b/src/parsers/d_value.rs
@@ -36,6 +36,6 @@ impl<'a> crate::parsers::Parser<'a> for DurationValue<'a> {
 
     /// See [`parse_d_value`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_d_value(input.into())
+        parse_d_value(input)
     }
 }

--- a/src/parsers/d_value.rs
+++ b/src/parsers/d_value.rs
@@ -35,7 +35,7 @@ impl<'a> crate::parsers::Parser<'a> for DurationValue<'a> {
     type Item = DurationValue<'a>;
 
     /// See [`parse_d_value`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_d_value(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_d_value(input.into())
     }
 }

--- a/src/parsers/d_value.rs
+++ b/src/parsers/d_value.rs
@@ -22,7 +22,7 @@ use nom::combinator::map;
 ///     )
 /// ));
 ///```
-pub fn parse_d_value<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, DurationValue<'a>> {
+pub fn parse_d_value<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, DurationValue> {
     let number = map(parse_number, DurationValue::new_number);
 
     // :numeric-fluents
@@ -31,11 +31,11 @@ pub fn parse_d_value<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Duratio
     alt((number, f_exp))(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for DurationValue<'a> {
-    type Item = DurationValue<'a>;
+impl crate::parsers::Parser for DurationValue {
+    type Item = DurationValue;
 
     /// See [`parse_d_value`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_d_value(input)
     }
 }

--- a/src/parsers/d_value.rs
+++ b/src/parsers/d_value.rs
@@ -12,23 +12,23 @@ use nom::combinator::map;
 /// ```
 /// # use pddl::parsers::{parse_d_value, preamble::*};
 /// # use pddl::{BinaryOp, DurationValue, FExp, FHead, FunctionSymbol, MultiOp};
-/// assert!(parse_d_value("1.23".into()).is_value(
+/// assert!(parse_d_value("1.23").is_value(
 ///     DurationValue::new_number(1.23)
 /// ));
 ///
-/// assert!(parse_d_value("fun-sym".into()).is_value(
+/// assert!(parse_d_value("fun-sym").is_value(
 ///     DurationValue::new_f_exp(
 ///         FExp::new_function(FHead::Simple("fun-sym".into()))
 ///     )
 /// ));
 ///```
-pub fn parse_d_value(input: Span) -> ParseResult<DurationValue> {
+pub fn parse_d_value<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, DurationValue<'a>> {
     let number = map(parse_number, DurationValue::new_number);
 
     // :numeric-fluents
     let f_exp = map(parse_f_exp, DurationValue::new_f_exp);
 
-    alt((number, f_exp))(input)
+    alt((number, f_exp))(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for DurationValue<'a> {

--- a/src/parsers/da_def.rs
+++ b/src/parsers/da_def.rs
@@ -1,6 +1,6 @@
 //! Provides parsers for durative action definitions.
 
-use crate::parsers::{empty_or, parens, prefix_expr, typed_list};
+use crate::parsers::{empty_or, parens, prefix_expr, typed_list, ParseResult, Span};
 use crate::parsers::{
     parse_da_effect, parse_da_gd, parse_da_symbol, parse_duration_constraint, parse_variable,
 };
@@ -9,13 +9,12 @@ use nom::bytes::complete::tag;
 use nom::character::complete::multispace1;
 use nom::combinator::map;
 use nom::sequence::{preceded, tuple};
-use nom::IResult;
 
 /// Parses a durative action definition.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::{parse_action_def, parse_da_def};
+/// # use pddl::parsers::{parse_action_def, parse_da_def, preamble::*};
 /// # use pddl::{ActionDefinition, ActionSymbol, AtomicFormula, CEffect, Effects, GoalDefinition, Literal, PEffect, Predicate, Preference, PreferenceGD, PreconditionGoalDefinition, Term, Variable};
 /// let input = r#"(:durative-action move
 ///         :parameters
@@ -46,14 +45,14 @@ use nom::IResult;
 ///                 )
 ///     )"#;
 ///
-/// let (_, da_def) = parse_da_def(input).unwrap();
+/// let (_, da_def) = parse_da_def(input.into()).unwrap();
 /// assert_eq!(da_def.symbol(), &"move".into());
 /// assert_eq!(da_def.parameters().len(), 3);
 /// assert!(da_def.duration().is_some());
 /// assert!(da_def.condition().is_some());
 /// assert!(da_def.effect().is_some());
 /// ```
-pub fn parse_da_def(input: &str) -> IResult<&str, DurativeActionDefinition> {
+pub fn parse_da_def(input: Span) -> ParseResult<DurativeActionDefinition> {
     let parameters = preceded(
         tag(":parameters"),
         preceded(multispace1, parens(typed_list(parse_variable))),
@@ -96,7 +95,7 @@ impl<'a> crate::parsers::Parser<'a> for DurativeActionDefinition<'a> {
     type Item = DurativeActionDefinition<'a>;
 
     /// See [`parse_da_def`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_da_def(input)
     }
 }
@@ -135,6 +134,6 @@ mod tests {
                         (at end (increase (distance-travelled) 5))
                         )
             )"#;
-        let (_, _gd) = parse_da_def(input).unwrap();
+        let (_, _gd) = parse_da_def(Span::new(input)).unwrap();
     }
 }

--- a/src/parsers/da_def.rs
+++ b/src/parsers/da_def.rs
@@ -95,8 +95,8 @@ impl<'a> crate::parsers::Parser<'a> for DurativeActionDefinition<'a> {
     type Item = DurativeActionDefinition<'a>;
 
     /// See [`parse_da_def`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_da_def(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_da_def(input.into())
     }
 }
 

--- a/src/parsers/da_def.rs
+++ b/src/parsers/da_def.rs
@@ -98,7 +98,7 @@ impl<'a> crate::parsers::Parser<'a> for DurativeActionDefinition<'a> {
 
     /// See [`parse_da_def`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_da_def(input.into())
+        parse_da_def(input)
     }
 }
 

--- a/src/parsers/da_def.rs
+++ b/src/parsers/da_def.rs
@@ -45,14 +45,16 @@ use nom::sequence::{preceded, tuple};
 ///                 )
 ///     )"#;
 ///
-/// let (_, da_def) = parse_da_def(input.into()).unwrap();
+/// let (_, da_def) = parse_da_def(input).unwrap();
 /// assert_eq!(da_def.symbol(), &"move".into());
 /// assert_eq!(da_def.parameters().len(), 3);
 /// assert!(da_def.duration().is_some());
 /// assert!(da_def.condition().is_some());
 /// assert!(da_def.effect().is_some());
 /// ```
-pub fn parse_da_def(input: Span) -> ParseResult<DurativeActionDefinition> {
+pub fn parse_da_def<'a, T: Into<Span<'a>>>(
+    input: T,
+) -> ParseResult<'a, DurativeActionDefinition<'a>> {
     let parameters = preceded(
         tag(":parameters"),
         preceded(multispace1, parens(typed_list(parse_variable))),
@@ -88,7 +90,7 @@ pub fn parse_da_def(input: Span) -> ParseResult<DurativeActionDefinition> {
         |(symbol, parameters, duration, condition, effect)| {
             DurativeActionDefinition::new(symbol, parameters, duration, condition, effect)
         },
-    )(input)
+    )(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for DurativeActionDefinition<'a> {

--- a/src/parsers/da_def.rs
+++ b/src/parsers/da_def.rs
@@ -52,9 +52,7 @@ use nom::sequence::{preceded, tuple};
 /// assert!(da_def.condition().is_some());
 /// assert!(da_def.effect().is_some());
 /// ```
-pub fn parse_da_def<'a, T: Into<Span<'a>>>(
-    input: T,
-) -> ParseResult<'a, DurativeActionDefinition<'a>> {
+pub fn parse_da_def<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, DurativeActionDefinition> {
     let parameters = preceded(
         tag(":parameters"),
         preceded(multispace1, parens(typed_list(parse_variable))),
@@ -93,11 +91,11 @@ pub fn parse_da_def<'a, T: Into<Span<'a>>>(
     )(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for DurativeActionDefinition<'a> {
-    type Item = DurativeActionDefinition<'a>;
+impl crate::parsers::Parser for DurativeActionDefinition {
+    type Item = DurativeActionDefinition;
 
     /// See [`parse_da_def`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_da_def(input)
     }
 }

--- a/src/parsers/da_effect.rs
+++ b/src/parsers/da_effect.rs
@@ -15,7 +15,7 @@ use nom::sequence::{preceded, tuple};
 /// # use pddl::parsers::{parse_da_effect, preamble::*};
 /// # use pddl::{AtomicFormula, ConditionalEffect, DurativeActionEffect, EqualityAtomicFormula, PEffect, Term, TimedEffect, TimeSpecifier, Variable};
 /// # use pddl::{Typed, TypedList};
-/// assert!(parse_da_effect("(at start (= x y))".into()).is_value(
+/// assert!(parse_da_effect("(at start (= x y))").is_value(
 ///     DurativeActionEffect::Timed(
 ///         TimedEffect::new_conditional(
 ///             TimeSpecifier::Start,
@@ -31,11 +31,11 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 ///
-/// assert!(parse_da_effect("(and )".into()).is_value(
+/// assert!(parse_da_effect("(and )").is_value(
 ///     DurativeActionEffect::new_and([])
 /// ));
 ///
-/// assert!(parse_da_effect("(and (at start (= x y)) (and ))".into()).is_value(
+/// assert!(parse_da_effect("(and (at start (= x y)) (and ))").is_value(
 ///     DurativeActionEffect::new_and([
 ///         DurativeActionEffect::Timed(
 ///             TimedEffect::new_conditional(
@@ -54,7 +54,7 @@ use nom::sequence::{preceded, tuple};
 ///     ])
 /// ));
 ///
-/// assert!(parse_da_effect("(forall (?a ?b) (at start (= a b)))".into()).is_value(
+/// assert!(parse_da_effect("(forall (?a ?b) (at start (= a b)))").is_value(
 ///     DurativeActionEffect::new_forall(
 ///         TypedList::from_iter([
 ///             Typed::new_object(Variable::from_str("a")),
@@ -76,7 +76,9 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 /// ```
-pub fn parse_da_effect(input: Span) -> ParseResult<DurativeActionEffect> {
+pub fn parse_da_effect<'a, T: Into<Span<'a>>>(
+    input: T,
+) -> ParseResult<'a, DurativeActionEffect<'a>> {
     let exactly = map(parse_timed_effect, DurativeActionEffect::from);
 
     let all = map(
@@ -105,7 +107,7 @@ pub fn parse_da_effect(input: Span) -> ParseResult<DurativeActionEffect> {
         DurativeActionEffect::from,
     );
 
-    alt((all, forall, when, exactly))(input)
+    alt((all, forall, when, exactly))(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for DurativeActionEffect<'a> {

--- a/src/parsers/da_effect.rs
+++ b/src/parsers/da_effect.rs
@@ -112,8 +112,8 @@ impl<'a> crate::parsers::Parser<'a> for DurativeActionEffect<'a> {
     type Item = DurativeActionEffect<'a>;
 
     /// See [`parse_da_effect`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_da_effect(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_da_effect(input.into())
     }
 }
 

--- a/src/parsers/da_effect.rs
+++ b/src/parsers/da_effect.rs
@@ -76,9 +76,7 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 /// ```
-pub fn parse_da_effect<'a, T: Into<Span<'a>>>(
-    input: T,
-) -> ParseResult<'a, DurativeActionEffect<'a>> {
+pub fn parse_da_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, DurativeActionEffect> {
     let exactly = map(parse_timed_effect, DurativeActionEffect::from);
 
     let all = map(
@@ -110,11 +108,11 @@ pub fn parse_da_effect<'a, T: Into<Span<'a>>>(
     alt((all, forall, when, exactly))(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for DurativeActionEffect<'a> {
-    type Item = DurativeActionEffect<'a>;
+impl crate::parsers::Parser for DurativeActionEffect {
+    type Item = DurativeActionEffect;
 
     /// See [`parse_da_effect`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_da_effect(input)
     }
 }

--- a/src/parsers/da_effect.rs
+++ b/src/parsers/da_effect.rs
@@ -115,7 +115,7 @@ impl<'a> crate::parsers::Parser<'a> for DurativeActionEffect<'a> {
 
     /// See [`parse_da_effect`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_da_effect(input.into())
+        parse_da_effect(input)
     }
 }
 

--- a/src/parsers/da_effect.rs
+++ b/src/parsers/da_effect.rs
@@ -1,22 +1,21 @@
 //! Provides parsers for durative action effects.
 
-use crate::parsers::{parens, prefix_expr, space_separated_list0, typed_list};
+use crate::parsers::{parens, prefix_expr, space_separated_list0, typed_list, ParseResult, Span};
 use crate::parsers::{parse_da_gd, parse_timed_effect, parse_variable};
 use crate::types::DurativeActionEffect;
 use nom::branch::alt;
 use nom::character::complete::multispace1;
 use nom::combinator::map;
 use nom::sequence::{preceded, tuple};
-use nom::IResult;
 
 /// Parses effects.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_da_effect;
+/// # use pddl::parsers::{parse_da_effect, preamble::*};
 /// # use pddl::{AtomicFormula, ConditionalEffect, DurativeActionEffect, EqualityAtomicFormula, PEffect, Term, TimedEffect, TimeSpecifier, Variable};
 /// # use pddl::{Typed, TypedList};
-/// assert_eq!(parse_da_effect("(at start (= x y))"), Ok(("",
+/// assert!(parse_da_effect("(at start (= x y))".into()).is_value(
 ///     DurativeActionEffect::Timed(
 ///         TimedEffect::new_conditional(
 ///             TimeSpecifier::Start,
@@ -30,13 +29,13 @@ use nom::IResult;
 ///             )
 ///         )
 ///     )
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_da_effect("(and )"), Ok(("",
+/// assert!(parse_da_effect("(and )".into()).is_value(
 ///     DurativeActionEffect::new_and([])
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_da_effect("(and (at start (= x y)) (and ))"), Ok(("",
+/// assert!(parse_da_effect("(and (at start (= x y)) (and ))".into()).is_value(
 ///     DurativeActionEffect::new_and([
 ///         DurativeActionEffect::Timed(
 ///             TimedEffect::new_conditional(
@@ -53,9 +52,9 @@ use nom::IResult;
 ///         ),
 ///         DurativeActionEffect::new_and([])
 ///     ])
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_da_effect("(forall (?a ?b) (at start (= a b)))"), Ok(("",
+/// assert!(parse_da_effect("(forall (?a ?b) (at start (= a b)))".into()).is_value(
 ///     DurativeActionEffect::new_forall(
 ///         TypedList::from_iter([
 ///             Typed::new_object(Variable::from_str("a")),
@@ -75,9 +74,9 @@ use nom::IResult;
 ///             )
 ///         )
 ///     )
-/// )));
+/// ));
 /// ```
-pub fn parse_da_effect(input: &str) -> IResult<&str, DurativeActionEffect> {
+pub fn parse_da_effect(input: Span) -> ParseResult<DurativeActionEffect> {
     let exactly = map(parse_timed_effect, DurativeActionEffect::from);
 
     let all = map(
@@ -113,7 +112,7 @@ impl<'a> crate::parsers::Parser<'a> for DurativeActionEffect<'a> {
     type Item = DurativeActionEffect<'a>;
 
     /// See [`parse_da_effect`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_da_effect(input)
     }
 }
@@ -133,7 +132,7 @@ mod tests {
                 (at end (increase (distance-travelled) 5))
                 )"#;
 
-        let (_, _effect) = parse_da_effect(input).unwrap();
+        let (_, _effect) = parse_da_effect(Span::new(input)).unwrap();
     }
 
     #[test]
@@ -147,6 +146,6 @@ mod tests {
                 (at end (increase (distance-travelled) 5))
                 )"#;
 
-        let (_, _effect) = parse_da_effect(input).unwrap();
+        let (_, _effect) = parse_da_effect(Span::new(input)).unwrap();
     }
 }

--- a/src/parsers/da_gd.rs
+++ b/src/parsers/da_gd.rs
@@ -110,8 +110,8 @@ impl<'a> crate::parsers::Parser<'a> for DurativeActionGoalDefinition<'a> {
     type Item = DurativeActionGoalDefinition<'a>;
 
     /// See [`parse_da_gd`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_da_gd(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_da_gd(input.into())
     }
 }
 

--- a/src/parsers/da_gd.rs
+++ b/src/parsers/da_gd.rs
@@ -113,7 +113,7 @@ impl<'a> crate::parsers::Parser<'a> for DurativeActionGoalDefinition<'a> {
 
     /// See [`parse_da_gd`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_da_gd(input.into())
+        parse_da_gd(input)
     }
 }
 

--- a/src/parsers/da_gd.rs
+++ b/src/parsers/da_gd.rs
@@ -86,7 +86,7 @@ use nom::sequence::{preceded, tuple};
 /// ```
 pub fn parse_da_gd<'a, T: Into<Span<'a>>>(
     input: T,
-) -> ParseResult<'a, DurativeActionGoalDefinition<'a>> {
+) -> ParseResult<'a, DurativeActionGoalDefinition> {
     let pref_timed_gd = map(parse_pref_timed_gd, DurativeActionGoalDefinition::new_timed);
     let and = map(
         prefix_expr("and", space_separated_list0(parse_da_gd)),
@@ -108,11 +108,11 @@ pub fn parse_da_gd<'a, T: Into<Span<'a>>>(
     alt((forall, and, pref_timed_gd))(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for DurativeActionGoalDefinition<'a> {
-    type Item = DurativeActionGoalDefinition<'a>;
+impl crate::parsers::Parser for DurativeActionGoalDefinition {
+    type Item = DurativeActionGoalDefinition;
 
     /// See [`parse_da_gd`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_da_gd(input)
     }
 }

--- a/src/parsers/da_gd.rs
+++ b/src/parsers/da_gd.rs
@@ -15,7 +15,7 @@ use nom::sequence::{preceded, tuple};
 /// # use pddl::parsers::{parse_da_gd, preamble::*};
 /// # use pddl::{AtomicFormula, EqualityAtomicFormula, GoalDefinition, Literal, Preference, PreferenceName, PreferenceGD, Term, Variable, DurativeActionGoalDefinition, PrefTimedGD, TimedGD, TimeSpecifier, Interval};
 /// # use pddl::{Typed, TypedList};
-/// assert!(parse_da_gd("(at start (= x y))".into()).is_value(
+/// assert!(parse_da_gd("(at start (= x y))").is_value(
 ///     DurativeActionGoalDefinition::Timed(
 ///         PrefTimedGD::Required(
 ///             TimedGD::new_at(
@@ -31,11 +31,11 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 ///
-/// assert!(parse_da_gd("(and )".into()).is_value(
+/// assert!(parse_da_gd("(and )").is_value(
 ///     DurativeActionGoalDefinition::new_and([])
 /// ));
 ///
-/// assert!(parse_da_gd("(and (at start (= x y)) (over all (= a b)))".into()).is_value(
+/// assert!(parse_da_gd("(and (at start (= x y)) (over all (= a b)))").is_value(
 ///     DurativeActionGoalDefinition::new_and([
 ///         DurativeActionGoalDefinition::Timed(PrefTimedGD::Required(
 ///             TimedGD::new_at(
@@ -62,7 +62,7 @@ use nom::sequence::{preceded, tuple};
 ///     ])
 /// ));
 ///
-/// assert!(parse_da_gd("(forall (?a ?b) (at start (= a b)))".into()).is_value(
+/// assert!(parse_da_gd("(forall (?a ?b) (at start (= a b)))").is_value(
 ///     DurativeActionGoalDefinition::new_forall(
 ///         TypedList::from_iter([
 ///             Typed::new_object(Variable::from_str("a")),
@@ -84,7 +84,9 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 /// ```
-pub fn parse_da_gd(input: Span) -> ParseResult<DurativeActionGoalDefinition> {
+pub fn parse_da_gd<'a, T: Into<Span<'a>>>(
+    input: T,
+) -> ParseResult<'a, DurativeActionGoalDefinition<'a>> {
     let pref_timed_gd = map(parse_pref_timed_gd, DurativeActionGoalDefinition::new_timed);
     let and = map(
         prefix_expr("and", space_separated_list0(parse_da_gd)),
@@ -103,7 +105,7 @@ pub fn parse_da_gd(input: Span) -> ParseResult<DurativeActionGoalDefinition> {
         |(vars, gd)| DurativeActionGoalDefinition::new_forall(vars, gd),
     );
 
-    alt((forall, and, pref_timed_gd))(input)
+    alt((forall, and, pref_timed_gd))(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for DurativeActionGoalDefinition<'a> {

--- a/src/parsers/da_symbol.rs
+++ b/src/parsers/da_symbol.rs
@@ -22,6 +22,6 @@ impl<'a> crate::parsers::Parser<'a> for DurativeActionSymbol<'a> {
 
     /// See [`parse_da_symbol`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_da_symbol(input.into())
+        parse_da_symbol(input)
     }
 }

--- a/src/parsers/da_symbol.rs
+++ b/src/parsers/da_symbol.rs
@@ -1,18 +1,17 @@
 //! Provides parsers for predicates.
 
-use crate::parsers::parse_name;
+use crate::parsers::{parse_name, ParseResult, Span};
 use crate::types::DurativeActionSymbol;
 use nom::combinator::map;
-use nom::IResult;
 
 /// Parses a durative action symbol, i.e. `<name>`.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_da_symbol;
-/// assert_eq!(parse_da_symbol("abcde"), Ok(("", "abcde".into())));
+/// # use pddl::parsers::{parse_da_symbol, preamble::*};
+/// assert!(parse_da_symbol("abcde".into()).is_value("abcde".into()));
 ///```
-pub fn parse_da_symbol(input: &str) -> IResult<&str, DurativeActionSymbol> {
+pub fn parse_da_symbol(input: Span) -> ParseResult<DurativeActionSymbol> {
     map(parse_name, DurativeActionSymbol::from)(input)
 }
 
@@ -20,7 +19,7 @@ impl<'a> crate::parsers::Parser<'a> for DurativeActionSymbol<'a> {
     type Item = DurativeActionSymbol<'a>;
 
     /// See [`parse_da_symbol`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_da_symbol(input)
     }
 }

--- a/src/parsers/da_symbol.rs
+++ b/src/parsers/da_symbol.rs
@@ -11,17 +11,15 @@ use nom::combinator::map;
 /// # use pddl::parsers::{parse_da_symbol, preamble::*};
 /// assert!(parse_da_symbol("abcde").is_value("abcde".into()));
 ///```
-pub fn parse_da_symbol<'a, T: Into<Span<'a>>>(
-    input: T,
-) -> ParseResult<'a, DurativeActionSymbol<'a>> {
+pub fn parse_da_symbol<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, DurativeActionSymbol> {
     map(parse_name, DurativeActionSymbol::from)(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for DurativeActionSymbol<'a> {
-    type Item = DurativeActionSymbol<'a>;
+impl crate::parsers::Parser for DurativeActionSymbol {
+    type Item = DurativeActionSymbol;
 
     /// See [`parse_da_symbol`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_da_symbol(input)
     }
 }

--- a/src/parsers/da_symbol.rs
+++ b/src/parsers/da_symbol.rs
@@ -19,7 +19,7 @@ impl<'a> crate::parsers::Parser<'a> for DurativeActionSymbol<'a> {
     type Item = DurativeActionSymbol<'a>;
 
     /// See [`parse_da_symbol`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_da_symbol(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_da_symbol(input.into())
     }
 }

--- a/src/parsers/da_symbol.rs
+++ b/src/parsers/da_symbol.rs
@@ -9,10 +9,12 @@ use nom::combinator::map;
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_da_symbol, preamble::*};
-/// assert!(parse_da_symbol("abcde".into()).is_value("abcde".into()));
+/// assert!(parse_da_symbol("abcde").is_value("abcde".into()));
 ///```
-pub fn parse_da_symbol(input: Span) -> ParseResult<DurativeActionSymbol> {
-    map(parse_name, DurativeActionSymbol::from)(input)
+pub fn parse_da_symbol<'a, T: Into<Span<'a>>>(
+    input: T,
+) -> ParseResult<'a, DurativeActionSymbol<'a>> {
+    map(parse_name, DurativeActionSymbol::from)(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for DurativeActionSymbol<'a> {

--- a/src/parsers/derived_predicate.rs
+++ b/src/parsers/derived_predicate.rs
@@ -1,18 +1,17 @@
 //! Provides parsers for derived predicates.
 
-use crate::parsers::prefix_expr;
 use crate::parsers::{parse_atomic_formula_skeleton, parse_gd};
+use crate::parsers::{prefix_expr, ParseResult, Span};
 use crate::types::DerivedPredicate;
 use nom::character::complete::multispace1;
 use nom::combinator::map;
 use nom::sequence::{preceded, tuple};
-use nom::IResult;
 
 /// Parses a derived predicate, i.e. `(:derived <atomic formula skeleton> <GD>)`.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_derived_predicate;
+/// # use pddl::parsers::{parse_derived_predicate, preamble::*};
 /// # use pddl::GoalDefinition;
 /// let input = r#"(:derived (train-usable ?t - train)
 ///                     (and
@@ -21,11 +20,11 @@ use nom::IResult;
 ///                     )
 ///                 )"#;
 ///
-/// let (remaining, predicate) = parse_derived_predicate(input).unwrap();
+/// let (remaining, predicate) = parse_derived_predicate(input.into()).unwrap();
 /// assert_eq!(predicate.predicate().name(), &"train-usable".into());
 /// assert!(matches!(predicate.expression(), &GoalDefinition::And(..)));
 ///```
-pub fn parse_derived_predicate(input: &str) -> IResult<&str, DerivedPredicate> {
+pub fn parse_derived_predicate(input: Span) -> ParseResult<DerivedPredicate> {
     map(
         prefix_expr(
             ":derived",
@@ -42,7 +41,7 @@ impl<'a> crate::parsers::Parser<'a> for DerivedPredicate<'a> {
     type Item = DerivedPredicate<'a>;
 
     /// See [`parse_derived_predicate`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_derived_predicate(input)
     }
 }

--- a/src/parsers/derived_predicate.rs
+++ b/src/parsers/derived_predicate.rs
@@ -26,7 +26,7 @@ use nom::sequence::{preceded, tuple};
 ///```
 pub fn parse_derived_predicate<'a, T: Into<Span<'a>>>(
     input: T,
-) -> ParseResult<'a, DerivedPredicate<'a>> {
+) -> ParseResult<'a, DerivedPredicate> {
     map(
         prefix_expr(
             ":derived",
@@ -39,11 +39,11 @@ pub fn parse_derived_predicate<'a, T: Into<Span<'a>>>(
     )(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for DerivedPredicate<'a> {
-    type Item = DerivedPredicate<'a>;
+impl crate::parsers::Parser for DerivedPredicate {
+    type Item = DerivedPredicate;
 
     /// See [`parse_derived_predicate`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_derived_predicate(input)
     }
 }

--- a/src/parsers/derived_predicate.rs
+++ b/src/parsers/derived_predicate.rs
@@ -20,11 +20,13 @@ use nom::sequence::{preceded, tuple};
 ///                     )
 ///                 )"#;
 ///
-/// let (remaining, predicate) = parse_derived_predicate(input.into()).unwrap();
+/// let (remaining, predicate) = parse_derived_predicate(input).unwrap();
 /// assert_eq!(predicate.predicate().name(), &"train-usable".into());
 /// assert!(matches!(predicate.expression(), &GoalDefinition::And(..)));
 ///```
-pub fn parse_derived_predicate(input: Span) -> ParseResult<DerivedPredicate> {
+pub fn parse_derived_predicate<'a, T: Into<Span<'a>>>(
+    input: T,
+) -> ParseResult<'a, DerivedPredicate<'a>> {
     map(
         prefix_expr(
             ":derived",
@@ -34,7 +36,7 @@ pub fn parse_derived_predicate(input: Span) -> ParseResult<DerivedPredicate> {
             )),
         ),
         DerivedPredicate::from,
-    )(input)
+    )(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for DerivedPredicate<'a> {

--- a/src/parsers/derived_predicate.rs
+++ b/src/parsers/derived_predicate.rs
@@ -41,7 +41,7 @@ impl<'a> crate::parsers::Parser<'a> for DerivedPredicate<'a> {
     type Item = DerivedPredicate<'a>;
 
     /// See [`parse_derived_predicate`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_derived_predicate(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_derived_predicate(input.into())
     }
 }

--- a/src/parsers/derived_predicate.rs
+++ b/src/parsers/derived_predicate.rs
@@ -44,6 +44,6 @@ impl<'a> crate::parsers::Parser<'a> for DerivedPredicate<'a> {
 
     /// See [`parse_derived_predicate`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_derived_predicate(input.into())
+        parse_derived_predicate(input)
     }
 }

--- a/src/parsers/domain.rs
+++ b/src/parsers/domain.rs
@@ -115,6 +115,6 @@ impl<'a> crate::parsers::Parser<'a> for Domain<'a> {
 
     /// See [`parse_domain`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_domain(input.into())
+        parse_domain(input)
     }
 }

--- a/src/parsers/domain.rs
+++ b/src/parsers/domain.rs
@@ -48,7 +48,7 @@ use nom::sequence::{preceded, tuple};
 ///            :effect (not (in ?x)) )
 ///     )"#;
 ///
-/// let (remainder, domain) = parse_domain(input.into()).unwrap();
+/// let (remainder, domain) = parse_domain(input).unwrap();
 ///
 /// assert!(remainder.is_empty());
 /// assert_eq!(domain.name(), &Name::new("briefcase-world"));
@@ -59,7 +59,7 @@ use nom::sequence::{preceded, tuple};
 /// assert!(domain.constraints().is_empty());
 /// assert_eq!(domain.structure().len(), 3);
 /// ```
-pub fn parse_domain(input: Span) -> ParseResult<Domain> {
+pub fn parse_domain<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Domain<'a>> {
     map(
         ws(prefix_expr(
             "define",
@@ -107,7 +107,7 @@ pub fn parse_domain(input: Span) -> ParseResult<Domain> {
                 .with_functions(functions.unwrap_or(Functions::default()))
                 .with_constraints(constraints.unwrap_or(DomainConstraintsDef::default()))
         },
-    )(input)
+    )(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for Domain<'a> {

--- a/src/parsers/domain.rs
+++ b/src/parsers/domain.rs
@@ -2,7 +2,7 @@
 
 use crate::parsers::{
     parse_constants_def, parse_domain_constraints_def, parse_functions_def, parse_predicates_def,
-    parse_require_def, parse_structure_def,
+    parse_require_def, parse_structure_def, ParseResult, Span,
 };
 use crate::parsers::{parse_name, parse_types_def, prefix_expr, space_separated_list1, ws};
 use crate::types::{
@@ -12,13 +12,12 @@ use crate::types::{DomainConstraintsDef, Types};
 use nom::character::complete::multispace1;
 use nom::combinator::{map, opt};
 use nom::sequence::{preceded, tuple};
-use nom::IResult;
 
 /// Parses a domain definition.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::{parse_action_def, parse_domain};
+/// # use pddl::parsers::{parse_action_def, parse_domain, preamble::*};
 /// # use pddl::Name;
 ///
 /// let input = r#"(define (domain briefcase-world)
@@ -49,9 +48,9 @@ use nom::IResult;
 ///            :effect (not (in ?x)) )
 ///     )"#;
 ///
-/// let (remainder, domain) = parse_domain(input).unwrap();
+/// let (remainder, domain) = parse_domain(input.into()).unwrap();
 ///
-/// assert_eq!(remainder, "");
+/// assert!(remainder.is_empty());
 /// assert_eq!(domain.name(), &Name::new("briefcase-world"));
 /// assert_eq!(domain.requirements().len(), 4);
 /// assert_eq!(domain.types().len(), 2);
@@ -60,7 +59,7 @@ use nom::IResult;
 /// assert!(domain.constraints().is_empty());
 /// assert_eq!(domain.structure().len(), 3);
 /// ```
-pub fn parse_domain(input: &str) -> IResult<&str, Domain> {
+pub fn parse_domain(input: Span) -> ParseResult<Domain> {
     map(
         ws(prefix_expr(
             "define",
@@ -115,7 +114,7 @@ impl<'a> crate::parsers::Parser<'a> for Domain<'a> {
     type Item = Domain<'a>;
 
     /// See [`parse_domain`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_domain(input)
     }
 }

--- a/src/parsers/domain.rs
+++ b/src/parsers/domain.rs
@@ -59,7 +59,7 @@ use nom::sequence::{preceded, tuple};
 /// assert!(domain.constraints().is_empty());
 /// assert_eq!(domain.structure().len(), 3);
 /// ```
-pub fn parse_domain<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Domain<'a>> {
+pub fn parse_domain<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Domain> {
     map(
         ws(prefix_expr(
             "define",
@@ -110,11 +110,11 @@ pub fn parse_domain<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Domain<'
     )(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for Domain<'a> {
-    type Item = Domain<'a>;
+impl crate::parsers::Parser for Domain {
+    type Item = Domain;
 
     /// See [`parse_domain`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_domain(input)
     }
 }

--- a/src/parsers/domain.rs
+++ b/src/parsers/domain.rs
@@ -114,7 +114,7 @@ impl<'a> crate::parsers::Parser<'a> for Domain<'a> {
     type Item = Domain<'a>;
 
     /// See [`parse_domain`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_domain(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_domain(input.into())
     }
 }

--- a/src/parsers/domain_constraints_def.rs
+++ b/src/parsers/domain_constraints_def.rs
@@ -28,7 +28,7 @@ impl<'a> crate::parsers::Parser<'a> for DomainConstraintsDef<'a> {
     type Item = DomainConstraintsDef<'a>;
 
     /// See [`parse_domain_constraints_def`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_domain_constraints_def(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_domain_constraints_def(input.into())
     }
 }

--- a/src/parsers/domain_constraints_def.rs
+++ b/src/parsers/domain_constraints_def.rs
@@ -13,15 +13,17 @@ use nom::combinator::map;
 /// # use pddl::{Type, Typed, TypedList};
 ///
 /// let input = "(:constraints (and))";
-/// assert!(parse_domain_constraints_def(input.into()).is_value(
+/// assert!(parse_domain_constraints_def(input).is_value(
 ///     DomainConstraintsDef::new(ConGD::new_and([]))
 /// ));
 /// ```
-pub fn parse_domain_constraints_def(input: Span) -> ParseResult<DomainConstraintsDef> {
+pub fn parse_domain_constraints_def<'a, T: Into<Span<'a>>>(
+    input: T,
+) -> ParseResult<'a, DomainConstraintsDef<'a>> {
     map(
         prefix_expr(":constraints", parse_con_gd),
         DomainConstraintsDef::new,
-    )(input)
+    )(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for DomainConstraintsDef<'a> {

--- a/src/parsers/domain_constraints_def.rs
+++ b/src/parsers/domain_constraints_def.rs
@@ -31,6 +31,6 @@ impl<'a> crate::parsers::Parser<'a> for DomainConstraintsDef<'a> {
 
     /// See [`parse_domain_constraints_def`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_domain_constraints_def(input.into())
+        parse_domain_constraints_def(input)
     }
 }

--- a/src/parsers/domain_constraints_def.rs
+++ b/src/parsers/domain_constraints_def.rs
@@ -1,24 +1,23 @@
 //! Provides parsers for domain constraint definitions.
 
-use crate::parsers::{parse_con_gd, prefix_expr};
+use crate::parsers::{parse_con_gd, prefix_expr, ParseResult, Span};
 use crate::types::DomainConstraintsDef;
 use nom::combinator::map;
-use nom::IResult;
 
 /// Parser that parses domain constraint definitions, i.e. `(:constraints <con-gd>)`.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::{parse_domain_constraints_def, parse_functions_def};
+/// # use pddl::parsers::{parse_domain_constraints_def, parse_functions_def, preamble::*};
 /// # use pddl::{Variable, AtomicFormulaSkeleton, Predicate, PredicateDefinitions, FunctionTypedList, FunctionTyped, AtomicFunctionSkeleton, FunctionSymbol, Functions, ConGD, DomainConstraintsDef};
 /// # use pddl::{Type, Typed, TypedList};
 ///
 /// let input = "(:constraints (and))";
-/// assert_eq!(parse_domain_constraints_def(input), Ok(("",
+/// assert!(parse_domain_constraints_def(input.into()).is_value(
 ///     DomainConstraintsDef::new(ConGD::new_and([]))
-/// )));
+/// ));
 /// ```
-pub fn parse_domain_constraints_def(input: &str) -> IResult<&str, DomainConstraintsDef> {
+pub fn parse_domain_constraints_def(input: Span) -> ParseResult<DomainConstraintsDef> {
     map(
         prefix_expr(":constraints", parse_con_gd),
         DomainConstraintsDef::new,
@@ -29,7 +28,7 @@ impl<'a> crate::parsers::Parser<'a> for DomainConstraintsDef<'a> {
     type Item = DomainConstraintsDef<'a>;
 
     /// See [`parse_domain_constraints_def`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_domain_constraints_def(input)
     }
 }

--- a/src/parsers/domain_constraints_def.rs
+++ b/src/parsers/domain_constraints_def.rs
@@ -19,18 +19,18 @@ use nom::combinator::map;
 /// ```
 pub fn parse_domain_constraints_def<'a, T: Into<Span<'a>>>(
     input: T,
-) -> ParseResult<'a, DomainConstraintsDef<'a>> {
+) -> ParseResult<'a, DomainConstraintsDef> {
     map(
         prefix_expr(":constraints", parse_con_gd),
         DomainConstraintsDef::new,
     )(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for DomainConstraintsDef<'a> {
-    type Item = DomainConstraintsDef<'a>;
+impl crate::parsers::Parser for DomainConstraintsDef {
+    type Item = DomainConstraintsDef;
 
     /// See [`parse_domain_constraints_def`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_domain_constraints_def(input)
     }
 }

--- a/src/parsers/duration_constraint.rs
+++ b/src/parsers/duration_constraint.rs
@@ -14,10 +14,10 @@ use nom::combinator::map;
 /// # use pddl::parsers::{parse_duration_constraint, preamble::*};
 /// # use pddl::{DOp, DurationConstraint, DurationValue, FunctionType, SimpleDurationConstraint, TimeSpecifier};
 /// let input = "()";
-/// assert!(parse_duration_constraint(input.into()).is_value(None));
+/// assert!(parse_duration_constraint(input).is_value(None));
 ///
 /// let input = "(= ?duration 5)";
-/// assert!(parse_duration_constraint(input.into()).is_value(
+/// assert!(parse_duration_constraint(input).is_value(
 ///     Some(DurationConstraint::new(
 ///         SimpleDurationConstraint::Op(
 ///             DOp::Equal,
@@ -27,7 +27,7 @@ use nom::combinator::map;
 /// ));
 ///
 /// let input = "(at end (<= ?duration 1.23))";
-/// assert!(parse_duration_constraint(input.into()).is_value(
+/// assert!(parse_duration_constraint(input).is_value(
 ///     Some(DurationConstraint::new(
 ///         SimpleDurationConstraint::new_at(
 ///             TimeSpecifier::End,
@@ -40,7 +40,7 @@ use nom::combinator::map;
 /// ));
 ///
 /// let input = "(and (at end (<= ?duration 1.23)) (>= ?duration 1.0))";
-/// assert!(parse_duration_constraint(input.into()).is_value(
+/// assert!(parse_duration_constraint(input).is_value(
 ///     Some(DurationConstraint::new_all([
 ///         SimpleDurationConstraint::new_at(
 ///             TimeSpecifier::End,
@@ -56,7 +56,9 @@ use nom::combinator::map;
 ///     ]))
 /// ));
 ///```
-pub fn parse_duration_constraint(input: Span) -> ParseResult<Option<DurationConstraint>> {
+pub fn parse_duration_constraint<'a, T: Into<Span<'a>>>(
+    input: T,
+) -> ParseResult<'a, Option<DurationConstraint<'a>>> {
     let none = map(tag("()"), |_| None);
     let simple = map(parse_simple_duration_constraint, |c| {
         Some(DurationConstraint::from(c))
@@ -71,7 +73,7 @@ pub fn parse_duration_constraint(input: Span) -> ParseResult<Option<DurationCons
         |cs| Some(DurationConstraint::from_iter(cs)),
     );
 
-    alt((none, simple, and))(input)
+    alt((none, simple, and))(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for DurationConstraint<'a> {

--- a/src/parsers/duration_constraint.rs
+++ b/src/parsers/duration_constraint.rs
@@ -78,7 +78,7 @@ impl<'a> crate::parsers::Parser<'a> for DurationConstraint<'a> {
     type Item = Option<DurationConstraint<'a>>;
 
     /// See [`parse_duration_constraint`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_duration_constraint(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_duration_constraint(input.into())
     }
 }

--- a/src/parsers/duration_constraint.rs
+++ b/src/parsers/duration_constraint.rs
@@ -58,7 +58,7 @@ use nom::combinator::map;
 ///```
 pub fn parse_duration_constraint<'a, T: Into<Span<'a>>>(
     input: T,
-) -> ParseResult<'a, Option<DurationConstraint<'a>>> {
+) -> ParseResult<'a, Option<DurationConstraint>> {
     let none = map(tag("()"), |_| None);
     let simple = map(parse_simple_duration_constraint, |c| {
         Some(DurationConstraint::from(c))
@@ -76,11 +76,11 @@ pub fn parse_duration_constraint<'a, T: Into<Span<'a>>>(
     alt((none, simple, and))(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for DurationConstraint<'a> {
-    type Item = Option<DurationConstraint<'a>>;
+impl crate::parsers::Parser for DurationConstraint {
+    type Item = Option<DurationConstraint>;
 
     /// See [`parse_duration_constraint`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_duration_constraint(input)
     }
 }

--- a/src/parsers/duration_constraint.rs
+++ b/src/parsers/duration_constraint.rs
@@ -81,6 +81,6 @@ impl<'a> crate::parsers::Parser<'a> for DurationConstraint<'a> {
 
     /// See [`parse_duration_constraint`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_duration_constraint(input.into())
+        parse_duration_constraint(input)
     }
 }

--- a/src/parsers/duration_constraint.rs
+++ b/src/parsers/duration_constraint.rs
@@ -1,34 +1,33 @@
 //! Provides parsers for duration constraints.
 
-use crate::parsers::parse_simple_duration_constraint;
+use crate::parsers::{parse_simple_duration_constraint, ParseResult, Span};
 use crate::parsers::{prefix_expr, space_separated_list1};
 use crate::types::DurationConstraint;
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::combinator::map;
-use nom::IResult;
 
 /// Parses a duration constraint.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_duration_constraint;
+/// # use pddl::parsers::{parse_duration_constraint, preamble::*};
 /// # use pddl::{DOp, DurationConstraint, DurationValue, FunctionType, SimpleDurationConstraint, TimeSpecifier};
 /// let input = "()";
-/// assert_eq!(parse_duration_constraint(input), Ok(("", None)));
+/// assert!(parse_duration_constraint(input.into()).is_value(None));
 ///
 /// let input = "(= ?duration 5)";
-/// assert_eq!(parse_duration_constraint(input), Ok(("",
+/// assert!(parse_duration_constraint(input.into()).is_value(
 ///     Some(DurationConstraint::new(
 ///         SimpleDurationConstraint::Op(
 ///             DOp::Equal,
 ///             DurationValue::Number(5.into())
 ///         )
 ///     ))
-/// )));
+/// ));
 ///
 /// let input = "(at end (<= ?duration 1.23))";
-/// assert_eq!(parse_duration_constraint(input), Ok(("",
+/// assert!(parse_duration_constraint(input.into()).is_value(
 ///     Some(DurationConstraint::new(
 ///         SimpleDurationConstraint::new_at(
 ///             TimeSpecifier::End,
@@ -38,10 +37,10 @@ use nom::IResult;
 ///             )
 ///         )
 ///     ))
-/// )));
+/// ));
 ///
 /// let input = "(and (at end (<= ?duration 1.23)) (>= ?duration 1.0))";
-/// assert_eq!(parse_duration_constraint(input), Ok(("",
+/// assert!(parse_duration_constraint(input.into()).is_value(
 ///     Some(DurationConstraint::new_all([
 ///         SimpleDurationConstraint::new_at(
 ///             TimeSpecifier::End,
@@ -55,9 +54,9 @@ use nom::IResult;
 ///             DurationValue::Number(1.0.into())
 ///         )
 ///     ]))
-/// )));
+/// ));
 ///```
-pub fn parse_duration_constraint(input: &str) -> IResult<&str, Option<DurationConstraint>> {
+pub fn parse_duration_constraint(input: Span) -> ParseResult<Option<DurationConstraint>> {
     let none = map(tag("()"), |_| None);
     let simple = map(parse_simple_duration_constraint, |c| {
         Some(DurationConstraint::from(c))
@@ -79,7 +78,7 @@ impl<'a> crate::parsers::Parser<'a> for DurationConstraint<'a> {
     type Item = Option<DurationConstraint<'a>>;
 
     /// See [`parse_duration_constraint`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_duration_constraint(input)
     }
 }

--- a/src/parsers/effects.rs
+++ b/src/parsers/effects.rs
@@ -1,19 +1,18 @@
 //! Provides parsers for effects.
 
-use crate::parsers::parse_c_effect;
+use crate::parsers::{parse_c_effect, ParseResult, Span};
 use crate::parsers::{prefix_expr, space_separated_list0};
 use crate::types::Effects;
 use nom::branch::alt;
 use nom::combinator::map;
-use nom::IResult;
 
 /// Parser for effects.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_effect;
+/// # use pddl::parsers::{parse_effect, preamble::*};
 /// # use pddl::{AtomicFormula, CEffect, Effects, EqualityAtomicFormula, PEffect, Term};
-/// assert_eq!(parse_effect("(= x y)"), Ok(("",
+/// assert!(parse_effect("(= x y)".into()).is_value(
 ///     Effects::new(
 ///         CEffect::Effect(
 ///             PEffect::AtomicFormula(AtomicFormula::Equality(
@@ -24,8 +23,8 @@ use nom::IResult;
 ///             )
 ///         )
 ///     )
-/// )));
-/// assert_eq!(parse_effect("(and (= x y) (not (= ?a B)))"), Ok(("",
+/// ));
+/// assert!(parse_effect("(and (= x y) (not (= ?a B)))".into()).is_value(
 ///     Effects::from_iter([
 ///         CEffect::Effect(
 ///             PEffect::AtomicFormula(AtomicFormula::Equality(
@@ -44,9 +43,9 @@ use nom::IResult;
 ///             )
 ///         )
 ///     ])
-/// )));
+/// ));
 /// ```
-pub fn parse_effect(input: &str) -> IResult<&str, Effects> {
+pub fn parse_effect<'a>(input: Span<'a>) -> ParseResult<'a, Effects> {
     let exactly = map(parse_c_effect, Effects::from);
     let all = map(
         prefix_expr("and", space_separated_list0(parse_c_effect)),
@@ -60,7 +59,7 @@ impl<'a> crate::parsers::Parser<'a> for Effects<'a> {
     type Item = Effects<'a>;
 
     /// See [`parse_effect`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_effect(input)
     }
 }

--- a/src/parsers/effects.rs
+++ b/src/parsers/effects.rs
@@ -60,6 +60,6 @@ impl<'a> crate::parsers::Parser<'a> for Effects<'a> {
 
     /// See [`parse_effect`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_effect(input.into())
+        parse_effect(input)
     }
 }

--- a/src/parsers/effects.rs
+++ b/src/parsers/effects.rs
@@ -12,7 +12,7 @@ use nom::combinator::map;
 /// ```
 /// # use pddl::parsers::{parse_effect, preamble::*};
 /// # use pddl::{AtomicFormula, CEffect, Effects, EqualityAtomicFormula, PEffect, Term};
-/// assert!(parse_effect("(= x y)".into()).is_value(
+/// assert!(parse_effect("(= x y)").is_value(
 ///     Effects::new(
 ///         CEffect::Effect(
 ///             PEffect::AtomicFormula(AtomicFormula::Equality(
@@ -24,7 +24,7 @@ use nom::combinator::map;
 ///         )
 ///     )
 /// ));
-/// assert!(parse_effect("(and (= x y) (not (= ?a B)))".into()).is_value(
+/// assert!(parse_effect("(and (= x y) (not (= ?a B)))").is_value(
 ///     Effects::from_iter([
 ///         CEffect::Effect(
 ///             PEffect::AtomicFormula(AtomicFormula::Equality(
@@ -45,14 +45,14 @@ use nom::combinator::map;
 ///     ])
 /// ));
 /// ```
-pub fn parse_effect<'a>(input: Span<'a>) -> ParseResult<'a, Effects> {
+pub fn parse_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Effects<'a>> {
     let exactly = map(parse_c_effect, Effects::from);
     let all = map(
         prefix_expr("and", space_separated_list0(parse_c_effect)),
         Effects::from,
     );
 
-    alt((exactly, all))(input)
+    alt((exactly, all))(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for Effects<'a> {

--- a/src/parsers/effects.rs
+++ b/src/parsers/effects.rs
@@ -59,7 +59,7 @@ impl<'a> crate::parsers::Parser<'a> for Effects<'a> {
     type Item = Effects<'a>;
 
     /// See [`parse_effect`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_effect(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_effect(input.into())
     }
 }

--- a/src/parsers/effects.rs
+++ b/src/parsers/effects.rs
@@ -45,7 +45,7 @@ use nom::combinator::map;
 ///     ])
 /// ));
 /// ```
-pub fn parse_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Effects<'a>> {
+pub fn parse_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Effects> {
     let exactly = map(parse_c_effect, Effects::from);
     let all = map(
         prefix_expr("and", space_separated_list0(parse_c_effect)),
@@ -55,11 +55,11 @@ pub fn parse_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Effects<
     alt((exactly, all))(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for Effects<'a> {
-    type Item = Effects<'a>;
+impl crate::parsers::Parser for Effects {
+    type Item = Effects;
 
     /// See [`parse_effect`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_effect(input)
     }
 }

--- a/src/parsers/empty_or.rs
+++ b/src/parsers/empty_or.rs
@@ -25,7 +25,7 @@ pub fn empty_or<'a, F, O, E: ParseError<Span<'a>>>(
 where
     F: FnMut(Span<'a>) -> ParseResult<'a, O, E>,
 {
-    let empty_parser = map(tag("()"), |_: Span<'a>| None);
+    let empty_parser = map(tag("()"), |_: Span| None);
     let inner_parser = map(inner, |o: O| Some(o));
 
     alt((empty_parser, inner_parser))

--- a/src/parsers/f_assign_da.rs
+++ b/src/parsers/f_assign_da.rs
@@ -12,9 +12,9 @@ use nom::sequence::{preceded, tuple};
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_f_assign_da;
-/// assert!(parse_f_assign_da("(assign fun-sym ?duration)".into()).is_ok());
+/// assert!(parse_f_assign_da("(assign fun-sym ?duration)").is_ok());
 ///```
-pub fn parse_f_assign_da(input: Span) -> ParseResult<FAssignDa> {
+pub fn parse_f_assign_da<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FAssignDa<'a>> {
     map(
         parens(tuple((
             parse_assign_op,
@@ -22,7 +22,7 @@ pub fn parse_f_assign_da(input: Span) -> ParseResult<FAssignDa> {
             preceded(multispace1, parse_f_exp_da),
         ))),
         FAssignDa::from,
-    )(input)
+    )(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for FAssignDa<'a> {

--- a/src/parsers/f_assign_da.rs
+++ b/src/parsers/f_assign_da.rs
@@ -30,7 +30,7 @@ impl<'a> crate::parsers::Parser<'a> for FAssignDa<'a> {
 
     /// See [`parse_f_assign_da`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_f_assign_da(input.into())
+        parse_f_assign_da(input)
     }
 }
 

--- a/src/parsers/f_assign_da.rs
+++ b/src/parsers/f_assign_da.rs
@@ -14,7 +14,7 @@ use nom::sequence::{preceded, tuple};
 /// # use pddl::parsers::parse_f_assign_da;
 /// assert!(parse_f_assign_da("(assign fun-sym ?duration)").is_ok());
 ///```
-pub fn parse_f_assign_da<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FAssignDa<'a>> {
+pub fn parse_f_assign_da<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FAssignDa> {
     map(
         parens(tuple((
             parse_assign_op,
@@ -25,11 +25,11 @@ pub fn parse_f_assign_da<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FAs
     )(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for FAssignDa<'a> {
-    type Item = FAssignDa<'a>;
+impl crate::parsers::Parser for FAssignDa {
+    type Item = FAssignDa;
 
     /// See [`parse_f_assign_da`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_f_assign_da(input)
     }
 }

--- a/src/parsers/f_assign_da.rs
+++ b/src/parsers/f_assign_da.rs
@@ -1,21 +1,20 @@
 //! Provides parsers for f-assign-das.
 
-use crate::parsers::parens;
+use crate::parsers::{parens, ParseResult, Span};
 use crate::parsers::{parse_assign_op, parse_f_exp_da, parse_f_head};
 use crate::types::FAssignDa;
 use nom::character::complete::multispace1;
 use nom::combinator::map;
 use nom::sequence::{preceded, tuple};
-use nom::IResult;
 
 /// Parses an f-assign-da.
 ///
 /// ## Example
 /// ```
 /// # use pddl::parsers::parse_f_assign_da;
-/// assert!(parse_f_assign_da("(assign fun-sym ?duration)").is_ok());
+/// assert!(parse_f_assign_da("(assign fun-sym ?duration)".into()).is_ok());
 ///```
-pub fn parse_f_assign_da(input: &str) -> IResult<&str, FAssignDa> {
+pub fn parse_f_assign_da(input: Span) -> ParseResult<FAssignDa> {
     map(
         parens(tuple((
             parse_assign_op,
@@ -30,7 +29,7 @@ impl<'a> crate::parsers::Parser<'a> for FAssignDa<'a> {
     type Item = FAssignDa<'a>;
 
     /// See [`parse_f_assign_da`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_f_assign_da(input)
     }
 }
@@ -42,6 +41,6 @@ mod tests {
     #[test]
     fn it_works() {
         let input = "(increase (distance-travelled) 5)";
-        let (_, _effect) = parse_f_assign_da(input).unwrap();
+        let (_, _effect) = parse_f_assign_da(Span::new(input)).unwrap();
     }
 }

--- a/src/parsers/f_assign_da.rs
+++ b/src/parsers/f_assign_da.rs
@@ -29,8 +29,8 @@ impl<'a> crate::parsers::Parser<'a> for FAssignDa<'a> {
     type Item = FAssignDa<'a>;
 
     /// See [`parse_f_assign_da`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_f_assign_da(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_f_assign_da(input.into())
     }
 }
 

--- a/src/parsers/f_comp.rs
+++ b/src/parsers/f_comp.rs
@@ -44,7 +44,7 @@ impl<'a> crate::parsers::Parser<'a> for FComp<'a> {
     type Item = FComp<'a>;
 
     /// See [`parse_f_comp`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_f_comp(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_f_comp(input.into())
     }
 }

--- a/src/parsers/f_comp.rs
+++ b/src/parsers/f_comp.rs
@@ -1,20 +1,19 @@
 //! Provides parsers for f-comps.
 
-use crate::parsers::parens;
+use crate::parsers::{parens, ParseResult, Span};
 use crate::parsers::{parse_binary_comp, parse_f_exp};
 use crate::types::FComp;
 use nom::character::complete::multispace1;
 use nom::combinator::map;
 use nom::sequence::{preceded, tuple};
-use nom::IResult;
 
 /// Parses an f-comp.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_f_comp;
+/// # use pddl::parsers::{parse_f_comp, preamble::*};
 /// # use pddl::{FunctionTerm, Variable, FunctionSymbol, Term, FComp, BinaryComp, FExp, BinaryOp};
-/// assert_eq!(parse_f_comp("(= (+ 1.23 2.34) (+ 1.23 2.34))"), Ok(("",
+/// assert!(parse_f_comp("(= (+ 1.23 2.34) (+ 1.23 2.34))".into()).is_value(
 ///     FComp::new(
 ///         BinaryComp::Equal,
 ///         FExp::new_binary_op(
@@ -28,9 +27,9 @@ use nom::IResult;
 ///             FExp::new_number(2.34),
 ///         )
 ///     )
-/// )));
+/// ));
 ///```
-pub fn parse_f_comp(input: &str) -> IResult<&str, FComp> {
+pub fn parse_f_comp(input: Span) -> ParseResult<FComp> {
     map(
         parens(tuple((
             parse_binary_comp,
@@ -45,7 +44,7 @@ impl<'a> crate::parsers::Parser<'a> for FComp<'a> {
     type Item = FComp<'a>;
 
     /// See [`parse_f_comp`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_f_comp(input)
     }
 }

--- a/src/parsers/f_comp.rs
+++ b/src/parsers/f_comp.rs
@@ -45,6 +45,6 @@ impl<'a> crate::parsers::Parser<'a> for FComp<'a> {
 
     /// See [`parse_f_comp`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_f_comp(input.into())
+        parse_f_comp(input)
     }
 }

--- a/src/parsers/f_comp.rs
+++ b/src/parsers/f_comp.rs
@@ -13,7 +13,7 @@ use nom::sequence::{preceded, tuple};
 /// ```
 /// # use pddl::parsers::{parse_f_comp, preamble::*};
 /// # use pddl::{FunctionTerm, Variable, FunctionSymbol, Term, FComp, BinaryComp, FExp, BinaryOp};
-/// assert!(parse_f_comp("(= (+ 1.23 2.34) (+ 1.23 2.34))".into()).is_value(
+/// assert!(parse_f_comp("(= (+ 1.23 2.34) (+ 1.23 2.34))").is_value(
 ///     FComp::new(
 ///         BinaryComp::Equal,
 ///         FExp::new_binary_op(
@@ -29,7 +29,7 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 ///```
-pub fn parse_f_comp(input: Span) -> ParseResult<FComp> {
+pub fn parse_f_comp<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FComp<'a>> {
     map(
         parens(tuple((
             parse_binary_comp,
@@ -37,7 +37,7 @@ pub fn parse_f_comp(input: Span) -> ParseResult<FComp> {
             preceded(multispace1, parse_f_exp),
         ))),
         FComp::from,
-    )(input)
+    )(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for FComp<'a> {

--- a/src/parsers/f_comp.rs
+++ b/src/parsers/f_comp.rs
@@ -29,7 +29,7 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 ///```
-pub fn parse_f_comp<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FComp<'a>> {
+pub fn parse_f_comp<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FComp> {
     map(
         parens(tuple((
             parse_binary_comp,
@@ -40,11 +40,11 @@ pub fn parse_f_comp<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FComp<'a
     )(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for FComp<'a> {
-    type Item = FComp<'a>;
+impl crate::parsers::Parser for FComp {
+    type Item = FComp;
 
     /// See [`parse_f_comp`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_f_comp(input)
     }
 }

--- a/src/parsers/f_exp.rs
+++ b/src/parsers/f_exp.rs
@@ -14,11 +14,11 @@ use nom::sequence::{preceded, tuple};
 /// ```
 /// # use pddl::parsers::{parse_f_exp, preamble::*};
 /// # use pddl::{BinaryOp, FExp, FHead, FunctionSymbol, MultiOp};
-/// assert!(parse_f_exp("1.23".into()).is_value(
+/// assert!(parse_f_exp("1.23").is_value(
 ///     FExp::new_number(1.23)
 /// ));
 ///
-/// assert!(parse_f_exp("(+ 1.23 2.34)".into()).is_value(
+/// assert!(parse_f_exp("(+ 1.23 2.34)").is_value(
 ///     FExp::new_binary_op(
 ///         BinaryOp::Addition,
 ///         FExp::new_number(1.23),
@@ -26,7 +26,7 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 ///
-/// assert!(parse_f_exp("(+ 1.23 2.34 3.45)".into()).is_value(
+/// assert!(parse_f_exp("(+ 1.23 2.34 3.45)").is_value(
 ///     FExp::new_multi_op(
 ///         MultiOp::Addition,
 ///         FExp::new_number(1.23),
@@ -34,17 +34,17 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 ///
-/// assert!(parse_f_exp("(- 1.23)".into()).is_value(
+/// assert!(parse_f_exp("(- 1.23)").is_value(
 ///     FExp::new_negative(FExp::new_number(1.23))
 /// ));
 ///
-/// assert!(parse_f_exp("fun-sym".into()).is_value(
+/// assert!(parse_f_exp("fun-sym").is_value(
 ///     FExp::new_function(
 ///         FHead::new(FunctionSymbol::from_str("fun-sym"))
 ///     )
 /// ));
 ///```
-pub fn parse_f_exp(input: Span) -> ParseResult<FExp> {
+pub fn parse_f_exp<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FExp<'a>> {
     // :numeric-fluents
     let number = map(parse_number, FExp::new_number);
 
@@ -77,7 +77,7 @@ pub fn parse_f_exp(input: Span) -> ParseResult<FExp> {
     // :numeric-fluents
     let f_head = map(parse_f_head, FExp::new_function);
 
-    alt((number, binary_op, multi_op, negated, f_head))(input)
+    alt((number, binary_op, multi_op, negated, f_head))(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for FExp<'a> {

--- a/src/parsers/f_exp.rs
+++ b/src/parsers/f_exp.rs
@@ -85,6 +85,6 @@ impl<'a> crate::parsers::Parser<'a> for FExp<'a> {
 
     /// See [`parse_f_exp`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_f_exp(input.into())
+        parse_f_exp(input)
     }
 }

--- a/src/parsers/f_exp.rs
+++ b/src/parsers/f_exp.rs
@@ -44,7 +44,7 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 ///```
-pub fn parse_f_exp<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FExp<'a>> {
+pub fn parse_f_exp<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FExp> {
     // :numeric-fluents
     let number = map(parse_number, FExp::new_number);
 
@@ -80,11 +80,11 @@ pub fn parse_f_exp<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FExp<'a>>
     alt((number, binary_op, multi_op, negated, f_head))(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for FExp<'a> {
-    type Item = FExp<'a>;
+impl crate::parsers::Parser for FExp {
+    type Item = FExp;
 
     /// See [`parse_f_exp`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_f_exp(input)
     }
 }

--- a/src/parsers/f_exp.rs
+++ b/src/parsers/f_exp.rs
@@ -84,7 +84,7 @@ impl<'a> crate::parsers::Parser<'a> for FExp<'a> {
     type Item = FExp<'a>;
 
     /// See [`parse_f_exp`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_f_exp(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_f_exp(input.into())
     }
 }

--- a/src/parsers/f_exp.rs
+++ b/src/parsers/f_exp.rs
@@ -1,51 +1,50 @@
 //! Provides parsers for f-exps.
 
-use crate::parsers::{parens, parse_number, space_separated_list1};
+use crate::parsers::{parens, parse_number, space_separated_list1, ParseResult, Span};
 use crate::parsers::{parse_binary_op, parse_f_head, parse_multi_op};
 use crate::types::FExp;
 use nom::branch::alt;
 use nom::character::complete::{char, multispace0, multispace1};
 use nom::combinator::map;
 use nom::sequence::{preceded, tuple};
-use nom::IResult;
 
 /// Parses an f-exp.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_f_exp;
+/// # use pddl::parsers::{parse_f_exp, preamble::*};
 /// # use pddl::{BinaryOp, FExp, FHead, FunctionSymbol, MultiOp};
-/// assert_eq!(parse_f_exp("1.23"), Ok(("",
+/// assert!(parse_f_exp("1.23".into()).is_value(
 ///     FExp::new_number(1.23)
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_f_exp("(+ 1.23 2.34)"), Ok(("",
+/// assert!(parse_f_exp("(+ 1.23 2.34)".into()).is_value(
 ///     FExp::new_binary_op(
 ///         BinaryOp::Addition,
 ///         FExp::new_number(1.23),
 ///         FExp::new_number(2.34)
 ///     )
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_f_exp("(+ 1.23 2.34 3.45)"), Ok(("",
+/// assert!(parse_f_exp("(+ 1.23 2.34 3.45)".into()).is_value(
 ///     FExp::new_multi_op(
 ///         MultiOp::Addition,
 ///         FExp::new_number(1.23),
 ///         [FExp::new_number(2.34), FExp::new_number(3.45)]
 ///     )
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_f_exp("(- 1.23)"), Ok(("",
+/// assert!(parse_f_exp("(- 1.23)".into()).is_value(
 ///     FExp::new_negative(FExp::new_number(1.23))
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_f_exp("fun-sym"), Ok(("",
+/// assert!(parse_f_exp("fun-sym".into()).is_value(
 ///     FExp::new_function(
 ///         FHead::new(FunctionSymbol::from_str("fun-sym"))
 ///     )
-/// )));
+/// ));
 ///```
-pub fn parse_f_exp(input: &str) -> IResult<&str, FExp> {
+pub fn parse_f_exp(input: Span) -> ParseResult<FExp> {
     // :numeric-fluents
     let number = map(parse_number, FExp::new_number);
 
@@ -85,7 +84,7 @@ impl<'a> crate::parsers::Parser<'a> for FExp<'a> {
     type Item = FExp<'a>;
 
     /// See [`parse_f_exp`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_f_exp(input)
     }
 }

--- a/src/parsers/f_exp_da.rs
+++ b/src/parsers/f_exp_da.rs
@@ -1,6 +1,6 @@
 //! Provides parsers for f-exp-da values..
 
-use crate::parsers::{parens, space_separated_list1};
+use crate::parsers::{parens, space_separated_list1, ParseResult, Span};
 use crate::parsers::{parse_binary_op, parse_f_exp, parse_multi_op};
 use crate::types::FExpDa;
 use nom::branch::alt;
@@ -8,35 +8,34 @@ use nom::bytes::complete::tag;
 use nom::character::complete::{char, multispace0, multispace1};
 use nom::combinator::map;
 use nom::sequence::{preceded, tuple};
-use nom::IResult;
 
 /// Parses an f-exp-da.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_f_exp_da;
+/// # use pddl::parsers::{parse_f_exp_da, preamble::*};
 /// # use pddl::{BinaryOp, FExpDa, FExp, FunctionSymbol, MultiOp};
-/// assert_eq!(parse_f_exp_da("?duration"), Ok(("",
+/// assert!(parse_f_exp_da("?duration".into()).is_value(
 ///     FExpDa::Duration
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_f_exp_da("(+ 1.23 2.34)"), Ok(("",
+/// assert!(parse_f_exp_da("(+ 1.23 2.34)".into()).is_value(
 ///     FExpDa::new_binary_op(
 ///         BinaryOp::Addition,
 ///             FExpDa::new_f_exp(FExp::new_number(1.23)),
 ///             FExpDa::new_f_exp(FExp::new_number(2.34))
 ///     )
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_f_exp_da("(+ 1.23 2.34 3.45)"), Ok(("",
+/// assert!(parse_f_exp_da("(+ 1.23 2.34 3.45)".into()).is_value(
 ///     FExpDa::new_multi_op(
 ///         MultiOp::Addition,
 ///         FExpDa::new_f_exp(FExp::new_number(1.23)),
 ///         [FExp::new_number(2.34).into(), FExp::new_number(3.45).into()]
 ///     )
-/// )));
+/// ));
 ///```
-pub fn parse_f_exp_da(input: &str) -> IResult<&str, FExpDa> {
+pub fn parse_f_exp_da(input: Span) -> ParseResult<FExpDa> {
     // :duration-inequalities
     let duration = map(tag("?duration"), |_| FExpDa::new_duration());
 
@@ -72,7 +71,7 @@ impl<'a> crate::parsers::Parser<'a> for FExpDa<'a> {
     type Item = FExpDa<'a>;
 
     /// See [`parse_f_exp_da`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_f_exp_da(input)
     }
 }

--- a/src/parsers/f_exp_da.rs
+++ b/src/parsers/f_exp_da.rs
@@ -71,7 +71,7 @@ impl<'a> crate::parsers::Parser<'a> for FExpDa<'a> {
     type Item = FExpDa<'a>;
 
     /// See [`parse_f_exp_da`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_f_exp_da(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_f_exp_da(input.into())
     }
 }

--- a/src/parsers/f_exp_da.rs
+++ b/src/parsers/f_exp_da.rs
@@ -15,11 +15,11 @@ use nom::sequence::{preceded, tuple};
 /// ```
 /// # use pddl::parsers::{parse_f_exp_da, preamble::*};
 /// # use pddl::{BinaryOp, FExpDa, FExp, FunctionSymbol, MultiOp};
-/// assert!(parse_f_exp_da("?duration".into()).is_value(
+/// assert!(parse_f_exp_da("?duration").is_value(
 ///     FExpDa::Duration
 /// ));
 ///
-/// assert!(parse_f_exp_da("(+ 1.23 2.34)".into()).is_value(
+/// assert!(parse_f_exp_da("(+ 1.23 2.34)").is_value(
 ///     FExpDa::new_binary_op(
 ///         BinaryOp::Addition,
 ///             FExpDa::new_f_exp(FExp::new_number(1.23)),
@@ -27,7 +27,7 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 ///
-/// assert!(parse_f_exp_da("(+ 1.23 2.34 3.45)".into()).is_value(
+/// assert!(parse_f_exp_da("(+ 1.23 2.34 3.45)").is_value(
 ///     FExpDa::new_multi_op(
 ///         MultiOp::Addition,
 ///         FExpDa::new_f_exp(FExp::new_number(1.23)),
@@ -35,7 +35,7 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 ///```
-pub fn parse_f_exp_da(input: Span) -> ParseResult<FExpDa> {
+pub fn parse_f_exp_da<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FExpDa<'a>> {
     // :duration-inequalities
     let duration = map(tag("?duration"), |_| FExpDa::new_duration());
 
@@ -64,7 +64,7 @@ pub fn parse_f_exp_da(input: Span) -> ParseResult<FExpDa> {
 
     let f_exp = map(parse_f_exp, FExpDa::new_f_exp);
 
-    alt((duration, binary_op, multi_op, negated, f_exp))(input)
+    alt((duration, binary_op, multi_op, negated, f_exp))(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for FExpDa<'a> {

--- a/src/parsers/f_exp_da.rs
+++ b/src/parsers/f_exp_da.rs
@@ -72,6 +72,6 @@ impl<'a> crate::parsers::Parser<'a> for FExpDa<'a> {
 
     /// See [`parse_f_exp_da`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_f_exp_da(input.into())
+        parse_f_exp_da(input)
     }
 }

--- a/src/parsers/f_exp_da.rs
+++ b/src/parsers/f_exp_da.rs
@@ -35,7 +35,7 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 ///```
-pub fn parse_f_exp_da<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FExpDa<'a>> {
+pub fn parse_f_exp_da<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FExpDa> {
     // :duration-inequalities
     let duration = map(tag("?duration"), |_| FExpDa::new_duration());
 
@@ -67,11 +67,11 @@ pub fn parse_f_exp_da<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FExpDa
     alt((duration, binary_op, multi_op, negated, f_exp))(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for FExpDa<'a> {
-    type Item = FExpDa<'a>;
+impl crate::parsers::Parser for FExpDa {
+    type Item = FExpDa;
 
     /// See [`parse_f_exp_da`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_f_exp_da(input)
     }
 }

--- a/src/parsers/f_exp_t.rs
+++ b/src/parsers/f_exp_t.rs
@@ -59,7 +59,7 @@ impl<'a> crate::parsers::Parser<'a> for FExpT<'a> {
     type Item = FExpT<'a>;
 
     /// See [`parse_f_exp_t`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_f_exp_t(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_f_exp_t(input.into())
     }
 }

--- a/src/parsers/f_exp_t.rs
+++ b/src/parsers/f_exp_t.rs
@@ -15,9 +15,9 @@ use nom::sequence::{preceded, terminated, tuple};
 /// ```
 /// # use pddl::parsers::{parse_f_exp, parse_f_exp_t, preamble::*};
 /// # use pddl::{BinaryOp, FExp, FExpT, FHead, FunctionSymbol, MultiOp, Term, Variable};
-/// assert!(parse_f_exp_t("#t".into()).is_value(FExpT::Now));
+/// assert!(parse_f_exp_t("#t").is_value(FExpT::Now));
 ///
-/// assert!(parse_f_exp_t("(* (fuel ?tank) #t)".into()).is_value(
+/// assert!(parse_f_exp_t("(* (fuel ?tank) #t)").is_value(
 ///     FExpT::new_scaled(
 ///         FExp::new_function(
 ///             FHead::new_with_terms(
@@ -28,7 +28,7 @@ use nom::sequence::{preceded, terminated, tuple};
 ///     )
 /// ));
 ///
-/// assert!(parse_f_exp_t("(* #t (fuel ?tank))".into()).is_value(
+/// assert!(parse_f_exp_t("(* #t (fuel ?tank))").is_value(
 ///     FExpT::new_scaled(
 ///         FExp::new_function(
 ///             FHead::new_with_terms(
@@ -39,7 +39,7 @@ use nom::sequence::{preceded, terminated, tuple};
 ///     )
 /// ));
 ///```
-pub fn parse_f_exp_t(input: Span) -> ParseResult<FExpT> {
+pub fn parse_f_exp_t<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FExpT<'a>> {
     let now = map(tag("#t"), |_| FExpT::new());
     let scaled = map(
         prefix_expr(
@@ -52,7 +52,7 @@ pub fn parse_f_exp_t(input: Span) -> ParseResult<FExpT> {
         FExpT::new_scaled,
     );
 
-    alt((scaled, now))(input)
+    alt((scaled, now))(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for FExpT<'a> {

--- a/src/parsers/f_exp_t.rs
+++ b/src/parsers/f_exp_t.rs
@@ -60,6 +60,6 @@ impl<'a> crate::parsers::Parser<'a> for FExpT<'a> {
 
     /// See [`parse_f_exp_t`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_f_exp_t(input.into())
+        parse_f_exp_t(input)
     }
 }

--- a/src/parsers/f_exp_t.rs
+++ b/src/parsers/f_exp_t.rs
@@ -39,7 +39,7 @@ use nom::sequence::{preceded, terminated, tuple};
 ///     )
 /// ));
 ///```
-pub fn parse_f_exp_t<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FExpT<'a>> {
+pub fn parse_f_exp_t<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FExpT> {
     let now = map(tag("#t"), |_| FExpT::new());
     let scaled = map(
         prefix_expr(
@@ -55,11 +55,11 @@ pub fn parse_f_exp_t<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FExpT<'
     alt((scaled, now))(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for FExpT<'a> {
-    type Item = FExpT<'a>;
+impl crate::parsers::Parser for FExpT {
+    type Item = FExpT;
 
     /// See [`parse_f_exp_t`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_f_exp_t(input)
     }
 }

--- a/src/parsers/f_exp_t.rs
+++ b/src/parsers/f_exp_t.rs
@@ -1,24 +1,23 @@
 //! Provides parsers for f-exps.
 
-use crate::parsers::parse_f_exp;
 use crate::parsers::prefix_expr;
+use crate::parsers::{parse_f_exp, ParseResult, Span};
 use crate::types::FExpT;
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::character::complete::multispace1;
 use nom::combinator::map;
 use nom::sequence::{preceded, terminated, tuple};
-use nom::IResult;
 
 /// Parses an f-exp-t.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::{parse_f_exp, parse_f_exp_t};
+/// # use pddl::parsers::{parse_f_exp, parse_f_exp_t, preamble::*};
 /// # use pddl::{BinaryOp, FExp, FExpT, FHead, FunctionSymbol, MultiOp, Term, Variable};
-/// assert_eq!(parse_f_exp_t("#t"), Ok(("", FExpT::Now)));
+/// assert!(parse_f_exp_t("#t".into()).is_value(FExpT::Now));
 ///
-/// assert_eq!(parse_f_exp_t("(* (fuel ?tank) #t)"), Ok(("",
+/// assert!(parse_f_exp_t("(* (fuel ?tank) #t)".into()).is_value(
 ///     FExpT::new_scaled(
 ///         FExp::new_function(
 ///             FHead::new_with_terms(
@@ -27,9 +26,9 @@ use nom::IResult;
 ///             )
 ///         )
 ///     )
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_f_exp_t("(* #t (fuel ?tank))"), Ok(("",
+/// assert!(parse_f_exp_t("(* #t (fuel ?tank))".into()).is_value(
 ///     FExpT::new_scaled(
 ///         FExp::new_function(
 ///             FHead::new_with_terms(
@@ -38,9 +37,9 @@ use nom::IResult;
 ///             )
 ///         )
 ///     )
-/// )));
+/// ));
 ///```
-pub fn parse_f_exp_t(input: &str) -> IResult<&str, FExpT> {
+pub fn parse_f_exp_t(input: Span) -> ParseResult<FExpT> {
     let now = map(tag("#t"), |_| FExpT::new());
     let scaled = map(
         prefix_expr(
@@ -60,7 +59,7 @@ impl<'a> crate::parsers::Parser<'a> for FExpT<'a> {
     type Item = FExpT<'a>;
 
     /// See [`parse_f_exp_t`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_f_exp_t(input)
     }
 }

--- a/src/parsers/f_head.rs
+++ b/src/parsers/f_head.rs
@@ -1,35 +1,34 @@
 //! Provides parsers for f-heads.
 
-use crate::parsers::{parens, space_separated_list0};
+use crate::parsers::{parens, space_separated_list0, ParseResult, Span};
 use crate::parsers::{parse_function_symbol, parse_term};
 use crate::types::FHead;
 use nom::branch::alt;
 use nom::character::complete::multispace1;
 use nom::combinator::map;
 use nom::sequence::{preceded, tuple};
-use nom::IResult;
 
 /// Parses an f-head.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_f_head;
+/// # use pddl::parsers::{parse_f_head, preamble::*};
 /// # use pddl::{FunctionTerm, Variable, FunctionSymbol, Term, FHead};
-/// assert_eq!(parse_f_head("fun-sym"), Ok(("",
+/// assert!(parse_f_head("fun-sym".into()).is_value(
 ///     FHead::new(FunctionSymbol::from_str("fun-sym"))
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_f_head("(fun-sym)"), Ok(("",
+/// assert!(parse_f_head("(fun-sym)".into()).is_value(
 ///     FHead::new(FunctionSymbol::from_str("fun-sym"))
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_f_head("(fun-sym term)"), Ok(("",
+/// assert!(parse_f_head("(fun-sym term)".into()).is_value(
 ///     FHead::new_with_terms(FunctionSymbol::from_str("fun-sym"), [
 ///         Term::Name("term".into())
 ///     ])
-/// )));
+/// ));
 ///```
-pub fn parse_f_head(input: &str) -> IResult<&str, FHead> {
+pub fn parse_f_head(input: Span) -> ParseResult<FHead> {
     let simple = map(parse_function_symbol, FHead::new);
     let simple_parens = map(parens(parse_function_symbol), FHead::new);
     let with_terms = map(
@@ -47,7 +46,7 @@ impl<'a> crate::parsers::Parser<'a> for FHead<'a> {
     type Item = FHead<'a>;
 
     /// See [`parse_f_head`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_f_head(input)
     }
 }

--- a/src/parsers/f_head.rs
+++ b/src/parsers/f_head.rs
@@ -47,6 +47,6 @@ impl<'a> crate::parsers::Parser<'a> for FHead<'a> {
 
     /// See [`parse_f_head`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_f_head(input.into())
+        parse_f_head(input)
     }
 }

--- a/src/parsers/f_head.rs
+++ b/src/parsers/f_head.rs
@@ -14,21 +14,21 @@ use nom::sequence::{preceded, tuple};
 /// ```
 /// # use pddl::parsers::{parse_f_head, preamble::*};
 /// # use pddl::{FunctionTerm, Variable, FunctionSymbol, Term, FHead};
-/// assert!(parse_f_head("fun-sym".into()).is_value(
+/// assert!(parse_f_head("fun-sym").is_value(
 ///     FHead::new(FunctionSymbol::from_str("fun-sym"))
 /// ));
 ///
-/// assert!(parse_f_head("(fun-sym)".into()).is_value(
+/// assert!(parse_f_head("(fun-sym)").is_value(
 ///     FHead::new(FunctionSymbol::from_str("fun-sym"))
 /// ));
 ///
-/// assert!(parse_f_head("(fun-sym term)".into()).is_value(
+/// assert!(parse_f_head("(fun-sym term)").is_value(
 ///     FHead::new_with_terms(FunctionSymbol::from_str("fun-sym"), [
 ///         Term::Name("term".into())
 ///     ])
 /// ));
 ///```
-pub fn parse_f_head(input: Span) -> ParseResult<FHead> {
+pub fn parse_f_head<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FHead<'a>> {
     let simple = map(parse_function_symbol, FHead::new);
     let simple_parens = map(parens(parse_function_symbol), FHead::new);
     let with_terms = map(
@@ -39,7 +39,7 @@ pub fn parse_f_head(input: Span) -> ParseResult<FHead> {
         |(symbol, terms)| FHead::new_with_terms(symbol, terms),
     );
 
-    alt((simple, simple_parens, with_terms))(input)
+    alt((simple, simple_parens, with_terms))(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for FHead<'a> {

--- a/src/parsers/f_head.rs
+++ b/src/parsers/f_head.rs
@@ -46,7 +46,7 @@ impl<'a> crate::parsers::Parser<'a> for FHead<'a> {
     type Item = FHead<'a>;
 
     /// See [`parse_f_head`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_f_head(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_f_head(input.into())
     }
 }

--- a/src/parsers/f_head.rs
+++ b/src/parsers/f_head.rs
@@ -28,7 +28,7 @@ use nom::sequence::{preceded, tuple};
 ///     ])
 /// ));
 ///```
-pub fn parse_f_head<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FHead<'a>> {
+pub fn parse_f_head<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FHead> {
     let simple = map(parse_function_symbol, FHead::new);
     let simple_parens = map(parens(parse_function_symbol), FHead::new);
     let with_terms = map(
@@ -42,11 +42,11 @@ pub fn parse_f_head<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FHead<'a
     alt((simple, simple_parens, with_terms))(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for FHead<'a> {
-    type Item = FHead<'a>;
+impl crate::parsers::Parser for FHead {
+    type Item = FHead;
 
     /// See [`parse_f_head`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_f_head(input)
     }
 }

--- a/src/parsers/function_symbol.rs
+++ b/src/parsers/function_symbol.rs
@@ -31,6 +31,6 @@ impl<'a> crate::parsers::Parser<'a> for FunctionSymbol<'a> {
 
     /// See [`parse_function_symbol`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_function_symbol(input.into())
+        parse_function_symbol(input)
     }
 }

--- a/src/parsers/function_symbol.rs
+++ b/src/parsers/function_symbol.rs
@@ -8,18 +8,20 @@ use crate::types::FunctionSymbol;
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_function_symbol, preamble::*};
-/// assert!(parse_function_symbol("abcde".into()).is_value("abcde".into()));
-/// assert!(parse_function_symbol("a-1_2".into()).is_value("a-1_2".into()));
-/// assert!(parse_function_symbol("Z01".into()).is_value("Z01".into()));
-/// assert!(parse_function_symbol("x-_-_".into()).is_value("x-_-_".into()));
+/// assert!(parse_function_symbol("abcde").is_value("abcde".into()));
+/// assert!(parse_function_symbol("a-1_2").is_value("a-1_2".into()));
+/// assert!(parse_function_symbol("Z01").is_value("Z01".into()));
+/// assert!(parse_function_symbol("x-_-_").is_value("x-_-_".into()));
 ///
-/// assert!(parse_function_symbol("".into()).is_err());
-/// assert!(parse_function_symbol(".".into()).is_err());
-/// assert!(parse_function_symbol("-abc".into()).is_err());
-/// assert!(parse_function_symbol("0124".into()).is_err());
-/// assert!(parse_function_symbol("-1".into()).is_err());
+/// assert!(parse_function_symbol("").is_err());
+/// assert!(parse_function_symbol(".").is_err());
+/// assert!(parse_function_symbol("-abc").is_err());
+/// assert!(parse_function_symbol("0124").is_err());
+/// assert!(parse_function_symbol("-1").is_err());
 ///```
-pub fn parse_function_symbol(input: Span) -> ParseResult<FunctionSymbol> {
+pub fn parse_function_symbol<'a, T: Into<Span<'a>>>(
+    input: T,
+) -> ParseResult<'a, FunctionSymbol<'a>> {
     let (remaining, name) = parse_name(input)?;
     Ok((remaining, name.into()))
 }

--- a/src/parsers/function_symbol.rs
+++ b/src/parsers/function_symbol.rs
@@ -28,7 +28,7 @@ impl<'a> crate::parsers::Parser<'a> for FunctionSymbol<'a> {
     type Item = FunctionSymbol<'a>;
 
     /// See [`parse_function_symbol`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_function_symbol(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_function_symbol(input.into())
     }
 }

--- a/src/parsers/function_symbol.rs
+++ b/src/parsers/function_symbol.rs
@@ -19,18 +19,16 @@ use crate::types::FunctionSymbol;
 /// assert!(parse_function_symbol("0124").is_err());
 /// assert!(parse_function_symbol("-1").is_err());
 ///```
-pub fn parse_function_symbol<'a, T: Into<Span<'a>>>(
-    input: T,
-) -> ParseResult<'a, FunctionSymbol<'a>> {
+pub fn parse_function_symbol<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FunctionSymbol> {
     let (remaining, name) = parse_name(input)?;
     Ok((remaining, name.into()))
 }
 
-impl<'a> crate::parsers::Parser<'a> for FunctionSymbol<'a> {
-    type Item = FunctionSymbol<'a>;
+impl crate::parsers::Parser for FunctionSymbol {
+    type Item = FunctionSymbol;
 
     /// See [`parse_function_symbol`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_function_symbol(input)
     }
 }

--- a/src/parsers/function_symbol.rs
+++ b/src/parsers/function_symbol.rs
@@ -1,26 +1,25 @@
 //! Provides parsers for function symbols.
 
-use crate::parsers::parse_name;
+use crate::parsers::{parse_name, ParseResult, Span};
 use crate::types::FunctionSymbol;
-use nom::IResult;
 
 /// Parses a function symbol, i.e. `<name>`.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_function_symbol;
-/// assert_eq!(parse_function_symbol("abcde"), Ok(("", "abcde".into())));
-/// assert_eq!(parse_function_symbol("a-1_2"), Ok(("", "a-1_2".into())));
-/// assert_eq!(parse_function_symbol("Z01"), Ok(("", "Z01".into())));
-/// assert_eq!(parse_function_symbol("x-_-_"), Ok(("", "x-_-_".into())));
+/// # use pddl::parsers::{parse_function_symbol, preamble::*};
+/// assert!(parse_function_symbol("abcde".into()).is_value("abcde".into()));
+/// assert!(parse_function_symbol("a-1_2".into()).is_value("a-1_2".into()));
+/// assert!(parse_function_symbol("Z01".into()).is_value("Z01".into()));
+/// assert!(parse_function_symbol("x-_-_".into()).is_value("x-_-_".into()));
 ///
-/// assert!(parse_function_symbol("").is_err());
-/// assert!(parse_function_symbol(".").is_err());
-/// assert!(parse_function_symbol("-abc").is_err());
-/// assert!(parse_function_symbol("0124").is_err());
-/// assert!(parse_function_symbol("-1").is_err());
+/// assert!(parse_function_symbol("".into()).is_err());
+/// assert!(parse_function_symbol(".".into()).is_err());
+/// assert!(parse_function_symbol("-abc".into()).is_err());
+/// assert!(parse_function_symbol("0124".into()).is_err());
+/// assert!(parse_function_symbol("-1".into()).is_err());
 ///```
-pub fn parse_function_symbol(input: &str) -> IResult<&str, FunctionSymbol> {
+pub fn parse_function_symbol(input: Span) -> ParseResult<FunctionSymbol> {
     let (remaining, name) = parse_name(input)?;
     Ok((remaining, name.into()))
 }
@@ -29,7 +28,7 @@ impl<'a> crate::parsers::Parser<'a> for FunctionSymbol<'a> {
     type Item = FunctionSymbol<'a>;
 
     /// See [`parse_function_symbol`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_function_symbol(input)
     }
 }

--- a/src/parsers/function_term.rs
+++ b/src/parsers/function_term.rs
@@ -13,22 +13,22 @@ use nom::sequence::{delimited, tuple};
 /// ```
 /// # use pddl::parsers::{parse_function_term, preamble::*};
 /// # use pddl::{FunctionTerm, Variable, FunctionSymbol, Term};
-/// assert!(parse_function_term("(fun-sym)".into()).is_value(FunctionTerm::new("fun-sym".into(), vec![])));
+/// assert!(parse_function_term("(fun-sym)").is_value(FunctionTerm::new("fun-sym".into(), vec![])));
 ///
 /// let x = Term::Name("x".into());
-/// assert!(parse_function_term("(fun-sym x)".into()).is_value(FunctionTerm::new("fun-sym".into(), vec![x])));
+/// assert!(parse_function_term("(fun-sym x)").is_value(FunctionTerm::new("fun-sym".into(), vec![x])));
 ///
 /// let x = Term::Name("x".into());
 /// let y = Term::Variable("y".into());
-/// assert!(parse_function_term("(fun-sym ?y x)".into()).is_value(FunctionTerm::new("fun-sym".into(), vec![y, x])));
+/// assert!(parse_function_term("(fun-sym ?y x)").is_value(FunctionTerm::new("fun-sym".into(), vec![y, x])));
 ///
 /// let x = Term::Name("x".into());
 /// let y = Term::Variable("y".into());
 /// let a = Term::Name("a".into());
 /// let ft = Term::Function(FunctionTerm::new(FunctionSymbol::from("fn"), vec![a]));
-/// assert!(parse_function_term("(fun-sym ?y x (fn a))".into()).is_value(FunctionTerm::new("fun-sym".into(), vec![y, x, ft])));
+/// assert!(parse_function_term("(fun-sym ?y x (fn a))").is_value(FunctionTerm::new("fun-sym".into(), vec![y, x, ft])));
 ///```
-pub fn parse_function_term(input: Span) -> ParseResult<FunctionTerm> {
+pub fn parse_function_term<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FunctionTerm<'a>> {
     map(
         delimited(
             tag("("),
@@ -36,7 +36,7 @@ pub fn parse_function_term(input: Span) -> ParseResult<FunctionTerm> {
             tag(")"),
         ),
         |(symbol, terms)| FunctionTerm::new(symbol, terms),
-    )(input)
+    )(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for FunctionTerm<'a> {

--- a/src/parsers/function_term.rs
+++ b/src/parsers/function_term.rs
@@ -28,7 +28,7 @@ use nom::sequence::{delimited, tuple};
 /// let ft = Term::Function(FunctionTerm::new(FunctionSymbol::from("fn"), vec![a]));
 /// assert!(parse_function_term("(fun-sym ?y x (fn a))").is_value(FunctionTerm::new("fun-sym".into(), vec![y, x, ft])));
 ///```
-pub fn parse_function_term<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FunctionTerm<'a>> {
+pub fn parse_function_term<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FunctionTerm> {
     map(
         delimited(
             tag("("),
@@ -39,11 +39,11 @@ pub fn parse_function_term<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, F
     )(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for FunctionTerm<'a> {
-    type Item = FunctionTerm<'a>;
+impl crate::parsers::Parser for FunctionTerm {
+    type Item = FunctionTerm;
 
     /// See [`parse_function_term`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_function_term(input)
     }
 }

--- a/src/parsers/function_term.rs
+++ b/src/parsers/function_term.rs
@@ -43,7 +43,7 @@ impl<'a> crate::parsers::Parser<'a> for FunctionTerm<'a> {
     type Item = FunctionTerm<'a>;
 
     /// See [`parse_function_term`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_function_term(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_function_term(input.into())
     }
 }

--- a/src/parsers/function_term.rs
+++ b/src/parsers/function_term.rs
@@ -44,6 +44,6 @@ impl<'a> crate::parsers::Parser<'a> for FunctionTerm<'a> {
 
     /// See [`parse_function_term`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_function_term(input.into())
+        parse_function_term(input)
     }
 }

--- a/src/parsers/function_type.rs
+++ b/src/parsers/function_type.rs
@@ -14,15 +14,15 @@ use nom::combinator::map;
 /// assert!(parse_function_type("number").is_value(FunctionType::new(Type::Exactly("number".into()))));
 /// assert!(parse_function_type("(either object number)").is_value(FunctionType::new(Type::from_iter(["object", "number"]))));
 ///```
-pub fn parse_function_type<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FunctionType<'a>> {
+pub fn parse_function_type<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FunctionType> {
     map(parse_type, FunctionType::from)(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for FunctionType<'a> {
-    type Item = FunctionType<'a>;
+impl crate::parsers::Parser for FunctionType {
+    type Item = FunctionType;
 
     /// See [`parse_function_type`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_function_type(input)
     }
 }

--- a/src/parsers/function_type.rs
+++ b/src/parsers/function_type.rs
@@ -1,21 +1,20 @@
 //! Provides parsers for function types.
 
-use crate::parsers::parse_type;
+use crate::parsers::{parse_type, ParseResult, Span};
 use crate::types::FunctionType;
 use nom::combinator::map;
-use nom::IResult;
 
 /// Parses a primitive type, i.e. `object | <name>`.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_function_type;
+/// # use pddl::parsers::{parse_function_type, preamble::*};
 /// # use pddl::{FunctionType};
 /// # use pddl::Type;
-/// assert_eq!(parse_function_type("number"), Ok(("", FunctionType::new(Type::Exactly("number".into())))));
-/// assert_eq!(parse_function_type("(either object number)"), Ok(("", FunctionType::new(Type::from_iter(["object", "number"])))));
+/// assert!(parse_function_type("number".into()).is_value(FunctionType::new(Type::Exactly("number".into()))));
+/// assert!(parse_function_type("(either object number)".into()).is_value(FunctionType::new(Type::from_iter(["object", "number"]))));
 ///```
-pub fn parse_function_type(input: &str) -> IResult<&str, FunctionType> {
+pub fn parse_function_type(input: Span) -> ParseResult<FunctionType> {
     map(parse_type, FunctionType::from)(input)
 }
 
@@ -23,7 +22,7 @@ impl<'a> crate::parsers::Parser<'a> for FunctionType<'a> {
     type Item = FunctionType<'a>;
 
     /// See [`parse_function_type`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_function_type(input)
     }
 }

--- a/src/parsers/function_type.rs
+++ b/src/parsers/function_type.rs
@@ -23,6 +23,6 @@ impl<'a> crate::parsers::Parser<'a> for FunctionType<'a> {
 
     /// See [`parse_function_type`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_function_type(input.into())
+        parse_function_type(input)
     }
 }

--- a/src/parsers/function_type.rs
+++ b/src/parsers/function_type.rs
@@ -11,11 +11,11 @@ use nom::combinator::map;
 /// # use pddl::parsers::{parse_function_type, preamble::*};
 /// # use pddl::{FunctionType};
 /// # use pddl::Type;
-/// assert!(parse_function_type("number".into()).is_value(FunctionType::new(Type::Exactly("number".into()))));
-/// assert!(parse_function_type("(either object number)".into()).is_value(FunctionType::new(Type::from_iter(["object", "number"]))));
+/// assert!(parse_function_type("number").is_value(FunctionType::new(Type::Exactly("number".into()))));
+/// assert!(parse_function_type("(either object number)").is_value(FunctionType::new(Type::from_iter(["object", "number"]))));
 ///```
-pub fn parse_function_type(input: Span) -> ParseResult<FunctionType> {
-    map(parse_type, FunctionType::from)(input)
+pub fn parse_function_type<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FunctionType<'a>> {
+    map(parse_type, FunctionType::from)(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for FunctionType<'a> {

--- a/src/parsers/function_type.rs
+++ b/src/parsers/function_type.rs
@@ -22,7 +22,7 @@ impl<'a> crate::parsers::Parser<'a> for FunctionType<'a> {
     type Item = FunctionType<'a>;
 
     /// See [`parse_function_type`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_function_type(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_function_type(input.into())
     }
 }

--- a/src/parsers/function_typed_list.rs
+++ b/src/parsers/function_typed_list.rs
@@ -1,21 +1,22 @@
-use crate::parsers::{parse_type, space_separated_list0, space_separated_list1, ws};
+use crate::parsers::{
+    parse_type, space_separated_list0, space_separated_list1, ws, ParseResult, Span,
+};
 use crate::types::{FunctionType, FunctionTyped, FunctionTypedList};
 use nom::character::complete::char;
 use nom::combinator::map;
 use nom::multi::many0;
 use nom::sequence::{preceded, tuple};
-use nom::IResult;
 
 /// Parses a typed list, i.e. `x* | x⁺ - <type> <typed-list (x)>.
 ///
 /// ## Example
 /// ```
 /// # use nom::character::complete::alpha1;
-/// # use pddl::parsers::{function_typed_list, parse_atomic_function_skeleton};
+/// # use pddl::parsers::{function_typed_list, parse_atomic_function_skeleton, preamble::*};
 /// # use pddl::{AtomicFunctionSkeleton, FunctionSymbol, FunctionTyped, FunctionTypedList, Variable};
 /// # use pddl::{Type, Typed, TypedList};
 /// // Single implicitly typed element.
-/// assert_eq!(function_typed_list(parse_atomic_function_skeleton)("(battery-amount ?r - rover)"), Ok(("",
+/// assert!(function_typed_list(parse_atomic_function_skeleton)("(battery-amount ?r - rover)".into()).is_value(
 ///     FunctionTypedList::from_iter([
 ///         FunctionTyped::new_number(
 ///             AtomicFunctionSkeleton::new(
@@ -26,13 +27,13 @@ use nom::IResult;
 ///             )
 ///         )
 ///     ])
-/// )));
+/// ));
 /// ```
 pub fn function_typed_list<'a, F, O>(
     inner: F,
-) -> impl FnMut(&'a str) -> IResult<&'a str, FunctionTypedList<O>>
+) -> impl FnMut(Span<'a>) -> ParseResult<'a, FunctionTypedList<O>>
 where
-    F: Clone + FnMut(&'a str) -> IResult<&'a str, O>,
+    F: Clone + FnMut(Span<'a>) -> ParseResult<'a, O>,
 {
     // TODO: With :numeric-fluents, this list can be x⁺ (i.e., implicitly typed number).
     // TODO: Without :numeric-fluents, this list is allowed to be empty or an explicitly typed list.

--- a/src/parsers/functions_def.rs
+++ b/src/parsers/functions_def.rs
@@ -41,6 +41,6 @@ impl<'a> crate::parsers::Parser<'a> for Functions<'a> {
 
     /// See [`parse_functions_def`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_functions_def(input.into())
+        parse_functions_def(input)
     }
 }

--- a/src/parsers/functions_def.rs
+++ b/src/parsers/functions_def.rs
@@ -1,20 +1,19 @@
 //! Provides parsers for constant definitions.
 
-use crate::parsers::prefix_expr;
 use crate::parsers::{function_typed_list, parse_atomic_function_skeleton};
+use crate::parsers::{prefix_expr, ParseResult, Span};
 use crate::types::Functions;
 use nom::combinator::map;
-use nom::IResult;
 
 /// Parser that parses constant definitions, i.e. `(:constants <typed list (name)>)`.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_functions_def;
+/// # use pddl::parsers::{parse_functions_def, preamble::*};
 /// # use pddl::{Variable, AtomicFormulaSkeleton, Predicate, PredicateDefinitions, FunctionTypedList, FunctionTyped, AtomicFunctionSkeleton, FunctionSymbol, Functions};
 /// # use pddl::{Type, Typed, TypedList};
 /// let input = "(:functions (battery-amount ?r - rover))";
-/// assert_eq!(parse_functions_def(input), Ok(("",
+/// assert!(parse_functions_def(input.into()).is_value(
 ///     Functions::from_iter([
 ///         FunctionTyped::new_number(
 ///             AtomicFunctionSkeleton::new(
@@ -25,9 +24,9 @@ use nom::IResult;
 ///             )
 ///         )
 ///     ])
-/// )));
+/// ));
 /// ```
-pub fn parse_functions_def(input: &str) -> IResult<&str, Functions> {
+pub fn parse_functions_def(input: Span) -> ParseResult<Functions> {
     map(
         prefix_expr(
             ":functions",
@@ -41,7 +40,7 @@ impl<'a> crate::parsers::Parser<'a> for Functions<'a> {
     type Item = Functions<'a>;
 
     /// See [`parse_functions_def`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_functions_def(input)
     }
 }

--- a/src/parsers/functions_def.rs
+++ b/src/parsers/functions_def.rs
@@ -40,7 +40,7 @@ impl<'a> crate::parsers::Parser<'a> for Functions<'a> {
     type Item = Functions<'a>;
 
     /// See [`parse_functions_def`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_functions_def(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_functions_def(input.into())
     }
 }

--- a/src/parsers/functions_def.rs
+++ b/src/parsers/functions_def.rs
@@ -26,7 +26,7 @@ use nom::combinator::map;
 ///     ])
 /// ));
 /// ```
-pub fn parse_functions_def<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Functions<'a>> {
+pub fn parse_functions_def<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Functions> {
     map(
         prefix_expr(
             ":functions",
@@ -36,11 +36,11 @@ pub fn parse_functions_def<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, F
     )(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for Functions<'a> {
-    type Item = Functions<'a>;
+impl crate::parsers::Parser for Functions {
+    type Item = Functions;
 
     /// See [`parse_functions_def`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_functions_def(input)
     }
 }

--- a/src/parsers/functions_def.rs
+++ b/src/parsers/functions_def.rs
@@ -13,7 +13,7 @@ use nom::combinator::map;
 /// # use pddl::{Variable, AtomicFormulaSkeleton, Predicate, PredicateDefinitions, FunctionTypedList, FunctionTyped, AtomicFunctionSkeleton, FunctionSymbol, Functions};
 /// # use pddl::{Type, Typed, TypedList};
 /// let input = "(:functions (battery-amount ?r - rover))";
-/// assert!(parse_functions_def(input.into()).is_value(
+/// assert!(parse_functions_def(input).is_value(
 ///     Functions::from_iter([
 ///         FunctionTyped::new_number(
 ///             AtomicFunctionSkeleton::new(
@@ -26,14 +26,14 @@ use nom::combinator::map;
 ///     ])
 /// ));
 /// ```
-pub fn parse_functions_def(input: Span) -> ParseResult<Functions> {
+pub fn parse_functions_def<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Functions<'a>> {
     map(
         prefix_expr(
             ":functions",
             function_typed_list(parse_atomic_function_skeleton),
         ),
         |vec| Functions::new(vec),
-    )(input)
+    )(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for Functions<'a> {

--- a/src/parsers/gd.rs
+++ b/src/parsers/gd.rs
@@ -194,7 +194,7 @@ impl<'a> crate::parsers::Parser<'a> for GoalDefinition<'a> {
     type Item = GoalDefinition<'a>;
 
     /// See [`parse_gd`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_gd(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_gd(input.into())
     }
 }

--- a/src/parsers/gd.rs
+++ b/src/parsers/gd.rs
@@ -131,7 +131,7 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 /// ```
-pub fn parse_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, GoalDefinition<'a>> {
+pub fn parse_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, GoalDefinition> {
     let af = map(
         atomic_formula(parse_term),
         GoalDefinition::new_atomic_formula,
@@ -190,11 +190,11 @@ pub fn parse_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, GoalDefiniti
     alt((and, or, not, imply, exists, forall, af, literal, f_comp))(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for GoalDefinition<'a> {
-    type Item = GoalDefinition<'a>;
+impl crate::parsers::Parser for GoalDefinition {
+    type Item = GoalDefinition;
 
     /// See [`parse_gd`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_gd(input)
     }
 }

--- a/src/parsers/gd.rs
+++ b/src/parsers/gd.rs
@@ -1,33 +1,34 @@
 //! Provides parsers for goal definitions.
 
-use crate::parsers::{atomic_formula, literal, parse_f_comp, parse_term, parse_variable};
+use crate::parsers::{
+    atomic_formula, literal, parse_f_comp, parse_term, parse_variable, ParseResult, Span,
+};
 use crate::parsers::{parens, prefix_expr, space_separated_list0, typed_list};
 use crate::types::GoalDefinition;
 use nom::branch::alt;
 use nom::character::complete::multispace1;
 use nom::combinator::map;
 use nom::sequence::{preceded, tuple};
-use nom::IResult;
 
 /// Parser for goal definitions.
 ///
 /// ## Examples
 /// ```
-/// # use pddl::parsers::parse_gd;
+/// # use pddl::parsers::{parse_gd, preamble::*};
 /// # use pddl::{AtomicFormula, BinaryComp, BinaryOp, EqualityAtomicFormula, FComp, FExp, GoalDefinition, Literal, Term, Variable};
 /// # use pddl::TypedList;
 /// // Atomic formula
-/// assert_eq!(parse_gd("(= x y)"), Ok(("",
+/// assert!(parse_gd("(= x y)".into()).is_value(
 ///     GoalDefinition::AtomicFormula(
 ///         AtomicFormula::new_equality(
 ///             Term::Name("x".into()),
 ///             Term::Name("y".into())
 ///         )
 ///     )
-/// )));
+/// ));
 ///
 /// // Literal
-/// assert_eq!(parse_gd("(not (= x y))"), Ok(("",
+/// assert!(parse_gd("(not (= x y))".into()).is_value(
 ///     GoalDefinition::new_not(
 ///         GoalDefinition::new_atomic_formula(
 ///             AtomicFormula::new_equality(
@@ -36,10 +37,10 @@ use nom::IResult;
 ///             )
 ///         )
 ///     )
-/// )));
+/// ));
 ///
 /// // Conjunction (and)
-/// assert_eq!(parse_gd("(and (not (= x y)) (= x z))"), Ok(("",
+/// assert!(parse_gd("(and (not (= x y)) (= x z))".into()).is_value(
 ///     GoalDefinition::new_and([
 ///         GoalDefinition::new_not(GoalDefinition::new_atomic_formula(
 ///             AtomicFormula::new_equality(
@@ -52,10 +53,10 @@ use nom::IResult;
 ///             Term::Name("z".into())
 ///         ))
 ///     ])
-/// )));
+/// ));
 ///
 /// // Disjunction (or)
-/// assert_eq!(parse_gd("(or (not (= x y)) (= x z))"), Ok(("",
+/// assert!(parse_gd("(or (not (= x y)) (= x z))".into()).is_value(
 ///     GoalDefinition::new_or([
 ///         GoalDefinition::new_not(GoalDefinition::new_atomic_formula(
 ///             AtomicFormula::new_equality(
@@ -68,10 +69,10 @@ use nom::IResult;
 ///             Term::Name("z".into())
 ///         ))
 ///     ])
-/// )));
+/// ));
 ///
 /// // Implication
-/// assert_eq!(parse_gd("(imply (not (= x y)) (= x z))"), Ok(("",
+/// assert!(parse_gd("(imply (not (= x y)) (= x z))".into()).is_value(
 ///     GoalDefinition::new_imply(
 ///         GoalDefinition::new_not(GoalDefinition::new_atomic_formula(
 ///             AtomicFormula::new_equality(
@@ -84,10 +85,10 @@ use nom::IResult;
 ///             Term::Name("z".into())
 ///         ))
 ///     )
-/// )));
+/// ));
 ///
 /// // Existential preconditions
-/// assert_eq!(parse_gd("(exists (?x ?y) (not (= ?x ?y)))"), Ok(("",
+/// assert!(parse_gd("(exists (?x ?y) (not (= ?x ?y)))".into()).is_value(
 ///     GoalDefinition::new_exists(
 ///         TypedList::from_iter([Variable::from_str("x").into(), Variable::from_str("y").into()]),
 ///         GoalDefinition::new_not(GoalDefinition::new_atomic_formula(
@@ -97,10 +98,10 @@ use nom::IResult;
 ///             )
 ///         ))
 ///     )
-/// )));
+/// ));
 ///
 /// // Universal preconditions
-/// assert_eq!(parse_gd("(forall (?x ?y) (not (= ?x ?y)))"), Ok(("",
+/// assert!(parse_gd("(forall (?x ?y) (not (= ?x ?y)))".into()).is_value(
 ///     GoalDefinition::new_forall(
 ///         TypedList::from_iter([Variable::from_str("x").into(), Variable::from_str("y").into()]),
 ///         GoalDefinition::new_not(GoalDefinition::new_atomic_formula(
@@ -110,9 +111,9 @@ use nom::IResult;
 ///             )
 ///         ))
 ///     )
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_gd("(= (+ 1.23 2.34) (+ 1.23 2.34))"), Ok(("",
+/// assert!(parse_gd("(= (+ 1.23 2.34) (+ 1.23 2.34))".into()).is_value(
 ///     GoalDefinition::new_f_comp(
 ///         FComp::new(
 ///             BinaryComp::Equal,
@@ -128,9 +129,9 @@ use nom::IResult;
 ///             )
 ///         )
 ///     )
-/// )));
+/// ));
 /// ```
-pub fn parse_gd(input: &str) -> IResult<&str, GoalDefinition> {
+pub fn parse_gd(input: Span) -> ParseResult<GoalDefinition> {
     let af = map(
         atomic_formula(parse_term),
         GoalDefinition::new_atomic_formula,
@@ -193,7 +194,7 @@ impl<'a> crate::parsers::Parser<'a> for GoalDefinition<'a> {
     type Item = GoalDefinition<'a>;
 
     /// See [`parse_gd`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_gd(input)
     }
 }

--- a/src/parsers/gd.rs
+++ b/src/parsers/gd.rs
@@ -195,6 +195,6 @@ impl<'a> crate::parsers::Parser<'a> for GoalDefinition<'a> {
 
     /// See [`parse_gd`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_gd(input.into())
+        parse_gd(input)
     }
 }

--- a/src/parsers/gd.rs
+++ b/src/parsers/gd.rs
@@ -18,7 +18,7 @@ use nom::sequence::{preceded, tuple};
 /// # use pddl::{AtomicFormula, BinaryComp, BinaryOp, EqualityAtomicFormula, FComp, FExp, GoalDefinition, Literal, Term, Variable};
 /// # use pddl::TypedList;
 /// // Atomic formula
-/// assert!(parse_gd("(= x y)".into()).is_value(
+/// assert!(parse_gd("(= x y)").is_value(
 ///     GoalDefinition::AtomicFormula(
 ///         AtomicFormula::new_equality(
 ///             Term::Name("x".into()),
@@ -28,7 +28,7 @@ use nom::sequence::{preceded, tuple};
 /// ));
 ///
 /// // Literal
-/// assert!(parse_gd("(not (= x y))".into()).is_value(
+/// assert!(parse_gd("(not (= x y))").is_value(
 ///     GoalDefinition::new_not(
 ///         GoalDefinition::new_atomic_formula(
 ///             AtomicFormula::new_equality(
@@ -40,7 +40,7 @@ use nom::sequence::{preceded, tuple};
 /// ));
 ///
 /// // Conjunction (and)
-/// assert!(parse_gd("(and (not (= x y)) (= x z))".into()).is_value(
+/// assert!(parse_gd("(and (not (= x y)) (= x z))").is_value(
 ///     GoalDefinition::new_and([
 ///         GoalDefinition::new_not(GoalDefinition::new_atomic_formula(
 ///             AtomicFormula::new_equality(
@@ -56,7 +56,7 @@ use nom::sequence::{preceded, tuple};
 /// ));
 ///
 /// // Disjunction (or)
-/// assert!(parse_gd("(or (not (= x y)) (= x z))".into()).is_value(
+/// assert!(parse_gd("(or (not (= x y)) (= x z))").is_value(
 ///     GoalDefinition::new_or([
 ///         GoalDefinition::new_not(GoalDefinition::new_atomic_formula(
 ///             AtomicFormula::new_equality(
@@ -72,7 +72,7 @@ use nom::sequence::{preceded, tuple};
 /// ));
 ///
 /// // Implication
-/// assert!(parse_gd("(imply (not (= x y)) (= x z))".into()).is_value(
+/// assert!(parse_gd("(imply (not (= x y)) (= x z))").is_value(
 ///     GoalDefinition::new_imply(
 ///         GoalDefinition::new_not(GoalDefinition::new_atomic_formula(
 ///             AtomicFormula::new_equality(
@@ -88,7 +88,7 @@ use nom::sequence::{preceded, tuple};
 /// ));
 ///
 /// // Existential preconditions
-/// assert!(parse_gd("(exists (?x ?y) (not (= ?x ?y)))".into()).is_value(
+/// assert!(parse_gd("(exists (?x ?y) (not (= ?x ?y)))").is_value(
 ///     GoalDefinition::new_exists(
 ///         TypedList::from_iter([Variable::from_str("x").into(), Variable::from_str("y").into()]),
 ///         GoalDefinition::new_not(GoalDefinition::new_atomic_formula(
@@ -101,7 +101,7 @@ use nom::sequence::{preceded, tuple};
 /// ));
 ///
 /// // Universal preconditions
-/// assert!(parse_gd("(forall (?x ?y) (not (= ?x ?y)))".into()).is_value(
+/// assert!(parse_gd("(forall (?x ?y) (not (= ?x ?y)))").is_value(
 ///     GoalDefinition::new_forall(
 ///         TypedList::from_iter([Variable::from_str("x").into(), Variable::from_str("y").into()]),
 ///         GoalDefinition::new_not(GoalDefinition::new_atomic_formula(
@@ -113,7 +113,7 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 ///
-/// assert!(parse_gd("(= (+ 1.23 2.34) (+ 1.23 2.34))".into()).is_value(
+/// assert!(parse_gd("(= (+ 1.23 2.34) (+ 1.23 2.34))").is_value(
 ///     GoalDefinition::new_f_comp(
 ///         FComp::new(
 ///             BinaryComp::Equal,
@@ -131,7 +131,7 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 /// ```
-pub fn parse_gd(input: Span) -> ParseResult<GoalDefinition> {
+pub fn parse_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, GoalDefinition<'a>> {
     let af = map(
         atomic_formula(parse_term),
         GoalDefinition::new_atomic_formula,
@@ -187,7 +187,7 @@ pub fn parse_gd(input: Span) -> ParseResult<GoalDefinition> {
     // :numeric-fluents
     let f_comp = map(parse_f_comp, GoalDefinition::new_f_comp);
 
-    alt((and, or, not, imply, exists, forall, af, literal, f_comp))(input)
+    alt((and, or, not, imply, exists, forall, af, literal, f_comp))(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for GoalDefinition<'a> {

--- a/src/parsers/goal_def.rs
+++ b/src/parsers/goal_def.rs
@@ -35,6 +35,6 @@ impl<'a> crate::parsers::Parser<'a> for GoalDef<'a> {
 
     /// See [`parse_problem_goal_def`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_problem_goal_def(input.into())
+        parse_problem_goal_def(input)
     }
 }

--- a/src/parsers/goal_def.rs
+++ b/src/parsers/goal_def.rs
@@ -11,7 +11,7 @@ use nom::combinator::map;
 /// # use pddl::parsers::{parse_problem_goal_def, preamble::*};
 /// # use pddl::{AtomicFormula, GoalDef, GoalDefinition, PreferenceGD, PreconditionGoalDefinition, Term};
 /// let input = "(:goal (= x y))";
-/// assert!(parse_problem_goal_def(input.into()).is_value(
+/// assert!(parse_problem_goal_def(input).is_value(
 ///     GoalDef::from(
 ///         PreconditionGoalDefinition::Preference(
 ///             PreferenceGD::Goal(
@@ -26,8 +26,8 @@ use nom::combinator::map;
 ///     )
 /// ));
 /// ```
-pub fn parse_problem_goal_def(input: Span) -> ParseResult<GoalDef> {
-    map(prefix_expr(":goal", parse_pre_gd), GoalDef::new)(input)
+pub fn parse_problem_goal_def<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, GoalDef<'a>> {
+    map(prefix_expr(":goal", parse_pre_gd), GoalDef::new)(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for GoalDef<'a> {

--- a/src/parsers/goal_def.rs
+++ b/src/parsers/goal_def.rs
@@ -26,15 +26,15 @@ use nom::combinator::map;
 ///     )
 /// ));
 /// ```
-pub fn parse_problem_goal_def<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, GoalDef<'a>> {
+pub fn parse_problem_goal_def<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, GoalDef> {
     map(prefix_expr(":goal", parse_pre_gd), GoalDef::new)(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for GoalDef<'a> {
-    type Item = GoalDef<'a>;
+impl crate::parsers::Parser for GoalDef {
+    type Item = GoalDef;
 
     /// See [`parse_problem_goal_def`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_problem_goal_def(input)
     }
 }

--- a/src/parsers/goal_def.rs
+++ b/src/parsers/goal_def.rs
@@ -1,18 +1,17 @@
 //! Provides parsers for pre-GD goal definitions.
 
-use crate::parsers::{parse_pre_gd, prefix_expr};
+use crate::parsers::{parse_pre_gd, prefix_expr, ParseResult, Span};
 use crate::types::GoalDef;
 use nom::combinator::map;
-use nom::IResult;
 
 /// Parses pre-GD goal definitions.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::{parse_problem_goal_def};
+/// # use pddl::parsers::{parse_problem_goal_def, preamble::*};
 /// # use pddl::{AtomicFormula, GoalDef, GoalDefinition, PreferenceGD, PreconditionGoalDefinition, Term};
 /// let input = "(:goal (= x y))";
-/// assert_eq!(parse_problem_goal_def(input), Ok(("",
+/// assert!(parse_problem_goal_def(input.into()).is_value(
 ///     GoalDef::from(
 ///         PreconditionGoalDefinition::Preference(
 ///             PreferenceGD::Goal(
@@ -25,9 +24,9 @@ use nom::IResult;
 ///             )
 ///         )
 ///     )
-/// )));
+/// ));
 /// ```
-pub fn parse_problem_goal_def(input: &str) -> IResult<&str, GoalDef> {
+pub fn parse_problem_goal_def(input: Span) -> ParseResult<GoalDef> {
     map(prefix_expr(":goal", parse_pre_gd), GoalDef::new)(input)
 }
 
@@ -35,7 +34,7 @@ impl<'a> crate::parsers::Parser<'a> for GoalDef<'a> {
     type Item = GoalDef<'a>;
 
     /// See [`parse_problem_goal_def`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_problem_goal_def(input)
     }
 }

--- a/src/parsers/goal_def.rs
+++ b/src/parsers/goal_def.rs
@@ -34,7 +34,7 @@ impl<'a> crate::parsers::Parser<'a> for GoalDef<'a> {
     type Item = GoalDef<'a>;
 
     /// See [`parse_problem_goal_def`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_problem_goal_def(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_problem_goal_def(input.into())
     }
 }

--- a/src/parsers/init_def.rs
+++ b/src/parsers/init_def.rs
@@ -11,7 +11,7 @@ use nom::combinator::map;
 /// # use pddl::parsers::{parse_problem_init_def, preamble::*};
 /// # use pddl::{AtomicFormula, InitElement, InitElements, NameLiteral, Number};
 /// let input = "(:init (train-not-in-use train1) (at 10 (train-not-in-use train2)))";
-/// assert!(parse_problem_init_def(input.into()).is_value(
+/// assert!(parse_problem_init_def(input).is_value(
 ///     InitElements::from_iter([
 ///         InitElement::new_literal(
 ///             NameLiteral::new(
@@ -33,11 +33,13 @@ use nom::combinator::map;
 ///     ])
 /// ));
 /// ```
-pub fn parse_problem_init_def(input: Span) -> ParseResult<InitElements> {
+pub fn parse_problem_init_def<'a, T: Into<Span<'a>>>(
+    input: T,
+) -> ParseResult<'a, InitElements<'a>> {
     map(
         prefix_expr(":init", space_separated_list0(parse_init_el)),
         InitElements::new,
-    )(input)
+    )(input.into())
 }
 impl<'a> crate::parsers::Parser<'a> for InitElements<'a> {
     type Item = InitElements<'a>;

--- a/src/parsers/init_def.rs
+++ b/src/parsers/init_def.rs
@@ -46,6 +46,6 @@ impl<'a> crate::parsers::Parser<'a> for InitElements<'a> {
 
     /// See [`parse_problem_init_def`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_problem_init_def(input.into())
+        parse_problem_init_def(input)
     }
 }

--- a/src/parsers/init_def.rs
+++ b/src/parsers/init_def.rs
@@ -33,19 +33,17 @@ use nom::combinator::map;
 ///     ])
 /// ));
 /// ```
-pub fn parse_problem_init_def<'a, T: Into<Span<'a>>>(
-    input: T,
-) -> ParseResult<'a, InitElements<'a>> {
+pub fn parse_problem_init_def<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, InitElements> {
     map(
         prefix_expr(":init", space_separated_list0(parse_init_el)),
         InitElements::new,
     )(input.into())
 }
-impl<'a> crate::parsers::Parser<'a> for InitElements<'a> {
-    type Item = InitElements<'a>;
+impl crate::parsers::Parser for InitElements {
+    type Item = InitElements;
 
     /// See [`parse_problem_init_def`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_problem_init_def(input)
     }
 }

--- a/src/parsers/init_def.rs
+++ b/src/parsers/init_def.rs
@@ -1,18 +1,17 @@
 //! Provides parsers for goal initial state definitions.
 
-use crate::parsers::{parse_init_el, prefix_expr, space_separated_list0};
+use crate::parsers::{parse_init_el, prefix_expr, space_separated_list0, ParseResult, Span};
 use crate::types::InitElements;
 use nom::combinator::map;
-use nom::IResult;
 
 /// Parser for goal initial state definitions.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::{parse_problem_init_def};
+/// # use pddl::parsers::{parse_problem_init_def, preamble::*};
 /// # use pddl::{AtomicFormula, InitElement, InitElements, NameLiteral, Number};
 /// let input = "(:init (train-not-in-use train1) (at 10 (train-not-in-use train2)))";
-/// assert_eq!(parse_problem_init_def(input), Ok(("",
+/// assert!(parse_problem_init_def(input.into()).is_value(
 ///     InitElements::from_iter([
 ///         InitElement::new_literal(
 ///             NameLiteral::new(
@@ -32,9 +31,9 @@ use nom::IResult;
 ///             )
 ///         )
 ///     ])
-/// )));
+/// ));
 /// ```
-pub fn parse_problem_init_def(input: &str) -> IResult<&str, InitElements> {
+pub fn parse_problem_init_def(input: Span) -> ParseResult<InitElements> {
     map(
         prefix_expr(":init", space_separated_list0(parse_init_el)),
         InitElements::new,
@@ -44,7 +43,7 @@ impl<'a> crate::parsers::Parser<'a> for InitElements<'a> {
     type Item = InitElements<'a>;
 
     /// See [`parse_problem_init_def`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_problem_init_def(input)
     }
 }

--- a/src/parsers/init_def.rs
+++ b/src/parsers/init_def.rs
@@ -43,7 +43,7 @@ impl<'a> crate::parsers::Parser<'a> for InitElements<'a> {
     type Item = InitElements<'a>;
 
     /// See [`parse_problem_init_def`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_problem_init_def(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_problem_init_def(input.into())
     }
 }

--- a/src/parsers/init_el.rs
+++ b/src/parsers/init_el.rs
@@ -52,7 +52,7 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 /// ```
-pub fn parse_init_el<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, InitElement<'a>> {
+pub fn parse_init_el<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, InitElement> {
     let literal_ = map(literal(parse_name), InitElement::new_literal);
 
     // :timed-initial-literals
@@ -88,11 +88,11 @@ pub fn parse_init_el<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, InitEle
     alt((literal_, at, is_numeric, is_object))(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for InitElement<'a> {
-    type Item = InitElement<'a>;
+impl crate::parsers::Parser for InitElement {
+    type Item = InitElement;
 
     /// See [`parse_init_el`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_init_el(input)
     }
 }

--- a/src/parsers/init_el.rs
+++ b/src/parsers/init_el.rs
@@ -93,6 +93,6 @@ impl<'a> crate::parsers::Parser<'a> for InitElement<'a> {
 
     /// See [`parse_init_el`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_init_el(input.into())
+        parse_init_el(input)
     }
 }

--- a/src/parsers/init_el.rs
+++ b/src/parsers/init_el.rs
@@ -15,7 +15,7 @@ use nom::sequence::{preceded, tuple};
 /// ```
 /// # use pddl::parsers::{parse_init_el, preamble::*};
 /// # use pddl::{AtomicFormula, BasicFunctionTerm, InitElement, Name, NameLiteral, Number, Predicate};
-/// assert!(parse_init_el("(train-not-in-use train1)".into()).is_value(
+/// assert!(parse_init_el("(train-not-in-use train1)").is_value(
 ///     InitElement::new_literal(
 ///         NameLiteral::new(
 ///             AtomicFormula::new_predicate(
@@ -26,7 +26,7 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 ///
-/// assert!(parse_init_el("(at 10 (train-not-in-use train2))".into()).is_value(
+/// assert!(parse_init_el("(at 10 (train-not-in-use train2))").is_value(
 ///     InitElement::new_at(
 ///         Number::from(10),
 ///         NameLiteral::new(
@@ -38,21 +38,21 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 ///
-/// assert!(parse_init_el("(= (battery rover) 100)".into()).is_value(
+/// assert!(parse_init_el("(= (battery rover) 100)").is_value(
 ///     InitElement::new_is_value(
 ///         BasicFunctionTerm::new("battery".into(), ["rover".into()]),
 ///         Number::from(100)
 ///     )
 /// ));
 ///
-/// assert!(parse_init_el("(= (location rover) base)".into()).is_value(
+/// assert!(parse_init_el("(= (location rover) base)").is_value(
 ///     InitElement::new_is_object(
 ///         BasicFunctionTerm::new("location".into(), ["rover".into()]),
 ///         Name::from("base")
 ///     )
 /// ));
 /// ```
-pub fn parse_init_el(input: Span) -> ParseResult<InitElement> {
+pub fn parse_init_el<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, InitElement<'a>> {
     let literal_ = map(literal(parse_name), InitElement::new_literal);
 
     // :timed-initial-literals
@@ -85,7 +85,7 @@ pub fn parse_init_el(input: Span) -> ParseResult<InitElement> {
         |(fun, name)| InitElement::new_is_object(fun, name),
     );
 
-    alt((literal_, at, is_numeric, is_object))(input)
+    alt((literal_, at, is_numeric, is_object))(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for InitElement<'a> {

--- a/src/parsers/init_el.rs
+++ b/src/parsers/init_el.rs
@@ -92,7 +92,7 @@ impl<'a> crate::parsers::Parser<'a> for InitElement<'a> {
     type Item = InitElement<'a>;
 
     /// See [`parse_init_el`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_init_el(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_init_el(input.into())
     }
 }

--- a/src/parsers/init_el.rs
+++ b/src/parsers/init_el.rs
@@ -1,20 +1,21 @@
 //! Provides parsers for initial state list elements.
 
-use crate::parsers::{literal, parse_basic_function_term, parse_name, parse_number, prefix_expr};
+use crate::parsers::{
+    literal, parse_basic_function_term, parse_name, parse_number, prefix_expr, ParseResult, Span,
+};
 use crate::types::InitElement;
 use nom::branch::alt;
 use nom::character::complete::multispace1;
 use nom::combinator::map;
 use nom::sequence::{preceded, tuple};
-use nom::IResult;
 
 /// Parses initial state list elements.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_init_el;
+/// # use pddl::parsers::{parse_init_el, preamble::*};
 /// # use pddl::{AtomicFormula, BasicFunctionTerm, InitElement, Name, NameLiteral, Number, Predicate};
-/// assert_eq!(parse_init_el("(train-not-in-use train1)"), Ok(("",
+/// assert!(parse_init_el("(train-not-in-use train1)".into()).is_value(
 ///     InitElement::new_literal(
 ///         NameLiteral::new(
 ///             AtomicFormula::new_predicate(
@@ -23,9 +24,9 @@ use nom::IResult;
 ///             )
 ///         )
 ///     )
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_init_el("(at 10 (train-not-in-use train2))"), Ok(("",
+/// assert!(parse_init_el("(at 10 (train-not-in-use train2))".into()).is_value(
 ///     InitElement::new_at(
 ///         Number::from(10),
 ///         NameLiteral::new(
@@ -35,23 +36,23 @@ use nom::IResult;
 ///             )
 ///         )
 ///     )
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_init_el("(= (battery rover) 100)"), Ok(("",
+/// assert!(parse_init_el("(= (battery rover) 100)".into()).is_value(
 ///     InitElement::new_is_value(
 ///         BasicFunctionTerm::new("battery".into(), ["rover".into()]),
 ///         Number::from(100)
 ///     )
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_init_el("(= (location rover) base)"), Ok(("",
+/// assert!(parse_init_el("(= (location rover) base)".into()).is_value(
 ///     InitElement::new_is_object(
 ///         BasicFunctionTerm::new("location".into(), ["rover".into()]),
 ///         Name::from("base")
 ///     )
-/// )));
+/// ));
 /// ```
-pub fn parse_init_el(input: &str) -> IResult<&str, InitElement> {
+pub fn parse_init_el(input: Span) -> ParseResult<InitElement> {
     let literal_ = map(literal(parse_name), InitElement::new_literal);
 
     // :timed-initial-literals
@@ -91,7 +92,7 @@ impl<'a> crate::parsers::Parser<'a> for InitElement<'a> {
     type Item = InitElement<'a>;
 
     /// See [`parse_init_el`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_init_el(input)
     }
 }

--- a/src/parsers/interval.rs
+++ b/src/parsers/interval.rs
@@ -12,12 +12,12 @@ use nom::combinator::map;
 /// ```
 /// # use pddl::parsers::{parse_interval, preamble::*};
 /// # use pddl::{Interval};
-/// assert!(parse_interval("all".into()).is_value(Interval::All));
+/// assert!(parse_interval("all").is_value(Interval::All));
 ///```
-pub fn parse_interval(input: Span) -> ParseResult<Interval> {
+pub fn parse_interval<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Interval> {
     map(tag(names::ALL), |x: Span| {
         Interval::try_from(*x.fragment()).expect("unhandled variant")
-    })(input)
+    })(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for Interval {

--- a/src/parsers/interval.rs
+++ b/src/parsers/interval.rs
@@ -24,7 +24,7 @@ impl<'a> crate::parsers::Parser<'a> for Interval {
     type Item = Interval;
 
     /// See [`parse_interval`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_interval(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_interval(input.into())
     }
 }

--- a/src/parsers/interval.rs
+++ b/src/parsers/interval.rs
@@ -20,11 +20,11 @@ pub fn parse_interval<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Interv
     })(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for Interval {
+impl crate::parsers::Parser for Interval {
     type Item = Interval;
 
     /// See [`parse_interval`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_interval(input)
     }
 }

--- a/src/parsers/interval.rs
+++ b/src/parsers/interval.rs
@@ -25,6 +25,6 @@ impl<'a> crate::parsers::Parser<'a> for Interval {
 
     /// See [`parse_interval`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_interval(input.into())
+        parse_interval(input)
     }
 }

--- a/src/parsers/interval.rs
+++ b/src/parsers/interval.rs
@@ -1,28 +1,30 @@
 //! Provides parsers for assignment operations.
 
+use crate::parsers::{ParseResult, Span};
 use crate::types::interval::names;
 use crate::types::Interval;
 use nom::bytes::complete::tag;
-use nom::combinator::map_res;
-use nom::IResult;
+use nom::combinator::map;
 
 /// Parses an intervals, i.e. `all`.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_interval;
+/// # use pddl::parsers::{parse_interval, preamble::*};
 /// # use pddl::{Interval};
-/// assert_eq!(parse_interval("all"), Ok(("", Interval::All)));
+/// assert!(parse_interval("all".into()).is_value(Interval::All));
 ///```
-pub fn parse_interval(input: &str) -> IResult<&str, Interval> {
-    map_res(tag(names::ALL), Interval::try_from)(input)
+pub fn parse_interval(input: Span) -> ParseResult<Interval> {
+    map(tag(names::ALL), |x: Span| {
+        Interval::try_from(*x.fragment()).expect("unhandled variant")
+    })(input)
 }
 
 impl<'a> crate::parsers::Parser<'a> for Interval {
     type Item = Interval;
 
     /// See [`parse_interval`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_interval(input)
     }
 }

--- a/src/parsers/length_spec.rs
+++ b/src/parsers/length_spec.rs
@@ -12,12 +12,12 @@ use nom::sequence::{preceded, tuple};
 /// ```
 /// # use pddl::parsers::{parse_problem_length_spec, preamble::*};
 /// # use pddl::LengthSpec;
-/// assert!(parse_problem_length_spec("(:length)".into()).is_value(LengthSpec::default()));
-/// assert!(parse_problem_length_spec("(:length (:serial 123))".into()).is_value(LengthSpec::new_serial(123)));
-/// assert!(parse_problem_length_spec("(:length (:parallel 42))".into()).is_value(LengthSpec::new_parallel(42)));
-/// assert!(parse_problem_length_spec("(:length (:serial 123) (:parallel 42))".into()).is_value(LengthSpec::new(Some(123), Some(42))));
+/// assert!(parse_problem_length_spec("(:length)").is_value(LengthSpec::default()));
+/// assert!(parse_problem_length_spec("(:length (:serial 123))").is_value(LengthSpec::new_serial(123)));
+/// assert!(parse_problem_length_spec("(:length (:parallel 42))").is_value(LengthSpec::new_parallel(42)));
+/// assert!(parse_problem_length_spec("(:length (:serial 123) (:parallel 42))").is_value(LengthSpec::new(Some(123), Some(42))));
 ///```
-pub fn parse_problem_length_spec(input: Span) -> ParseResult<LengthSpec> {
+pub fn parse_problem_length_spec<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, LengthSpec> {
     let serial = prefix_expr(":serial", nom::character::complete::u64);
     let parallel = prefix_expr(":parallel", nom::character::complete::u64);
     let length = prefix_expr(
@@ -27,7 +27,7 @@ pub fn parse_problem_length_spec(input: Span) -> ParseResult<LengthSpec> {
 
     map(length, |(serial, parallel)| {
         LengthSpec::new(serial, parallel)
-    })(input)
+    })(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for LengthSpec {

--- a/src/parsers/length_spec.rs
+++ b/src/parsers/length_spec.rs
@@ -1,26 +1,25 @@
 //! Provides parsers for length specification.
 
-use crate::parsers::prefix_expr;
+use crate::parsers::{prefix_expr, ParseResult, Span};
 use crate::types::LengthSpec;
-use nom::character::complete::{digit1, multispace0};
-use nom::combinator::{map, map_res, opt, recognize};
+use nom::character::complete::multispace0;
+use nom::combinator::{map, opt};
 use nom::sequence::{preceded, tuple};
-use nom::IResult;
 
 /// Parses a length specification. Deprecated since PDDL 2.1.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_problem_length_spec;
+/// # use pddl::parsers::{parse_problem_length_spec, preamble::*};
 /// # use pddl::LengthSpec;
-/// assert_eq!(parse_problem_length_spec("(:length)"), Ok(("", LengthSpec::default())));
-/// assert_eq!(parse_problem_length_spec("(:length (:serial 123))"), Ok(("", LengthSpec::new_serial(123))));
-/// assert_eq!(parse_problem_length_spec("(:length (:parallel 42))"), Ok(("", LengthSpec::new_parallel(42))));
-/// assert_eq!(parse_problem_length_spec("(:length (:serial 123) (:parallel 42))"), Ok(("", LengthSpec::new(Some(123), Some(42)))));
+/// assert!(parse_problem_length_spec("(:length)".into()).is_value(LengthSpec::default()));
+/// assert!(parse_problem_length_spec("(:length (:serial 123))".into()).is_value(LengthSpec::new_serial(123)));
+/// assert!(parse_problem_length_spec("(:length (:parallel 42))".into()).is_value(LengthSpec::new_parallel(42)));
+/// assert!(parse_problem_length_spec("(:length (:serial 123) (:parallel 42))".into()).is_value(LengthSpec::new(Some(123), Some(42))));
 ///```
-pub fn parse_problem_length_spec(input: &str) -> IResult<&str, LengthSpec> {
-    let serial = prefix_expr(":serial", map_res(recognize(digit1), str::parse));
-    let parallel = prefix_expr(":parallel", map_res(recognize(digit1), str::parse));
+pub fn parse_problem_length_spec(input: Span) -> ParseResult<LengthSpec> {
+    let serial = prefix_expr(":serial", nom::character::complete::u64);
+    let parallel = prefix_expr(":parallel", nom::character::complete::u64);
     let length = prefix_expr(
         ":length",
         tuple((opt(serial), opt(preceded(multispace0, parallel)))),
@@ -35,7 +34,7 @@ impl<'a> crate::parsers::Parser<'a> for LengthSpec {
     type Item = LengthSpec;
 
     /// See [`parse_problem_length_spec`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_problem_length_spec(input)
     }
 }

--- a/src/parsers/length_spec.rs
+++ b/src/parsers/length_spec.rs
@@ -30,11 +30,11 @@ pub fn parse_problem_length_spec<'a, T: Into<Span<'a>>>(input: T) -> ParseResult
     })(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for LengthSpec {
+impl crate::parsers::Parser for LengthSpec {
     type Item = LengthSpec;
 
     /// See [`parse_problem_length_spec`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_problem_length_spec(input)
     }
 }

--- a/src/parsers/length_spec.rs
+++ b/src/parsers/length_spec.rs
@@ -34,7 +34,7 @@ impl<'a> crate::parsers::Parser<'a> for LengthSpec {
     type Item = LengthSpec;
 
     /// See [`parse_problem_length_spec`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_problem_length_spec(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_problem_length_spec(input.into())
     }
 }

--- a/src/parsers/length_spec.rs
+++ b/src/parsers/length_spec.rs
@@ -35,6 +35,6 @@ impl<'a> crate::parsers::Parser<'a> for LengthSpec {
 
     /// See [`parse_problem_length_spec`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_problem_length_spec(input.into())
+        parse_problem_length_spec(input)
     }
 }

--- a/src/parsers/metric_f_exp.rs
+++ b/src/parsers/metric_f_exp.rs
@@ -139,7 +139,7 @@ impl<'a> crate::parsers::Parser<'a> for MetricFExp<'a> {
     type Item = MetricFExp<'a>;
 
     /// See [`parse_metric_f_exp`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_metric_f_exp(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_metric_f_exp(input.into())
     }
 }

--- a/src/parsers/metric_f_exp.rs
+++ b/src/parsers/metric_f_exp.rs
@@ -140,6 +140,6 @@ impl<'a> crate::parsers::Parser<'a> for MetricFExp<'a> {
 
     /// See [`parse_metric_f_exp`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_metric_f_exp(input.into())
+        parse_metric_f_exp(input)
     }
 }

--- a/src/parsers/metric_f_exp.rs
+++ b/src/parsers/metric_f_exp.rs
@@ -75,7 +75,7 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 ///```
-pub fn parse_metric_f_exp<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, MetricFExp<'a>> {
+pub fn parse_metric_f_exp<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, MetricFExp> {
     let binary_op = map(
         parens(tuple((
             parse_binary_op,
@@ -135,11 +135,11 @@ pub fn parse_metric_f_exp<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Me
     ))(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for MetricFExp<'a> {
-    type Item = MetricFExp<'a>;
+impl crate::parsers::Parser for MetricFExp {
+    type Item = MetricFExp;
 
     /// See [`parse_metric_f_exp`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_metric_f_exp(input)
     }
 }

--- a/src/parsers/metric_f_exp.rs
+++ b/src/parsers/metric_f_exp.rs
@@ -18,17 +18,17 @@ use nom::sequence::{preceded, tuple};
 /// ```
 /// # use pddl::parsers::{parse_metric_f_exp, preamble::*};
 /// # use pddl::{BinaryOp, MetricFExp, FunctionSymbol, MultiOp, Name, PreferenceName};
-/// assert!(parse_metric_f_exp("1.23".into()).is_value(
+/// assert!(parse_metric_f_exp("1.23").is_value(
 ///     MetricFExp::new_number(1.23)
 /// ));
 ///
-/// assert!(parse_metric_f_exp("(- total-time)".into()).is_value(
+/// assert!(parse_metric_f_exp("(- total-time)").is_value(
 ///     MetricFExp::new_negative(
 ///         MetricFExp::TotalTime
 ///     )
 /// ));
 ///
-/// assert!(parse_metric_f_exp("(+ 1.23 2.34)".into()).is_value(
+/// assert!(parse_metric_f_exp("(+ 1.23 2.34)").is_value(
 ///     MetricFExp::new_binary_op(
 ///         BinaryOp::Addition,
 ///         MetricFExp::new_number(1.23),
@@ -36,7 +36,7 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 ///
-/// assert!(parse_metric_f_exp("(+ 1.23 2.34 3.45)".into()).is_value(
+/// assert!(parse_metric_f_exp("(+ 1.23 2.34 3.45)").is_value(
 ///     MetricFExp::new_multi_op(
 ///         MultiOp::Addition,
 ///         MetricFExp::new_number(1.23),
@@ -44,27 +44,27 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 ///
-/// assert!(parse_metric_f_exp("(is-violated preference)".into()).is_value(
+/// assert!(parse_metric_f_exp("(is-violated preference)").is_value(
 ///     MetricFExp::new_is_violated(
 ///         PreferenceName::from("preference")
 ///     )
 /// ));
 ///
-/// assert!(parse_metric_f_exp("fun-sym".into()).is_value(
+/// assert!(parse_metric_f_exp("fun-sym").is_value(
 ///     MetricFExp::new_function(
 ///         FunctionSymbol::from_str("fun-sym"),
 ///         []
 ///     )
 /// ));
 ///
-/// assert!(parse_metric_f_exp("(fun-sym)".into()).is_value(
+/// assert!(parse_metric_f_exp("(fun-sym)").is_value(
 ///     MetricFExp::new_function(
 ///         FunctionSymbol::from_str("fun-sym"),
 ///         []
 ///     )
 /// ));
 ///
-/// assert!(parse_metric_f_exp("(fun-sym a b c)".into()).is_value(
+/// assert!(parse_metric_f_exp("(fun-sym a b c)").is_value(
 ///     MetricFExp::new_function(
 ///         FunctionSymbol::from_str("fun-sym"),
 ///         [
@@ -75,7 +75,7 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 ///```
-pub fn parse_metric_f_exp(input: Span) -> ParseResult<MetricFExp> {
+pub fn parse_metric_f_exp<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, MetricFExp<'a>> {
     let binary_op = map(
         parens(tuple((
             parse_binary_op,
@@ -132,7 +132,7 @@ pub fn parse_metric_f_exp(input: Span) -> ParseResult<MetricFExp> {
         is_violated,
         complex_function,
         simple_function,
-    ))(input)
+    ))(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for MetricFExp<'a> {

--- a/src/parsers/metric_spec.rs
+++ b/src/parsers/metric_spec.rs
@@ -40,6 +40,6 @@ impl<'a> crate::parsers::Parser<'a> for MetricSpec<'a> {
 
     /// See [`parse_problem_metric_spec`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_problem_metric_spec(input.into())
+        parse_problem_metric_spec(input)
     }
 }

--- a/src/parsers/metric_spec.rs
+++ b/src/parsers/metric_spec.rs
@@ -12,14 +12,16 @@ use nom::sequence::{preceded, tuple};
 /// ```
 /// # use pddl::parsers::{parse_problem_metric_spec, preamble::*};
 /// # use pddl::{MetricFExp, MetricSpec, Optimization};
-/// assert!(parse_problem_metric_spec("(:metric minimize total-time)".into()).is_value(
+/// assert!(parse_problem_metric_spec("(:metric minimize total-time)").is_value(
 ///     MetricSpec::new(
 ///         Optimization::Minimize,
 ///         MetricFExp::TotalTime
 ///     )
 /// ));
 ///```
-pub fn parse_problem_metric_spec(input: Span) -> ParseResult<MetricSpec> {
+pub fn parse_problem_metric_spec<'a, T: Into<Span<'a>>>(
+    input: T,
+) -> ParseResult<'a, MetricSpec<'a>> {
     // :numeric-fluents
     map(
         prefix_expr(
@@ -30,7 +32,7 @@ pub fn parse_problem_metric_spec(input: Span) -> ParseResult<MetricSpec> {
             )),
         ),
         |(optimization, exp)| MetricSpec::new(optimization, exp),
-    )(input)
+    )(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for MetricSpec<'a> {

--- a/src/parsers/metric_spec.rs
+++ b/src/parsers/metric_spec.rs
@@ -37,7 +37,7 @@ impl<'a> crate::parsers::Parser<'a> for MetricSpec<'a> {
     type Item = MetricSpec<'a>;
 
     /// See [`parse_problem_metric_spec`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_problem_metric_spec(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_problem_metric_spec(input.into())
     }
 }

--- a/src/parsers/metric_spec.rs
+++ b/src/parsers/metric_spec.rs
@@ -19,9 +19,7 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 ///```
-pub fn parse_problem_metric_spec<'a, T: Into<Span<'a>>>(
-    input: T,
-) -> ParseResult<'a, MetricSpec<'a>> {
+pub fn parse_problem_metric_spec<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, MetricSpec> {
     // :numeric-fluents
     map(
         prefix_expr(
@@ -35,11 +33,11 @@ pub fn parse_problem_metric_spec<'a, T: Into<Span<'a>>>(
     )(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for MetricSpec<'a> {
-    type Item = MetricSpec<'a>;
+impl crate::parsers::Parser for MetricSpec {
+    type Item = MetricSpec;
 
     /// See [`parse_problem_metric_spec`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_problem_metric_spec(input)
     }
 }

--- a/src/parsers/metric_spec.rs
+++ b/src/parsers/metric_spec.rs
@@ -1,26 +1,25 @@
 //! Provides parsers for metric specification.
 
-use crate::parsers::{parse_metric_f_exp, parse_optimization, prefix_expr};
+use crate::parsers::{parse_metric_f_exp, parse_optimization, prefix_expr, ParseResult, Span};
 use crate::types::MetricSpec;
 use nom::character::complete::multispace1;
 use nom::combinator::map;
 use nom::sequence::{preceded, tuple};
-use nom::IResult;
 
 /// Parses a metric specification.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_problem_metric_spec;
+/// # use pddl::parsers::{parse_problem_metric_spec, preamble::*};
 /// # use pddl::{MetricFExp, MetricSpec, Optimization};
-/// assert_eq!(parse_problem_metric_spec("(:metric minimize total-time)"), Ok(("",
+/// assert!(parse_problem_metric_spec("(:metric minimize total-time)".into()).is_value(
 ///     MetricSpec::new(
 ///         Optimization::Minimize,
 ///         MetricFExp::TotalTime
 ///     )
-/// )));
+/// ));
 ///```
-pub fn parse_problem_metric_spec(input: &str) -> IResult<&str, MetricSpec> {
+pub fn parse_problem_metric_spec(input: Span) -> ParseResult<MetricSpec> {
     // :numeric-fluents
     map(
         prefix_expr(
@@ -38,7 +37,7 @@ impl<'a> crate::parsers::Parser<'a> for MetricSpec<'a> {
     type Item = MetricSpec<'a>;
 
     /// See [`parse_problem_metric_spec`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_problem_metric_spec(input)
     }
 }

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -66,6 +66,7 @@ mod requirements;
 mod simple_duration_constraint;
 mod structure_def;
 mod term;
+mod test_helpers;
 mod time_specifier;
 mod timed_effect;
 mod timed_gd;
@@ -76,12 +77,36 @@ mod types_def;
 mod utilities;
 mod variable;
 
+#[cfg(test)]
+pub(crate) use test_helpers::Match;
+pub use test_helpers::UnwrapValue;
+
 /// Provides the `parse` method.
 pub trait Parser<'a> {
     type Item;
 
     /// Parses the `input` into the specified [`Item`](Self::Item) type.
-    fn parse(input: &'a str) -> nom::IResult<&str, Self::Item>;
+    fn parse_str(input: &'a str) -> ParseResult<Self::Item> {
+        Self::parse(Span::new(input))
+    }
+
+    /// Parses the `input` into the specified [`Item`](Self::Item) type.
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item>;
+}
+
+/// Input type for parsers.
+pub type Span<'a> = nom_locate::LocatedSpan<&'a str>;
+
+/// A parsing error.
+pub type ParseError<'a> = nom_greedyerror::GreedyError<Span<'a>, nom::error::ErrorKind>;
+
+/// A result from a parser.
+pub type ParseResult<'a, T, E = ParseError<'a>> = nom::IResult<Span<'a>, T, E>;
+
+pub mod preamble {
+    pub use crate::parsers::test_helpers::UnwrapValue;
+    pub use crate::parsers::Parser;
+    pub use crate::parsers::{ParseError, ParseResult, Span};
 }
 
 // Parsers.

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -82,14 +82,14 @@ pub(crate) use test_helpers::Match;
 pub use test_helpers::UnwrapValue;
 
 /// Provides the `parse` method.
-pub trait Parser<'a> {
+pub trait Parser {
     type Item;
 
     /// Parses the `input` into the specified [`Item`](Self::Item) type.
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item>;
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item>;
 
     /// Parses the `input` into the specified [`Item`](Self::Item) type.
-    fn parse_span(input: Span<'a>) -> ParseResult<Self::Item> {
+    fn parse_span(input: Span) -> ParseResult<Self::Item> {
         Self::parse(input)
     }
 }

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -92,6 +92,13 @@ pub trait Parser {
     fn parse_span(input: Span) -> ParseResult<Self::Item> {
         Self::parse(input)
     }
+
+    /// Uses the [`Parser::parse`] method to parse the input and, if successful,
+    /// discards the unparsed remaining input.
+    fn from_str(input: &str) -> Result<Self::Item, nom::Err<ParseError>> {
+        let (_, value) = Self::parse(input)?;
+        Ok(value)
+    }
 }
 
 /// Input type for parsers.

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -86,12 +86,12 @@ pub trait Parser<'a> {
     type Item;
 
     /// Parses the `input` into the specified [`Item`](Self::Item) type.
-    fn parse_str(input: &'a str) -> ParseResult<Self::Item> {
-        Self::parse(Span::new(input))
-    }
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item>;
 
     /// Parses the `input` into the specified [`Item`](Self::Item) type.
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item>;
+    fn parse_span(input: Span<'a>) -> ParseResult<Self::Item> {
+        Self::parse(input)
+    }
 }
 
 /// Input type for parsers.

--- a/src/parsers/multi_op.rs
+++ b/src/parsers/multi_op.rs
@@ -12,14 +12,14 @@ use nom::combinator::map;
 /// ```
 /// # use pddl::parsers::{parse_multi_op, preamble::*};
 /// # use pddl::{MultiOp};
-/// assert!(parse_multi_op("*".into()).is_value(MultiOp::Multiplication));
-/// assert!(parse_multi_op("+".into()).is_value(MultiOp::Addition));
+/// assert!(parse_multi_op("*").is_value(MultiOp::Multiplication));
+/// assert!(parse_multi_op("+").is_value(MultiOp::Addition));
 ///```
-pub fn parse_multi_op(input: Span) -> ParseResult<MultiOp> {
+pub fn parse_multi_op<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, MultiOp> {
     map(
         alt((tag(names::MULTIPLICATION), tag(names::ADDITION))),
         |x: Span| MultiOp::try_from(*x.fragment()).expect("unhandled variant"),
-    )(input)
+    )(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for MultiOp {

--- a/src/parsers/multi_op.rs
+++ b/src/parsers/multi_op.rs
@@ -26,7 +26,7 @@ impl<'a> crate::parsers::Parser<'a> for MultiOp {
     type Item = MultiOp;
 
     /// See [`parse_multi_op`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_multi_op(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_multi_op(input.into())
     }
 }

--- a/src/parsers/multi_op.rs
+++ b/src/parsers/multi_op.rs
@@ -22,11 +22,11 @@ pub fn parse_multi_op<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, MultiO
     )(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for MultiOp {
+impl crate::parsers::Parser for MultiOp {
     type Item = MultiOp;
 
     /// See [`parse_multi_op`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_multi_op(input)
     }
 }

--- a/src/parsers/multi_op.rs
+++ b/src/parsers/multi_op.rs
@@ -27,6 +27,6 @@ impl<'a> crate::parsers::Parser<'a> for MultiOp {
 
     /// See [`parse_multi_op`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_multi_op(input.into())
+        parse_multi_op(input)
     }
 }

--- a/src/parsers/multi_op.rs
+++ b/src/parsers/multi_op.rs
@@ -1,24 +1,24 @@
 //! Provides parsers for multi-operand operations.
 
+use crate::parsers::{ParseResult, Span};
 use crate::types::{multi_op::names, MultiOp};
 use nom::branch::alt;
 use nom::bytes::complete::tag;
-use nom::combinator::map_res;
-use nom::IResult;
+use nom::combinator::map;
 
 /// Parses a multi-operand operation, i.e. `* | +`.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_multi_op;
+/// # use pddl::parsers::{parse_multi_op, preamble::*};
 /// # use pddl::{MultiOp};
-/// assert_eq!(parse_multi_op("*"), Ok(("", MultiOp::Multiplication)));
-/// assert_eq!(parse_multi_op("+"), Ok(("", MultiOp::Addition)));
+/// assert!(parse_multi_op("*".into()).is_value(MultiOp::Multiplication));
+/// assert!(parse_multi_op("+".into()).is_value(MultiOp::Addition));
 ///```
-pub fn parse_multi_op(input: &str) -> IResult<&str, MultiOp> {
-    map_res(
+pub fn parse_multi_op(input: Span) -> ParseResult<MultiOp> {
+    map(
         alt((tag(names::MULTIPLICATION), tag(names::ADDITION))),
-        MultiOp::try_from,
+        |x: Span| MultiOp::try_from(*x.fragment()).expect("unhandled variant"),
     )(input)
 }
 
@@ -26,7 +26,7 @@ impl<'a> crate::parsers::Parser<'a> for MultiOp {
     type Item = MultiOp;
 
     /// See [`parse_multi_op`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_multi_op(input)
     }
 }

--- a/src/parsers/name.rs
+++ b/src/parsers/name.rs
@@ -14,22 +14,22 @@ use nom::sequence::tuple;
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_name, preamble::*};
-/// assert!(parse_name(Span::new("abcde")).is_value("abcde".into()));
-/// assert!(parse_name(Span::new("a-1_2")).is_value("a-1_2".into()));
-/// assert!(parse_name(Span::new("Z01")).is_value("Z01".into()));
-/// assert!(parse_name(Span::new("x-_-_")).is_value("x-_-_".into()));
+/// assert!(parse_name("abcde").is_value("abcde".into()));
+/// assert!(parse_name("a-1_2").is_value("a-1_2".into()));
+/// assert!(parse_name("Z01").is_value("Z01".into()));
+/// assert!(parse_name("x-_-_").is_value("x-_-_".into()));
 ///
-/// assert!(parse_name(Span::new("")).is_err());
-/// assert!(parse_name(Span::new(".")).is_err());
-/// assert!(parse_name(Span::new("-abc")).is_err());
-/// assert!(parse_name(Span::new("0124")).is_err());
-/// assert!(parse_name(Span::new("-1")).is_err());
+/// assert!(parse_name("").is_err());
+/// assert!(parse_name(".").is_err());
+/// assert!(parse_name("-abc").is_err());
+/// assert!(parse_name("0124").is_err());
+/// assert!(parse_name("-1").is_err());
 ///```
-pub fn parse_name(input: Span) -> ParseResult<Name> {
+pub fn parse_name<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Name<'a>> {
     map(
         recognize(tuple((alpha1, many0(parse_any_char)))),
         |x: Span| Name::from(*x.fragment()),
-    )(input)
+    )(input.into())
 }
 
 /// Parses any accepted character.
@@ -41,7 +41,7 @@ impl<'a> crate::parsers::Parser<'a> for Name<'a> {
     type Item = Name<'a>;
 
     /// See [`parse_name`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_name(input)
     }
 }

--- a/src/parsers/name.rs
+++ b/src/parsers/name.rs
@@ -25,7 +25,7 @@ use nom::sequence::tuple;
 /// assert!(parse_name("0124").is_err());
 /// assert!(parse_name("-1").is_err());
 ///```
-pub fn parse_name<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Name<'a>> {
+pub fn parse_name<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Name> {
     map(
         recognize(tuple((alpha1, many0(parse_any_char)))),
         |x: Span| Name::from(*x.fragment()),
@@ -37,11 +37,11 @@ pub fn parse_any_char(input: Span) -> ParseResult<Span> {
     recognize(alt((alpha1, digit1, tag("-"), tag("_"))))(input)
 }
 
-impl<'a> crate::parsers::Parser<'a> for Name<'a> {
-    type Item = Name<'a>;
+impl crate::parsers::Parser for Name {
+    type Item = Name;
 
     /// See [`parse_name`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_name(input)
     }
 }

--- a/src/parsers/number.rs
+++ b/src/parsers/number.rs
@@ -1,59 +1,44 @@
 //! Provides parsers for numbers, decimals and digits.
 
+use crate::parsers::{ParseResult, Span};
 use crate::types::Number;
 use nom::character::complete::{char, digit1};
-use nom::character::is_digit;
-use nom::combinator::{map_res, recognize};
-use nom::error::ErrorKind;
+use nom::combinator::{map, recognize};
 use nom::multi::many_m_n;
+use nom::number::complete::float;
 use nom::sequence::tuple;
-use nom::{error_position, IResult};
-use std::str::FromStr;
+use nom::Parser;
 
 /// Parses a number, i.e. `<digit>⁺[<decimal>]`.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_number;
-/// assert_eq!(parse_number("0"), Ok(("", 0.0.into())));
-/// assert_eq!(parse_number("1000a"), Ok(("a", 1000.0.into())));
-/// assert_eq!(parse_number("012"), Ok(("", 12.0.into())));
-/// assert_eq!(parse_number("1.234"), Ok(("", 1.234.into())));
+/// # use pddl::parsers::{parse_number, preamble::*};
+/// assert!(parse_number("0".into()).is_value(0.0.into()));
+/// assert!(parse_number("1000a".into()).is_value(1000.0.into()));
+/// assert!(parse_number("012".into()).is_value(12.0.into()));
+/// assert!(parse_number("1.234".into()).is_value(1.234.into()));
 ///
-/// assert!(parse_number(".0").is_err());
-/// assert!(parse_number(".").is_err());
-/// assert!(parse_number("-1").is_err());
+/// assert!(parse_number(".0".into()).is_err());
+/// assert!(parse_number(".".into()).is_err());
+/// assert!(parse_number("-1".into()).is_err());
 ///```
-pub fn parse_number(input: &str) -> IResult<&str, Number> {
-    map_res(
-        recognize(tuple((digit1, many_m_n(0, 1, parse_decimal)))),
-        Number::from_str,
-    )(input)
+pub fn parse_number(input: Span) -> ParseResult<Number> {
+    let pattern = recognize(tuple((digit1, many_m_n(0, 1, parse_decimal))));
+    let float = pattern.and_then(float);
+    map(float, Number::new)(input)
 }
 
 /// Parses a decimal, i.e. `.<digit>⁺`.
-pub fn parse_decimal(input: &str) -> IResult<&str, &str> {
+pub fn parse_decimal(input: Span) -> ParseResult<Span> {
     recognize(tuple((char('.'), digit1)))(input)
-}
-
-/// Parses a decimal, i.e. `0..9`.
-pub fn parse_digit(input: &str) -> IResult<&str, &str> {
-    if input.is_empty() {
-        return Err(nom::Err::Error(error_position!(input, ErrorKind::Count)));
-    }
-
-    if !is_digit(input.as_bytes()[0]) {
-        return Err(nom::Err::Error(error_position!(input, ErrorKind::Digit)));
-    }
-
-    Ok((&input[1..], &input[..1]))
 }
 
 impl<'a> crate::parsers::Parser<'a> for Number {
     type Item = Number;
 
     /// See [`parse_number`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_number(input)
     }
 }
@@ -61,22 +46,13 @@ impl<'a> crate::parsers::Parser<'a> for Number {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parsers::Match;
 
     #[test]
     fn parse_decimal_works() {
-        assert_eq!(parse_decimal(".0"), Ok(("", ".0")));
-        assert_eq!(parse_decimal(".012"), Ok(("", ".012")));
-        assert!(parse_decimal(".").is_err());
-        assert!(parse_decimal("012").is_err());
-    }
-
-    #[test]
-    fn parse_digit_works() {
-        assert_eq!(parse_digit("0"), Ok(("", "0")));
-        assert_eq!(parse_digit("12"), Ok(("2", "1")));
-        assert_eq!(parse_digit("1a"), Ok(("a", "1")));
-        assert_eq!(parse_digit("91a"), Ok(("1a", "9")));
-        assert!(parse_digit("").is_err());
-        assert!(parse_digit("a").is_err());
+        assert!(parse_decimal(Span::new(".0")).is_exactly(".0"));
+        assert!(parse_decimal(Span::new(".012")).is_exactly(".012"));
+        assert!(parse_decimal(Span::new(".")).is_err());
+        assert!(parse_decimal(Span::new("012")).is_err());
     }
 }

--- a/src/parsers/number.rs
+++ b/src/parsers/number.rs
@@ -34,11 +34,11 @@ pub fn parse_decimal(input: Span) -> ParseResult<Span> {
     recognize(tuple((char('.'), digit1)))(input)
 }
 
-impl<'a> crate::parsers::Parser<'a> for Number {
+impl crate::parsers::Parser for Number {
     type Item = Number;
 
     /// See [`parse_number`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_number(input)
     }
 }

--- a/src/parsers/number.rs
+++ b/src/parsers/number.rs
@@ -14,19 +14,19 @@ use nom::Parser;
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_number, preamble::*};
-/// assert!(parse_number("0".into()).is_value(0.0.into()));
-/// assert!(parse_number("1000a".into()).is_value(1000.0.into()));
-/// assert!(parse_number("012".into()).is_value(12.0.into()));
-/// assert!(parse_number("1.234".into()).is_value(1.234.into()));
+/// assert!(parse_number("0").is_value(0.0.into()));
+/// assert!(parse_number("1000a").is_value(1000.0.into()));
+/// assert!(parse_number("012").is_value(12.0.into()));
+/// assert!(parse_number("1.234").is_value(1.234.into()));
 ///
-/// assert!(parse_number(".0".into()).is_err());
-/// assert!(parse_number(".".into()).is_err());
-/// assert!(parse_number("-1".into()).is_err());
+/// assert!(parse_number(".0").is_err());
+/// assert!(parse_number(".").is_err());
+/// assert!(parse_number("-1").is_err());
 ///```
-pub fn parse_number(input: Span) -> ParseResult<Number> {
+pub fn parse_number<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Number> {
     let pattern = recognize(tuple((digit1, many_m_n(0, 1, parse_decimal))));
     let float = pattern.and_then(float);
-    map(float, Number::new)(input)
+    map(float, Number::new)(input.into())
 }
 
 /// Parses a decimal, i.e. `.<digit>⁺`.

--- a/src/parsers/number.rs
+++ b/src/parsers/number.rs
@@ -39,7 +39,7 @@ impl<'a> crate::parsers::Parser<'a> for Number {
 
     /// See [`parse_number`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_number(input.into())
+        parse_number(input)
     }
 }
 

--- a/src/parsers/number.rs
+++ b/src/parsers/number.rs
@@ -38,8 +38,8 @@ impl<'a> crate::parsers::Parser<'a> for Number {
     type Item = Number;
 
     /// See [`parse_number`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_number(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_number(input.into())
     }
 }
 

--- a/src/parsers/objects_def.rs
+++ b/src/parsers/objects_def.rs
@@ -11,18 +11,20 @@ use nom::combinator::map;
 /// # use pddl::parsers::{parse_problem_objects_declaration, preamble::*};
 /// # use pddl::{Name, Objects, ToTyped, Type};
 /// let input = "(:objects train1 train2)";
-/// assert!(parse_problem_objects_declaration(input.into()).is_value(
+/// assert!(parse_problem_objects_declaration(input).is_value(
 ///     Objects::new([
 ///         Name::new("train1").to_typed(Type::OBJECT),
 ///         Name::new("train2").to_typed(Type::OBJECT),
 ///     ])
 /// ));
 /// ```
-pub fn parse_problem_objects_declaration(input: Span) -> ParseResult<Objects> {
+pub fn parse_problem_objects_declaration<'a, T: Into<Span<'a>>>(
+    input: T,
+) -> ParseResult<'a, Objects<'a>> {
     map(
         prefix_expr(":objects", typed_list(parse_name)),
         Objects::new,
-    )(input)
+    )(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for Objects<'a> {

--- a/src/parsers/objects_def.rs
+++ b/src/parsers/objects_def.rs
@@ -1,25 +1,24 @@
 //! Provides parsers for goal object declarations.
 
-use crate::parsers::{parse_name, prefix_expr, typed_list};
+use crate::parsers::{parse_name, prefix_expr, typed_list, ParseResult, Span};
 use crate::types::Objects;
 use nom::combinator::map;
-use nom::IResult;
 
 /// Parser for goal object declarations.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::{parse_problem_objects_declaration};
+/// # use pddl::parsers::{parse_problem_objects_declaration, preamble::*};
 /// # use pddl::{Name, Objects, ToTyped, Type};
 /// let input = "(:objects train1 train2)";
-/// assert_eq!(parse_problem_objects_declaration(input), Ok(("",
+/// assert!(parse_problem_objects_declaration(input.into()).is_value(
 ///     Objects::new([
 ///         Name::new("train1").to_typed(Type::OBJECT),
 ///         Name::new("train2").to_typed(Type::OBJECT),
 ///     ])
-/// )));
+/// ));
 /// ```
-pub fn parse_problem_objects_declaration(input: &str) -> IResult<&str, Objects> {
+pub fn parse_problem_objects_declaration(input: Span) -> ParseResult<Objects> {
     map(
         prefix_expr(":objects", typed_list(parse_name)),
         Objects::new,
@@ -30,7 +29,7 @@ impl<'a> crate::parsers::Parser<'a> for Objects<'a> {
     type Item = Objects<'a>;
 
     /// See [`parse_problem_objects_declaration`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_problem_objects_declaration(input)
     }
 }

--- a/src/parsers/objects_def.rs
+++ b/src/parsers/objects_def.rs
@@ -32,6 +32,6 @@ impl<'a> crate::parsers::Parser<'a> for Objects<'a> {
 
     /// See [`parse_problem_objects_declaration`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_problem_objects_declaration(input.into())
+        parse_problem_objects_declaration(input)
     }
 }

--- a/src/parsers/objects_def.rs
+++ b/src/parsers/objects_def.rs
@@ -20,18 +20,18 @@ use nom::combinator::map;
 /// ```
 pub fn parse_problem_objects_declaration<'a, T: Into<Span<'a>>>(
     input: T,
-) -> ParseResult<'a, Objects<'a>> {
+) -> ParseResult<'a, Objects> {
     map(
         prefix_expr(":objects", typed_list(parse_name)),
         Objects::new,
     )(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for Objects<'a> {
-    type Item = Objects<'a>;
+impl crate::parsers::Parser for Objects {
+    type Item = Objects;
 
     /// See [`parse_problem_objects_declaration`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_problem_objects_declaration(input)
     }
 }

--- a/src/parsers/objects_def.rs
+++ b/src/parsers/objects_def.rs
@@ -29,7 +29,7 @@ impl<'a> crate::parsers::Parser<'a> for Objects<'a> {
     type Item = Objects<'a>;
 
     /// See [`parse_problem_objects_declaration`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_problem_objects_declaration(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_problem_objects_declaration(input.into())
     }
 }

--- a/src/parsers/optimization.rs
+++ b/src/parsers/optimization.rs
@@ -22,11 +22,11 @@ pub fn parse_optimization<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Op
     )(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for Optimization {
+impl crate::parsers::Parser for Optimization {
     type Item = Optimization;
 
     /// See [`parse_optimization`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_optimization(input)
     }
 }

--- a/src/parsers/optimization.rs
+++ b/src/parsers/optimization.rs
@@ -27,6 +27,6 @@ impl<'a> crate::parsers::Parser<'a> for Optimization {
 
     /// See [`parse_optimization`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_optimization(input.into())
+        parse_optimization(input)
     }
 }

--- a/src/parsers/optimization.rs
+++ b/src/parsers/optimization.rs
@@ -26,7 +26,7 @@ impl<'a> crate::parsers::Parser<'a> for Optimization {
     type Item = Optimization;
 
     /// See [`parse_optimization`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_optimization(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_optimization(input.into())
     }
 }

--- a/src/parsers/optimization.rs
+++ b/src/parsers/optimization.rs
@@ -12,14 +12,14 @@ use nom::combinator::map;
 /// ```
 /// # use pddl::parsers::{parse_optimization, preamble::*};
 /// # use pddl::{Optimization};
-/// assert!(parse_optimization("minimize".into()).is_value(Optimization::Minimize));
-/// assert!(parse_optimization("maximize".into()).is_value(Optimization::Maximize));
+/// assert!(parse_optimization("minimize").is_value(Optimization::Minimize));
+/// assert!(parse_optimization("maximize").is_value(Optimization::Maximize));
 ///```
-pub fn parse_optimization(input: Span) -> ParseResult<Optimization> {
+pub fn parse_optimization<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Optimization> {
     map(
         alt((tag(names::MINIMIZE), tag(names::MAXIMIZE))),
         |x: Span| Optimization::try_from(*x.fragment()).expect("unhandled variant"),
-    )(input)
+    )(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for Optimization {

--- a/src/parsers/optimization.rs
+++ b/src/parsers/optimization.rs
@@ -1,24 +1,24 @@
 //! Provides parsers for optimization.
 
+use crate::parsers::{ParseResult, Span};
 use crate::types::{optimization::names, Optimization};
 use nom::branch::alt;
 use nom::bytes::complete::tag;
-use nom::combinator::map_res;
-use nom::IResult;
+use nom::combinator::map;
 
 /// Parses an optimization goal, i.e. `minimize | maximize`.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_optimization;
+/// # use pddl::parsers::{parse_optimization, preamble::*};
 /// # use pddl::{Optimization};
-/// assert_eq!(parse_optimization("minimize"), Ok(("", Optimization::Minimize)));
-/// assert_eq!(parse_optimization("maximize"), Ok(("", Optimization::Maximize)));
+/// assert!(parse_optimization("minimize".into()).is_value(Optimization::Minimize));
+/// assert!(parse_optimization("maximize".into()).is_value(Optimization::Maximize));
 ///```
-pub fn parse_optimization(input: &str) -> IResult<&str, Optimization> {
-    map_res(
+pub fn parse_optimization(input: Span) -> ParseResult<Optimization> {
+    map(
         alt((tag(names::MINIMIZE), tag(names::MAXIMIZE))),
-        Optimization::try_from,
+        |x: Span| Optimization::try_from(*x.fragment()).expect("unhandled variant"),
     )(input)
 }
 
@@ -26,7 +26,7 @@ impl<'a> crate::parsers::Parser<'a> for Optimization {
     type Item = Optimization;
 
     /// See [`parse_optimization`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_optimization(input)
     }
 }

--- a/src/parsers/p_effect.rs
+++ b/src/parsers/p_effect.rs
@@ -105,8 +105,8 @@ impl<'a> crate::parsers::Parser<'a> for PEffect<'a> {
     type Item = PEffect<'a>;
 
     /// See [`parse_p_effect`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_p_effect(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_p_effect(input.into())
     }
 }
 

--- a/src/parsers/p_effect.rs
+++ b/src/parsers/p_effect.rs
@@ -66,7 +66,7 @@ use nom::sequence::{preceded, terminated, tuple};
 ///     )
 /// ));
 /// ```
-pub fn parse_p_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, PEffect<'a>> {
+pub fn parse_p_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, PEffect> {
     let is = map(atomic_formula(parse_term), |af| PEffect::new(af));
     let is_not = map(prefix_expr("not", atomic_formula(parse_term)), |af| {
         PEffect::new_not(af)
@@ -101,11 +101,11 @@ pub fn parse_p_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, PEffec
     alt((object_undefined, object, numeric, is_not, is))(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for PEffect<'a> {
-    type Item = PEffect<'a>;
+impl crate::parsers::Parser for PEffect {
+    type Item = PEffect;
 
     /// See [`parse_p_effect`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_p_effect(input)
     }
 }

--- a/src/parsers/p_effect.rs
+++ b/src/parsers/p_effect.rs
@@ -18,7 +18,7 @@ use nom::sequence::{preceded, terminated, tuple};
 /// ```
 /// # use pddl::parsers::{parse_p_effect, preamble::*};
 /// # use pddl::{AssignOp, AtomicFormula, EqualityAtomicFormula, FExp, FHead, FunctionSymbol, FunctionTerm, PEffect, Term};
-/// assert!(parse_p_effect("(= x y)".into()).is_value(
+/// assert!(parse_p_effect("(= x y)").is_value(
 ///     PEffect::AtomicFormula(AtomicFormula::Equality(
 ///         EqualityAtomicFormula::new(
 ///             Term::Name("x".into()),
@@ -27,7 +27,7 @@ use nom::sequence::{preceded, terminated, tuple};
 ///     )
 /// ));
 ///
-/// assert!(parse_p_effect("(not (= ?a B))".into()).is_value(
+/// assert!(parse_p_effect("(not (= ?a B))").is_value(
 ///     PEffect::NotAtomicFormula(AtomicFormula::Equality(
 ///         EqualityAtomicFormula::new(
 ///             Term::Variable("a".into()),
@@ -36,7 +36,7 @@ use nom::sequence::{preceded, terminated, tuple};
 ///     )
 /// ));
 ///
-/// assert!(parse_p_effect("(assign fun-sym 1.23)".into()).is_value(
+/// assert!(parse_p_effect("(assign fun-sym 1.23)").is_value(
 ///     PEffect::new_numeric_fluent(
 ///         AssignOp::Assign,
 ///         FHead::new(FunctionSymbol::from_str("fun-sym")),
@@ -44,7 +44,7 @@ use nom::sequence::{preceded, terminated, tuple};
 ///     )
 /// ));
 ///
-/// assert!(parse_p_effect("(assign fun-sym 1.23)".into()).is_value(
+/// assert!(parse_p_effect("(assign fun-sym 1.23)").is_value(
 ///     PEffect::new_numeric_fluent(
 ///         AssignOp::Assign,
 ///         FHead::new(FunctionSymbol::from_str("fun-sym")),
@@ -52,21 +52,21 @@ use nom::sequence::{preceded, terminated, tuple};
 ///     )
 /// ));
 ///
-/// assert!(parse_p_effect("(assign (fun-sym) undefined)".into()).is_value(
+/// assert!(parse_p_effect("(assign (fun-sym) undefined)").is_value(
 ///     PEffect::new_object_fluent(
 ///         FunctionTerm::new(FunctionSymbol::from_str("fun-sym"), []),
 ///         None
 ///     )
 /// ));
 ///
-/// assert!(parse_p_effect("(assign (fun-sym) something)".into()).is_value(
+/// assert!(parse_p_effect("(assign (fun-sym) something)").is_value(
 ///     PEffect::new_object_fluent(
 ///         FunctionTerm::new(FunctionSymbol::from_str("fun-sym"), []),
 ///         Some(Term::Name("something".into()))
 ///     )
 /// ));
 /// ```
-pub fn parse_p_effect(input: Span) -> ParseResult<PEffect> {
+pub fn parse_p_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, PEffect<'a>> {
     let is = map(atomic_formula(parse_term), |af| PEffect::new(af));
     let is_not = map(prefix_expr("not", atomic_formula(parse_term)), |af| {
         PEffect::new_not(af)
@@ -98,7 +98,7 @@ pub fn parse_p_effect(input: Span) -> ParseResult<PEffect> {
         |(f_term, term)| PEffect::new_object_fluent(f_term, Some(term)),
     );
 
-    alt((object_undefined, object, numeric, is_not, is))(input)
+    alt((object_undefined, object, numeric, is_not, is))(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for PEffect<'a> {

--- a/src/parsers/p_effect.rs
+++ b/src/parsers/p_effect.rs
@@ -106,7 +106,7 @@ impl<'a> crate::parsers::Parser<'a> for PEffect<'a> {
 
     /// See [`parse_p_effect`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_p_effect(input.into())
+        parse_p_effect(input)
     }
 }
 

--- a/src/parsers/pre_gd.rs
+++ b/src/parsers/pre_gd.rs
@@ -68,7 +68,7 @@ use nom::sequence::{preceded, tuple};
 /// ```
 pub fn parse_pre_gd<'a, T: Into<Span<'a>>>(
     input: T,
-) -> ParseResult<'a, PreconditionGoalDefinitions<'a>> {
+) -> ParseResult<'a, PreconditionGoalDefinitions> {
     let pref_gd = map(parse_pref_gd, |x| {
         PreconditionGoalDefinitions::from(PreconditionGoalDefinition::new_preference(x))
     });
@@ -94,11 +94,11 @@ pub fn parse_pre_gd<'a, T: Into<Span<'a>>>(
     alt((forall, and, pref_gd))(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for PreconditionGoalDefinitions<'a> {
-    type Item = PreconditionGoalDefinitions<'a>;
+impl crate::parsers::Parser for PreconditionGoalDefinitions {
+    type Item = PreconditionGoalDefinitions;
 
     /// See [`parse_pre_gd`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_pre_gd(input)
     }
 }

--- a/src/parsers/pre_gd.rs
+++ b/src/parsers/pre_gd.rs
@@ -66,7 +66,9 @@ use nom::sequence::{preceded, tuple};
 ///     ).into()
 /// ));
 /// ```
-pub fn parse_pre_gd<'a>(input: Span<'a>) -> ParseResult<'a, PreconditionGoalDefinitions> {
+pub fn parse_pre_gd<'a, T: Into<Span<'a>>>(
+    input: T,
+) -> ParseResult<'a, PreconditionGoalDefinitions<'a>> {
     let pref_gd = map(parse_pref_gd, |x| {
         PreconditionGoalDefinitions::from(PreconditionGoalDefinition::new_preference(x))
     });
@@ -89,7 +91,7 @@ pub fn parse_pre_gd<'a>(input: Span<'a>) -> ParseResult<'a, PreconditionGoalDefi
         },
     );
 
-    alt((forall, and, pref_gd))(input)
+    alt((forall, and, pref_gd))(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for PreconditionGoalDefinitions<'a> {

--- a/src/parsers/pre_gd.rs
+++ b/src/parsers/pre_gd.rs
@@ -96,7 +96,7 @@ impl<'a> crate::parsers::Parser<'a> for PreconditionGoalDefinitions<'a> {
     type Item = PreconditionGoalDefinitions<'a>;
 
     /// See [`parse_pre_gd`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_pre_gd(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_pre_gd(input.into())
     }
 }

--- a/src/parsers/pre_gd.rs
+++ b/src/parsers/pre_gd.rs
@@ -1,6 +1,6 @@
 //! Provides parsers for goal definitions.
 
-use crate::parsers::{parens, prefix_expr, space_separated_list0, typed_list};
+use crate::parsers::{parens, prefix_expr, space_separated_list0, typed_list, ParseResult, Span};
 use crate::parsers::{parse_pref_gd, parse_variable};
 use crate::types::PreconditionGoalDefinition;
 use crate::PreconditionGoalDefinitions;
@@ -8,15 +8,14 @@ use nom::branch::alt;
 use nom::character::complete::multispace1;
 use nom::combinator::map;
 use nom::sequence::{preceded, tuple};
-use nom::IResult;
 
 /// Parser for goal definitions.
 ///
 /// ## Examples
 /// ```
-/// # use pddl::parsers::{parse_pre_gd};
+/// # use pddl::parsers::{parse_pre_gd, preamble::*};
 /// # use pddl::{AtomicFormula, EqualityAtomicFormula, GoalDefinition, Literal, Preference, PreferenceName, PreferenceGD, PreconditionGoalDefinitions, PreconditionGoalDefinition, Term, Variable, Type, Typed, TypedList};
-/// assert_eq!(parse_pre_gd("(= x y)"), Ok(("",
+/// assert!(parse_pre_gd(Span::new("(= x y)")).is_value(
 ///     PreconditionGoalDefinitions::new_preference(
 ///         PreferenceGD::Goal(
 ///             GoalDefinition::AtomicFormula(
@@ -27,9 +26,9 @@ use nom::IResult;
 ///             )
 ///         )
 ///     )
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_pre_gd("(and (= x y) (= a b))"), Ok(("",
+/// assert!(parse_pre_gd(Span::new("(and (= x y) (= a b))")).is_value(
 ///     PreconditionGoalDefinitions::from_iter([
 ///         PreconditionGoalDefinition::Preference(PreferenceGD::Goal(
 ///             GoalDefinition::AtomicFormula(
@@ -48,9 +47,9 @@ use nom::IResult;
 ///             )
 ///         ))
 ///     ])
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_pre_gd("(forall (?a ?b) (= a b))"), Ok(("",
+/// assert!(parse_pre_gd(Span::new("(forall (?a ?b) (= a b))")).is_value(
 ///     PreconditionGoalDefinition::new_forall(
 ///         TypedList::from_iter([
 ///             Typed::new(Variable::from_str("a"), Type::OBJECT),
@@ -65,9 +64,9 @@ use nom::IResult;
 ///             )
 ///         )).into()
 ///     ).into()
-/// )));
+/// ));
 /// ```
-pub fn parse_pre_gd(input: &str) -> IResult<&str, PreconditionGoalDefinitions> {
+pub fn parse_pre_gd<'a>(input: Span<'a>) -> ParseResult<'a, PreconditionGoalDefinitions> {
     let pref_gd = map(parse_pref_gd, |x| {
         PreconditionGoalDefinitions::from(PreconditionGoalDefinition::new_preference(x))
     });
@@ -97,7 +96,7 @@ impl<'a> crate::parsers::Parser<'a> for PreconditionGoalDefinitions<'a> {
     type Item = PreconditionGoalDefinitions<'a>;
 
     /// See [`parse_pre_gd`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_pre_gd(input)
     }
 }

--- a/src/parsers/pre_gd.rs
+++ b/src/parsers/pre_gd.rs
@@ -99,6 +99,6 @@ impl<'a> crate::parsers::Parser<'a> for PreconditionGoalDefinitions<'a> {
 
     /// See [`parse_pre_gd`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_pre_gd(input.into())
+        parse_pre_gd(input)
     }
 }

--- a/src/parsers/predicate.rs
+++ b/src/parsers/predicate.rs
@@ -29,6 +29,6 @@ impl<'a> crate::parsers::Parser<'a> for Predicate<'a> {
 
     /// See [`parse_predicate`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_predicate(input.into())
+        parse_predicate(input)
     }
 }

--- a/src/parsers/predicate.rs
+++ b/src/parsers/predicate.rs
@@ -20,15 +20,15 @@ use nom::combinator::map;
 /// assert!(parse_predicate(Span::new("0124")).is_err());
 /// assert!(parse_predicate(Span::new("-1")).is_err());
 ///```
-pub fn parse_predicate<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Predicate<'a>> {
+pub fn parse_predicate<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Predicate> {
     map(parse_name, Predicate::from)(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for Predicate<'a> {
-    type Item = Predicate<'a>;
+impl crate::parsers::Parser for Predicate {
+    type Item = Predicate;
 
     /// See [`parse_predicate`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_predicate(input)
     }
 }

--- a/src/parsers/predicate.rs
+++ b/src/parsers/predicate.rs
@@ -1,27 +1,26 @@
 //! Provides parsers for predicates.
 
-use crate::parsers::parse_name;
+use crate::parsers::{parse_name, ParseResult, Span};
 use crate::types::Predicate;
 use nom::combinator::map;
-use nom::IResult;
 
 /// Parses a predicate, i.e. `<name>`.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_predicate;
-/// assert_eq!(parse_predicate("abcde"), Ok(("", "abcde".into())));
-/// assert_eq!(parse_predicate("a-1_2"), Ok(("", "a-1_2".into())));
-/// assert_eq!(parse_predicate("Z01"), Ok(("", "Z01".into())));
-/// assert_eq!(parse_predicate("x-_-_"), Ok(("", "x-_-_".into())));
+/// # use pddl::parsers::{parse_predicate, preamble::*};
+/// assert!(parse_predicate(Span::new("abcde")).is_value("abcde".into()));
+/// assert!(parse_predicate(Span::new("a-1_2")).is_value("a-1_2".into()));
+/// assert!(parse_predicate(Span::new("Z01")).is_value("Z01".into()));
+/// assert!(parse_predicate(Span::new("x-_-_")).is_value("x-_-_".into()));
 ///
-/// assert!(parse_predicate("").is_err());
-/// assert!(parse_predicate(".").is_err());
-/// assert!(parse_predicate("-abc").is_err());
-/// assert!(parse_predicate("0124").is_err());
-/// assert!(parse_predicate("-1").is_err());
+/// assert!(parse_predicate(Span::new("")).is_err());
+/// assert!(parse_predicate(Span::new(".")).is_err());
+/// assert!(parse_predicate(Span::new("-abc")).is_err());
+/// assert!(parse_predicate(Span::new("0124")).is_err());
+/// assert!(parse_predicate(Span::new("-1")).is_err());
 ///```
-pub fn parse_predicate(input: &str) -> IResult<&str, Predicate> {
+pub fn parse_predicate<'a>(input: Span<'a>) -> ParseResult<'a, Predicate> {
     map(parse_name, Predicate::from)(input)
 }
 
@@ -29,7 +28,7 @@ impl<'a> crate::parsers::Parser<'a> for Predicate<'a> {
     type Item = Predicate<'a>;
 
     /// See [`parse_predicate`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_predicate(input)
     }
 }

--- a/src/parsers/predicate.rs
+++ b/src/parsers/predicate.rs
@@ -20,8 +20,8 @@ use nom::combinator::map;
 /// assert!(parse_predicate(Span::new("0124")).is_err());
 /// assert!(parse_predicate(Span::new("-1")).is_err());
 ///```
-pub fn parse_predicate<'a>(input: Span<'a>) -> ParseResult<'a, Predicate> {
-    map(parse_name, Predicate::from)(input)
+pub fn parse_predicate<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Predicate<'a>> {
+    map(parse_name, Predicate::from)(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for Predicate<'a> {

--- a/src/parsers/predicate.rs
+++ b/src/parsers/predicate.rs
@@ -28,7 +28,7 @@ impl<'a> crate::parsers::Parser<'a> for Predicate<'a> {
     type Item = Predicate<'a>;
 
     /// See [`parse_predicate`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_predicate(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_predicate(input.into())
     }
 }

--- a/src/parsers/predicates_def.rs
+++ b/src/parsers/predicates_def.rs
@@ -51,6 +51,6 @@ impl<'a> crate::parsers::Parser<'a> for PredicateDefinitions<'a> {
 
     /// See [`parse_predicates_def`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_predicates_def(input.into())
+        parse_predicates_def(input)
     }
 }

--- a/src/parsers/predicates_def.rs
+++ b/src/parsers/predicates_def.rs
@@ -17,7 +17,7 @@ use nom::combinator::map;
 ///                     (in ?x ?y - physob)
 ///                )"#;
 ///
-/// assert!(parse_predicates_def(input.into()).is_value(
+/// assert!(parse_predicates_def(input).is_value(
 ///     PredicateDefinitions::new(vec![
 ///         AtomicFormulaSkeleton::new(
 ///             Predicate::from("at"),
@@ -34,14 +34,16 @@ use nom::combinator::map;
 ///     ])
 /// ));
 /// ```
-pub fn parse_predicates_def(input: Span) -> ParseResult<PredicateDefinitions> {
+pub fn parse_predicates_def<'a, T: Into<Span<'a>>>(
+    input: T,
+) -> ParseResult<'a, PredicateDefinitions<'a>> {
     map(
         prefix_expr(
             ":predicates",
             space_separated_list1(parse_atomic_formula_skeleton),
         ),
         |vec| PredicateDefinitions::new(vec),
-    )(input)
+    )(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for PredicateDefinitions<'a> {

--- a/src/parsers/predicates_def.rs
+++ b/src/parsers/predicates_def.rs
@@ -1,16 +1,15 @@
 //! Provides parsers for predicate definitions.
 
-use crate::parsers::parse_atomic_formula_skeleton;
+use crate::parsers::{parse_atomic_formula_skeleton, ParseResult, Span};
 use crate::parsers::{prefix_expr, space_separated_list1};
 use crate::types::PredicateDefinitions;
 use nom::combinator::map;
-use nom::IResult;
 
 /// Parser that parses predicate definitions, i.e. `(:predicates <atomic formula skeleton>⁺)`.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_predicates_def;
+/// # use pddl::parsers::{parse_predicates_def, preamble::*};
 /// # use pddl::{Variable, AtomicFormulaSkeleton, Predicate, PredicateDefinitions};
 /// # use pddl::{ToTyped, TypedList};
 /// let input = r#"(:predicates
@@ -18,7 +17,7 @@ use nom::IResult;
 ///                     (in ?x ?y - physob)
 ///                )"#;
 ///
-/// assert_eq!(parse_predicates_def(input), Ok(("",
+/// assert!(parse_predicates_def(input.into()).is_value(
 ///     PredicateDefinitions::new(vec![
 ///         AtomicFormulaSkeleton::new(
 ///             Predicate::from("at"),
@@ -33,9 +32,9 @@ use nom::IResult;
 ///                 Variable::from("y").to_typed("physob"),
 ///             ]))
 ///     ])
-/// )));
+/// ));
 /// ```
-pub fn parse_predicates_def(input: &str) -> IResult<&str, PredicateDefinitions> {
+pub fn parse_predicates_def(input: Span) -> ParseResult<PredicateDefinitions> {
     map(
         prefix_expr(
             ":predicates",
@@ -49,7 +48,7 @@ impl<'a> crate::parsers::Parser<'a> for PredicateDefinitions<'a> {
     type Item = PredicateDefinitions<'a>;
 
     /// See [`parse_predicates_def`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_predicates_def(input)
     }
 }

--- a/src/parsers/predicates_def.rs
+++ b/src/parsers/predicates_def.rs
@@ -36,7 +36,7 @@ use nom::combinator::map;
 /// ```
 pub fn parse_predicates_def<'a, T: Into<Span<'a>>>(
     input: T,
-) -> ParseResult<'a, PredicateDefinitions<'a>> {
+) -> ParseResult<'a, PredicateDefinitions> {
     map(
         prefix_expr(
             ":predicates",
@@ -46,11 +46,11 @@ pub fn parse_predicates_def<'a, T: Into<Span<'a>>>(
     )(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for PredicateDefinitions<'a> {
-    type Item = PredicateDefinitions<'a>;
+impl crate::parsers::Parser for PredicateDefinitions {
+    type Item = PredicateDefinitions;
 
     /// See [`parse_predicates_def`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_predicates_def(input)
     }
 }

--- a/src/parsers/predicates_def.rs
+++ b/src/parsers/predicates_def.rs
@@ -48,7 +48,7 @@ impl<'a> crate::parsers::Parser<'a> for PredicateDefinitions<'a> {
     type Item = PredicateDefinitions<'a>;
 
     /// See [`parse_predicates_def`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_predicates_def(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_predicates_def(input.into())
     }
 }

--- a/src/parsers/pref_con_gd.rs
+++ b/src/parsers/pref_con_gd.rs
@@ -2,20 +2,19 @@
 
 use crate::parsers::{
     parens, parse_con_gd, parse_pref_name, parse_variable, prefix_expr, space_separated_list0,
-    typed_list,
+    typed_list, ParseResult, Span,
 };
 use crate::PrefConGDs;
 use nom::branch::alt;
 use nom::character::complete::multispace1;
 use nom::combinator::map;
 use nom::sequence::{preceded, tuple};
-use nom::IResult;
 
 /// Parses preferred goal definitions.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_pref_con_gd;
+/// # use pddl::parsers::{parse_pref_con_gd, preamble::*};
 /// # use pddl::{AtomicFormula, Con2GD, ConGD, GoalDefinition, Number, PrefConGD, PrefConGDs, Term, ToTyped, Type, TypedList, Variable};
 /// // (= x y)
 /// let gd_a =
@@ -37,18 +36,18 @@ use nom::IResult;
 ///         )
 ///     );
 ///
-/// assert_eq!(parse_pref_con_gd("(and)"), Ok(("",
+/// assert!(parse_pref_con_gd("(and)".into()).is_value(
 ///     PrefConGDs::default()
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_pref_con_gd("(and (at end (= x y)) (at end (not (= x z))))"), Ok(("",
+/// assert!(parse_pref_con_gd("(and (at end (= x y)) (at end (not (= x z))))".into()).is_value(
 ///     PrefConGDs::from_iter([
 ///         PrefConGD::new_goal(ConGD::new_at_end(gd_a.clone())),
 ///         PrefConGD::new_goal(ConGD::new_at_end(gd_b.clone())),
 ///     ])
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_pref_con_gd("(forall (?x ?z) (sometime (= ?x ?z)))"), Ok(("",
+/// assert!(parse_pref_con_gd("(forall (?x ?z) (sometime (= ?x ?z)))".into()).is_value(
 ///     PrefConGDs::new_forall(
 ///         TypedList::from_iter([
 ///             Variable::from("x").to_typed(Type::OBJECT),
@@ -67,21 +66,21 @@ use nom::IResult;
 ///             )
 ///         )
 ///     )
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_pref_con_gd("(at end (= x y))"), Ok(("",
+/// assert!(parse_pref_con_gd("(at end (= x y))".into()).is_value(
 ///     PrefConGDs::new_goal(ConGD::AtEnd(gd_a.clone()))
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_pref_con_gd("(preference (at end (= x y)))"), Ok(("",
+/// assert!(parse_pref_con_gd("(preference (at end (= x y)))".into()).is_value(
 ///     PrefConGDs::new_preference(None, ConGD::AtEnd(gd_a.clone()))
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_pref_con_gd("(preference name (at end (= x y)))"), Ok(("",
+/// assert!(parse_pref_con_gd("(preference name (at end (= x y)))".into()).is_value(
 ///     PrefConGDs::new_preference(Some("name".into()), ConGD::AtEnd(gd_a.clone()))
-/// )));
+/// ));
 /// ```
-pub fn parse_pref_con_gd(input: &str) -> IResult<&str, PrefConGDs> {
+pub fn parse_pref_con_gd(input: Span) -> ParseResult<PrefConGDs> {
     let and = map(
         prefix_expr("and", space_separated_list0(parse_pref_con_gd)),
         |x| PrefConGDs::from_iter(x.into_iter().flatten()),
@@ -122,7 +121,7 @@ impl<'a> crate::parsers::Parser<'a> for PrefConGDs<'a> {
     type Item = PrefConGDs<'a>;
 
     /// See [`parse_pref_con_gd`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_pref_con_gd(input)
     }
 }

--- a/src/parsers/pref_con_gd.rs
+++ b/src/parsers/pref_con_gd.rs
@@ -36,18 +36,18 @@ use nom::sequence::{preceded, tuple};
 ///         )
 ///     );
 ///
-/// assert!(parse_pref_con_gd("(and)".into()).is_value(
+/// assert!(parse_pref_con_gd("(and)").is_value(
 ///     PrefConGDs::default()
 /// ));
 ///
-/// assert!(parse_pref_con_gd("(and (at end (= x y)) (at end (not (= x z))))".into()).is_value(
+/// assert!(parse_pref_con_gd("(and (at end (= x y)) (at end (not (= x z))))").is_value(
 ///     PrefConGDs::from_iter([
 ///         PrefConGD::new_goal(ConGD::new_at_end(gd_a.clone())),
 ///         PrefConGD::new_goal(ConGD::new_at_end(gd_b.clone())),
 ///     ])
 /// ));
 ///
-/// assert!(parse_pref_con_gd("(forall (?x ?z) (sometime (= ?x ?z)))".into()).is_value(
+/// assert!(parse_pref_con_gd("(forall (?x ?z) (sometime (= ?x ?z)))").is_value(
 ///     PrefConGDs::new_forall(
 ///         TypedList::from_iter([
 ///             Variable::from("x").to_typed(Type::OBJECT),
@@ -68,19 +68,19 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 ///
-/// assert!(parse_pref_con_gd("(at end (= x y))".into()).is_value(
+/// assert!(parse_pref_con_gd("(at end (= x y))").is_value(
 ///     PrefConGDs::new_goal(ConGD::AtEnd(gd_a.clone()))
 /// ));
 ///
-/// assert!(parse_pref_con_gd("(preference (at end (= x y)))".into()).is_value(
+/// assert!(parse_pref_con_gd("(preference (at end (= x y)))").is_value(
 ///     PrefConGDs::new_preference(None, ConGD::AtEnd(gd_a.clone()))
 /// ));
 ///
-/// assert!(parse_pref_con_gd("(preference name (at end (= x y)))".into()).is_value(
+/// assert!(parse_pref_con_gd("(preference name (at end (= x y)))").is_value(
 ///     PrefConGDs::new_preference(Some("name".into()), ConGD::AtEnd(gd_a.clone()))
 /// ));
 /// ```
-pub fn parse_pref_con_gd(input: Span) -> ParseResult<PrefConGDs> {
+pub fn parse_pref_con_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, PrefConGDs<'a>> {
     let and = map(
         prefix_expr("and", space_separated_list0(parse_pref_con_gd)),
         |x| PrefConGDs::from_iter(x.into_iter().flatten()),
@@ -114,7 +114,7 @@ pub fn parse_pref_con_gd(input: Span) -> ParseResult<PrefConGDs> {
 
     let goal = map(parse_con_gd, PrefConGDs::new_goal);
 
-    alt((and, forall, named_preference, unnamed_preference, goal))(input)
+    alt((and, forall, named_preference, unnamed_preference, goal))(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for PrefConGDs<'a> {

--- a/src/parsers/pref_con_gd.rs
+++ b/src/parsers/pref_con_gd.rs
@@ -122,6 +122,6 @@ impl<'a> crate::parsers::Parser<'a> for PrefConGDs<'a> {
 
     /// See [`parse_pref_con_gd`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_pref_con_gd(input.into())
+        parse_pref_con_gd(input)
     }
 }

--- a/src/parsers/pref_con_gd.rs
+++ b/src/parsers/pref_con_gd.rs
@@ -121,7 +121,7 @@ impl<'a> crate::parsers::Parser<'a> for PrefConGDs<'a> {
     type Item = PrefConGDs<'a>;
 
     /// See [`parse_pref_con_gd`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_pref_con_gd(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_pref_con_gd(input.into())
     }
 }

--- a/src/parsers/pref_con_gd.rs
+++ b/src/parsers/pref_con_gd.rs
@@ -80,7 +80,7 @@ use nom::sequence::{preceded, tuple};
 ///     PrefConGDs::new_preference(Some("name".into()), ConGD::AtEnd(gd_a.clone()))
 /// ));
 /// ```
-pub fn parse_pref_con_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, PrefConGDs<'a>> {
+pub fn parse_pref_con_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, PrefConGDs> {
     let and = map(
         prefix_expr("and", space_separated_list0(parse_pref_con_gd)),
         |x| PrefConGDs::from_iter(x.into_iter().flatten()),
@@ -117,11 +117,11 @@ pub fn parse_pref_con_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Pre
     alt((and, forall, named_preference, unnamed_preference, goal))(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for PrefConGDs<'a> {
-    type Item = PrefConGDs<'a>;
+impl crate::parsers::Parser for PrefConGDs {
+    type Item = PrefConGDs;
 
     /// See [`parse_pref_con_gd`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_pref_con_gd(input)
     }
 }

--- a/src/parsers/pref_gd.rs
+++ b/src/parsers/pref_gd.rs
@@ -1,22 +1,21 @@
 //! Provides parsers for preference goal definitions.
 
-use crate::parsers::prefix_expr;
 use crate::parsers::{parse_gd, parse_pref_name};
+use crate::parsers::{prefix_expr, ParseResult, Span};
 use crate::types::{Preference, PreferenceGD};
 use nom::branch::alt;
 use nom::character::complete::multispace1;
 use nom::combinator::{map, opt};
 use nom::sequence::{preceded, tuple};
-use nom::IResult;
 
 /// Parser for goal definitions.
 ///
 /// ## Examples
 /// ```
-/// # use pddl::parsers::parse_pref_gd;
+/// # use pddl::parsers::{parse_pref_gd, preamble::*};
 /// # use pddl::{AtomicFormula, EqualityAtomicFormula, GoalDefinition, Literal, Preference, PreferenceName, PreferenceGD, Term, Variable};
 /// // Simple goal definition.
-/// assert_eq!(parse_pref_gd("(= x y)"), Ok(("",
+/// assert!(parse_pref_gd("(= x y)".into()).is_value(
 ///     PreferenceGD::Goal(
 ///         GoalDefinition::AtomicFormula(
 ///             AtomicFormula::new_equality(
@@ -25,10 +24,10 @@ use nom::IResult;
 ///             )
 ///         )
 ///     )
-/// )));
+/// ));
 ///
 /// // Named preference.
-/// assert_eq!(parse_pref_gd("(preference p (= x y))"), Ok(("",
+/// assert!(parse_pref_gd("(preference p (= x y))".into()).is_value(
 ///     PreferenceGD::Preference(
 ///         Preference::new(
 ///             Some(PreferenceName::from("p")),
@@ -40,10 +39,10 @@ use nom::IResult;
 ///             )
 ///         )
 ///     )
-/// )));
+/// ));
 ///
 /// // Unnamed preference.
-/// assert_eq!(parse_pref_gd("(preference (= x y))"), Ok(("",
+/// assert!(parse_pref_gd("(preference (= x y))".into()).is_value(
 ///     PreferenceGD::Preference(
 ///         Preference::new(
 ///             None,
@@ -55,9 +54,9 @@ use nom::IResult;
 ///             )
 ///         )
 ///     )
-/// )));
+/// ));
 /// ```
-pub fn parse_pref_gd(input: &str) -> IResult<&str, PreferenceGD> {
+pub fn parse_pref_gd(input: Span) -> ParseResult<PreferenceGD> {
     // :preferences
     let pref_named = map(
         prefix_expr(
@@ -80,7 +79,7 @@ impl<'a> crate::parsers::Parser<'a> for PreferenceGD<'a> {
     type Item = PreferenceGD<'a>;
 
     /// See [`parse_pref_gd`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_pref_gd(input)
     }
 }

--- a/src/parsers/pref_gd.rs
+++ b/src/parsers/pref_gd.rs
@@ -56,7 +56,7 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 /// ```
-pub fn parse_pref_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, PreferenceGD<'a>> {
+pub fn parse_pref_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, PreferenceGD> {
     // :preferences
     let pref_named = map(
         prefix_expr(
@@ -75,11 +75,11 @@ pub fn parse_pref_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Prefere
     alt((pref_named, pref_unnamed, gd))(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for PreferenceGD<'a> {
-    type Item = PreferenceGD<'a>;
+impl crate::parsers::Parser for PreferenceGD {
+    type Item = PreferenceGD;
 
     /// See [`parse_pref_gd`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_pref_gd(input)
     }
 }

--- a/src/parsers/pref_gd.rs
+++ b/src/parsers/pref_gd.rs
@@ -80,6 +80,6 @@ impl<'a> crate::parsers::Parser<'a> for PreferenceGD<'a> {
 
     /// See [`parse_pref_gd`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_pref_gd(input.into())
+        parse_pref_gd(input)
     }
 }

--- a/src/parsers/pref_gd.rs
+++ b/src/parsers/pref_gd.rs
@@ -15,7 +15,7 @@ use nom::sequence::{preceded, tuple};
 /// # use pddl::parsers::{parse_pref_gd, preamble::*};
 /// # use pddl::{AtomicFormula, EqualityAtomicFormula, GoalDefinition, Literal, Preference, PreferenceName, PreferenceGD, Term, Variable};
 /// // Simple goal definition.
-/// assert!(parse_pref_gd("(= x y)".into()).is_value(
+/// assert!(parse_pref_gd("(= x y)").is_value(
 ///     PreferenceGD::Goal(
 ///         GoalDefinition::AtomicFormula(
 ///             AtomicFormula::new_equality(
@@ -27,7 +27,7 @@ use nom::sequence::{preceded, tuple};
 /// ));
 ///
 /// // Named preference.
-/// assert!(parse_pref_gd("(preference p (= x y))".into()).is_value(
+/// assert!(parse_pref_gd("(preference p (= x y))").is_value(
 ///     PreferenceGD::Preference(
 ///         Preference::new(
 ///             Some(PreferenceName::from("p")),
@@ -42,7 +42,7 @@ use nom::sequence::{preceded, tuple};
 /// ));
 ///
 /// // Unnamed preference.
-/// assert!(parse_pref_gd("(preference (= x y))".into()).is_value(
+/// assert!(parse_pref_gd("(preference (= x y))").is_value(
 ///     PreferenceGD::Preference(
 ///         Preference::new(
 ///             None,
@@ -56,7 +56,7 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 /// ```
-pub fn parse_pref_gd(input: Span) -> ParseResult<PreferenceGD> {
+pub fn parse_pref_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, PreferenceGD<'a>> {
     // :preferences
     let pref_named = map(
         prefix_expr(
@@ -72,7 +72,7 @@ pub fn parse_pref_gd(input: Span) -> ParseResult<PreferenceGD> {
 
     let gd = map(parse_gd, PreferenceGD::from_gd);
 
-    alt((pref_named, pref_unnamed, gd))(input)
+    alt((pref_named, pref_unnamed, gd))(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for PreferenceGD<'a> {

--- a/src/parsers/pref_gd.rs
+++ b/src/parsers/pref_gd.rs
@@ -79,7 +79,7 @@ impl<'a> crate::parsers::Parser<'a> for PreferenceGD<'a> {
     type Item = PreferenceGD<'a>;
 
     /// See [`parse_pref_gd`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_pref_gd(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_pref_gd(input.into())
     }
 }

--- a/src/parsers/pref_name.rs
+++ b/src/parsers/pref_name.rs
@@ -8,10 +8,10 @@ use nom::combinator::map;
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_pref_name, preamble::*};
-/// assert!(parse_pref_name("abcde".into()).is_value("abcde".into()));
+/// assert!(parse_pref_name("abcde").is_value("abcde".into()));
 ///```
-pub fn parse_pref_name(input: Span) -> ParseResult<PreferenceName> {
-    map(parse_name, PreferenceName::new)(input)
+pub fn parse_pref_name<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, PreferenceName<'a>> {
+    map(parse_name, PreferenceName::new)(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for PreferenceName<'a> {

--- a/src/parsers/pref_name.rs
+++ b/src/parsers/pref_name.rs
@@ -18,7 +18,7 @@ impl<'a> crate::parsers::Parser<'a> for PreferenceName<'a> {
     type Item = PreferenceName<'a>;
 
     /// See [`parse_pref_name`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_pref_name(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_pref_name(input.into())
     }
 }

--- a/src/parsers/pref_name.rs
+++ b/src/parsers/pref_name.rs
@@ -19,6 +19,6 @@ impl<'a> crate::parsers::Parser<'a> for PreferenceName<'a> {
 
     /// See [`parse_pref_name`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_pref_name(input.into())
+        parse_pref_name(input)
     }
 }

--- a/src/parsers/pref_name.rs
+++ b/src/parsers/pref_name.rs
@@ -1,17 +1,16 @@
 //! Provides parsers for preference names.
-use crate::parsers::parse_name;
+use crate::parsers::{parse_name, ParseResult, Span};
 use crate::types::PreferenceName;
 use nom::combinator::map;
-use nom::IResult;
 
 /// Parses a preference name.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_pref_name;
-/// assert_eq!(parse_pref_name("abcde"), Ok(("", "abcde".into())));
+/// # use pddl::parsers::{parse_pref_name, preamble::*};
+/// assert!(parse_pref_name("abcde".into()).is_value("abcde".into()));
 ///```
-pub fn parse_pref_name(input: &str) -> IResult<&str, PreferenceName> {
+pub fn parse_pref_name(input: Span) -> ParseResult<PreferenceName> {
     map(parse_name, PreferenceName::new)(input)
 }
 
@@ -19,7 +18,7 @@ impl<'a> crate::parsers::Parser<'a> for PreferenceName<'a> {
     type Item = PreferenceName<'a>;
 
     /// See [`parse_pref_name`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_pref_name(input)
     }
 }

--- a/src/parsers/pref_name.rs
+++ b/src/parsers/pref_name.rs
@@ -10,15 +10,15 @@ use nom::combinator::map;
 /// # use pddl::parsers::{parse_pref_name, preamble::*};
 /// assert!(parse_pref_name("abcde").is_value("abcde".into()));
 ///```
-pub fn parse_pref_name<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, PreferenceName<'a>> {
+pub fn parse_pref_name<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, PreferenceName> {
     map(parse_name, PreferenceName::new)(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for PreferenceName<'a> {
-    type Item = PreferenceName<'a>;
+impl crate::parsers::Parser for PreferenceName {
+    type Item = PreferenceName;
 
     /// See [`parse_pref_name`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_pref_name(input)
     }
 }

--- a/src/parsers/pref_timed_gd.rs
+++ b/src/parsers/pref_timed_gd.rs
@@ -59,7 +59,7 @@ use nom::sequence::{terminated, tuple};
 ///     )
 /// ));
 /// ```
-pub fn parse_pref_timed_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, PrefTimedGD<'a>> {
+pub fn parse_pref_timed_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, PrefTimedGD> {
     let required = map(parse_timed_gd, PrefTimedGD::from);
 
     // :preferences
@@ -77,11 +77,11 @@ pub fn parse_pref_timed_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, P
     alt((preference, required))(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for PrefTimedGD<'a> {
-    type Item = PrefTimedGD<'a>;
+impl crate::parsers::Parser for PrefTimedGD {
+    type Item = PrefTimedGD;
 
     /// See [`parse_pref_timed_gd`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_pref_timed_gd(input)
     }
 }

--- a/src/parsers/pref_timed_gd.rs
+++ b/src/parsers/pref_timed_gd.rs
@@ -82,6 +82,6 @@ impl<'a> crate::parsers::Parser<'a> for PrefTimedGD<'a> {
 
     /// See [`parse_pref_timed_gd`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_pref_timed_gd(input.into())
+        parse_pref_timed_gd(input)
     }
 }

--- a/src/parsers/pref_timed_gd.rs
+++ b/src/parsers/pref_timed_gd.rs
@@ -81,7 +81,7 @@ impl<'a> crate::parsers::Parser<'a> for PrefTimedGD<'a> {
     type Item = PrefTimedGD<'a>;
 
     /// See [`parse_pref_timed_gd`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_pref_timed_gd(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_pref_timed_gd(input.into())
     }
 }

--- a/src/parsers/pref_timed_gd.rs
+++ b/src/parsers/pref_timed_gd.rs
@@ -14,7 +14,7 @@ use nom::sequence::{terminated, tuple};
 /// ```
 /// # use pddl::parsers::{parse_pref_timed_gd, preamble::*};
 /// # use pddl::{AtomicFormula, GoalDefinition, Interval, PrefTimedGD, Term, TimedGD, TimeSpecifier};
-/// assert!(parse_pref_timed_gd("(at start (= x y))".into()).is_value(
+/// assert!(parse_pref_timed_gd("(at start (= x y))").is_value(
 ///     PrefTimedGD::Required(
 ///         TimedGD::new_at(
 ///             TimeSpecifier::Start,
@@ -29,7 +29,7 @@ use nom::sequence::{terminated, tuple};
 /// ));
 ///
 ///
-/// assert!(parse_pref_timed_gd("(preference (over all (= x y)))".into()).is_value(
+/// assert!(parse_pref_timed_gd("(preference (over all (= x y)))").is_value(
 ///     PrefTimedGD::Preference(
 ///         None,
 ///         TimedGD::new_over(
@@ -44,7 +44,7 @@ use nom::sequence::{terminated, tuple};
 ///     )
 /// ));
 ///
-/// assert!(parse_pref_timed_gd("(preference pref-name (over all (= x y)))".into()).is_value(
+/// assert!(parse_pref_timed_gd("(preference pref-name (over all (= x y)))").is_value(
 ///     PrefTimedGD::Preference(
 ///         Some("pref-name".into()),
 ///         TimedGD::new_over(
@@ -59,7 +59,7 @@ use nom::sequence::{terminated, tuple};
 ///     )
 /// ));
 /// ```
-pub fn parse_pref_timed_gd(input: Span) -> ParseResult<PrefTimedGD> {
+pub fn parse_pref_timed_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, PrefTimedGD<'a>> {
     let required = map(parse_timed_gd, PrefTimedGD::from);
 
     // :preferences
@@ -74,7 +74,7 @@ pub fn parse_pref_timed_gd(input: Span) -> ParseResult<PrefTimedGD> {
         PrefTimedGD::from,
     );
 
-    alt((preference, required))(input)
+    alt((preference, required))(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for PrefTimedGD<'a> {

--- a/src/parsers/pref_timed_gd.rs
+++ b/src/parsers/pref_timed_gd.rs
@@ -1,21 +1,20 @@
 //! Provides parsers for (preferred) timed goal definitions.
 
-use crate::parsers::prefix_expr;
 use crate::parsers::{parse_pref_name, parse_timed_gd};
+use crate::parsers::{prefix_expr, ParseResult, Span};
 use crate::types::PrefTimedGD;
 use nom::branch::alt;
 use nom::character::complete::multispace1;
 use nom::combinator::{map, opt};
 use nom::sequence::{terminated, tuple};
-use nom::IResult;
 
 /// Parser for (preferred) timed goal definitions.
 ///
 /// ## Examples
 /// ```
-/// # use pddl::parsers::{parse_pref_timed_gd};
+/// # use pddl::parsers::{parse_pref_timed_gd, preamble::*};
 /// # use pddl::{AtomicFormula, GoalDefinition, Interval, PrefTimedGD, Term, TimedGD, TimeSpecifier};
-/// assert_eq!(parse_pref_timed_gd("(at start (= x y))"), Ok(("",
+/// assert!(parse_pref_timed_gd("(at start (= x y))".into()).is_value(
 ///     PrefTimedGD::Required(
 ///         TimedGD::new_at(
 ///             TimeSpecifier::Start,
@@ -27,10 +26,10 @@ use nom::IResult;
 ///             )
 ///         )
 ///     )
-/// )));
+/// ));
 ///
 ///
-/// assert_eq!(parse_pref_timed_gd("(preference (over all (= x y)))"), Ok(("",
+/// assert!(parse_pref_timed_gd("(preference (over all (= x y)))".into()).is_value(
 ///     PrefTimedGD::Preference(
 ///         None,
 ///         TimedGD::new_over(
@@ -43,9 +42,9 @@ use nom::IResult;
 ///             )
 ///         )
 ///     )
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_pref_timed_gd("(preference pref-name (over all (= x y)))"), Ok(("",
+/// assert!(parse_pref_timed_gd("(preference pref-name (over all (= x y)))".into()).is_value(
 ///     PrefTimedGD::Preference(
 ///         Some("pref-name".into()),
 ///         TimedGD::new_over(
@@ -58,9 +57,9 @@ use nom::IResult;
 ///             )
 ///         )
 ///     )
-/// )));
+/// ));
 /// ```
-pub fn parse_pref_timed_gd(input: &str) -> IResult<&str, PrefTimedGD> {
+pub fn parse_pref_timed_gd(input: Span) -> ParseResult<PrefTimedGD> {
     let required = map(parse_timed_gd, PrefTimedGD::from);
 
     // :preferences
@@ -82,7 +81,7 @@ impl<'a> crate::parsers::Parser<'a> for PrefTimedGD<'a> {
     type Item = PrefTimedGD<'a>;
 
     /// See [`parse_pref_timed_gd`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_pref_timed_gd(input)
     }
 }

--- a/src/parsers/primitive_type.rs
+++ b/src/parsers/primitive_type.rs
@@ -28,7 +28,7 @@ impl<'a> crate::parsers::Parser<'a> for PrimitiveType<'a> {
     type Item = PrimitiveType<'a>;
 
     /// See [`parse_primitive_type`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_primitive_type(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_primitive_type(input.into())
     }
 }

--- a/src/parsers/primitive_type.rs
+++ b/src/parsers/primitive_type.rs
@@ -16,7 +16,7 @@ use nom::combinator::map;
 /// assert!(parse_primitive_type(Span::new("a-1_2")).is_value("a-1_2".into()));
 /// assert!(parse_primitive_type(Span::new("obj!ect")).is_value("obj".into()));
 ///```
-pub fn parse_primitive_type<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, PrimitiveType<'a>> {
+pub fn parse_primitive_type<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, PrimitiveType> {
     map(alt((parse_object, parse_name)), PrimitiveType::from)(input.into())
 }
 
@@ -24,11 +24,11 @@ fn parse_object(input: Span) -> ParseResult<Name> {
     map(tag("object"), |x: Span| Name::from(*x.fragment()))(input)
 }
 
-impl<'a> crate::parsers::Parser<'a> for PrimitiveType<'a> {
-    type Item = PrimitiveType<'a>;
+impl crate::parsers::Parser for PrimitiveType {
+    type Item = PrimitiveType;
 
     /// See [`parse_primitive_type`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_primitive_type(input)
     }
 }

--- a/src/parsers/primitive_type.rs
+++ b/src/parsers/primitive_type.rs
@@ -29,6 +29,6 @@ impl<'a> crate::parsers::Parser<'a> for PrimitiveType<'a> {
 
     /// See [`parse_primitive_type`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_primitive_type(input.into())
+        parse_primitive_type(input)
     }
 }

--- a/src/parsers/primitive_type.rs
+++ b/src/parsers/primitive_type.rs
@@ -1,37 +1,34 @@
 //! Provides parsers for primitive types.
 
-use crate::parsers::parse_name;
+use crate::parsers::{parse_name, ParseResult, Span};
 use crate::types::{Name, PrimitiveType};
 use nom::branch::alt;
 use nom::bytes::complete::tag;
-use nom::combinator::recognize;
-use nom::IResult;
+use nom::combinator::map;
 
 /// Parses a primitive type, i.e. `object | <name>`.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_primitive_type;
-/// assert_eq!(parse_primitive_type("object"), Ok(("", "object".into())));
-/// assert_eq!(parse_primitive_type("number"), Ok(("", "number".into())));
-/// assert_eq!(parse_primitive_type("a-1_2"), Ok(("", "a-1_2".into())));
-/// assert_eq!(parse_primitive_type("obj!ect"), Ok(("!ect", "obj".into())));
+/// # use pddl::parsers::{parse_primitive_type, preamble::*};
+/// assert!(parse_primitive_type(Span::new("object")).is_value("object".into()));
+/// assert!(parse_primitive_type(Span::new("number")).is_value("number".into()));
+/// assert!(parse_primitive_type(Span::new("a-1_2")).is_value("a-1_2".into()));
+/// assert!(parse_primitive_type(Span::new("obj!ect")).is_value("obj".into()));
 ///```
-pub fn parse_primitive_type(input: &str) -> IResult<&str, PrimitiveType> {
-    let (remaining, r#type) = recognize(alt((parse_object, parse_name)))(input)?;
-    Ok((remaining, PrimitiveType::from(r#type)))
+pub fn parse_primitive_type(input: Span) -> ParseResult<PrimitiveType> {
+    map(alt((parse_object, parse_name)), PrimitiveType::from)(input)
 }
 
-fn parse_object(input: &str) -> IResult<&str, Name> {
-    let (remaining, name) = tag("object")(input)?;
-    Ok((remaining, Name::from(name)))
+fn parse_object(input: Span) -> ParseResult<Name> {
+    map(tag("object"), |x: Span| Name::from(*x.fragment()))(input)
 }
 
 impl<'a> crate::parsers::Parser<'a> for PrimitiveType<'a> {
     type Item = PrimitiveType<'a>;
 
     /// See [`parse_primitive_type`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_primitive_type(input)
     }
 }

--- a/src/parsers/primitive_type.rs
+++ b/src/parsers/primitive_type.rs
@@ -16,8 +16,8 @@ use nom::combinator::map;
 /// assert!(parse_primitive_type(Span::new("a-1_2")).is_value("a-1_2".into()));
 /// assert!(parse_primitive_type(Span::new("obj!ect")).is_value("obj".into()));
 ///```
-pub fn parse_primitive_type(input: Span) -> ParseResult<PrimitiveType> {
-    map(alt((parse_object, parse_name)), PrimitiveType::from)(input)
+pub fn parse_primitive_type<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, PrimitiveType<'a>> {
+    map(alt((parse_object, parse_name)), PrimitiveType::from)(input.into())
 }
 
 fn parse_object(input: Span) -> ParseResult<Name> {

--- a/src/parsers/problem.rs
+++ b/src/parsers/problem.rs
@@ -26,7 +26,7 @@ use nom::sequence::{preceded, tuple};
 ///         (:goal (and (at B office) (at D office) (at P home)))
 ///     )"#;
 ///
-/// let (remainder, problem) = parse_problem(input.into()).unwrap();
+/// let (remainder, problem) = parse_problem(input).unwrap();
 ///
 /// assert!(remainder.is_empty());
 /// assert_eq!(problem.name(), &Name::new("get-paid"));
@@ -35,7 +35,7 @@ use nom::sequence::{preceded, tuple};
 /// assert_eq!(problem.init().len(), 9);
 /// assert_eq!(problem.goal().len(), 3);
 /// ```
-pub fn parse_problem(input: Span) -> ParseResult<Problem> {
+pub fn parse_problem<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Problem<'a>> {
     map(
         ws(prefix_expr(
             "define",
@@ -67,7 +67,7 @@ pub fn parse_problem(input: Span) -> ParseResult<Problem> {
                 length,
             )
         },
-    )(input)
+    )(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for Problem<'a> {

--- a/src/parsers/problem.rs
+++ b/src/parsers/problem.rs
@@ -74,7 +74,7 @@ impl<'a> crate::parsers::Parser<'a> for Problem<'a> {
     type Item = Problem<'a>;
 
     /// See [`parse_problem`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_problem(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_problem(input.into())
     }
 }

--- a/src/parsers/problem.rs
+++ b/src/parsers/problem.rs
@@ -75,6 +75,6 @@ impl<'a> crate::parsers::Parser<'a> for Problem<'a> {
 
     /// See [`parse_problem`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_problem(input.into())
+        parse_problem(input)
     }
 }

--- a/src/parsers/problem.rs
+++ b/src/parsers/problem.rs
@@ -35,7 +35,7 @@ use nom::sequence::{preceded, tuple};
 /// assert_eq!(problem.init().len(), 9);
 /// assert_eq!(problem.goal().len(), 3);
 /// ```
-pub fn parse_problem<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Problem<'a>> {
+pub fn parse_problem<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Problem> {
     map(
         ws(prefix_expr(
             "define",
@@ -70,11 +70,11 @@ pub fn parse_problem<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Problem
     )(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for Problem<'a> {
-    type Item = Problem<'a>;
+impl crate::parsers::Parser for Problem {
+    type Item = Problem;
 
     /// See [`parse_problem`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_problem(input)
     }
 }

--- a/src/parsers/problem.rs
+++ b/src/parsers/problem.rs
@@ -1,6 +1,6 @@
 //! Provides parsers for problem definitions.
 
-use crate::parsers::{parse_name, prefix_expr, ws};
+use crate::parsers::{parse_name, prefix_expr, ws, ParseResult, Span};
 use crate::parsers::{
     parse_problem_constraints_def, parse_problem_goal_def, parse_problem_init_def,
     parse_problem_length_spec, parse_problem_metric_spec, parse_problem_objects_declaration,
@@ -11,13 +11,12 @@ use crate::types::{ProblemConstraintsDef, Requirements};
 use nom::character::complete::multispace1;
 use nom::combinator::{map, opt};
 use nom::sequence::{preceded, tuple};
-use nom::IResult;
 
 /// Parses a problem definitions.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::{parse_action_def, parse_problem};
+/// # use pddl::parsers::{parse_action_def, parse_problem, preamble::*};
 /// # use pddl::{Name, PreconditionGoalDefinition};
 /// let input = r#"(define (problem get-paid)
 ///         (:domain briefcase-world)
@@ -27,16 +26,16 @@ use nom::IResult;
 ///         (:goal (and (at B office) (at D office) (at P home)))
 ///     )"#;
 ///
-/// let (remainder, problem) = parse_problem(input).unwrap();
+/// let (remainder, problem) = parse_problem(input.into()).unwrap();
 ///
-/// assert_eq!(remainder, "");
+/// assert!(remainder.is_empty());
 /// assert_eq!(problem.name(), &Name::new("get-paid"));
 /// assert_eq!(problem.domain(), &Name::new("briefcase-world"));
 /// assert!(problem.requirements().is_empty());
 /// assert_eq!(problem.init().len(), 9);
 /// assert_eq!(problem.goal().len(), 3);
 /// ```
-pub fn parse_problem(input: &str) -> IResult<&str, Problem> {
+pub fn parse_problem(input: Span) -> ParseResult<Problem> {
     map(
         ws(prefix_expr(
             "define",
@@ -75,7 +74,7 @@ impl<'a> crate::parsers::Parser<'a> for Problem<'a> {
     type Item = Problem<'a>;
 
     /// See [`parse_problem`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_problem(input)
     }
 }

--- a/src/parsers/problem_constraints_def.rs
+++ b/src/parsers/problem_constraints_def.rs
@@ -11,18 +11,20 @@ use nom::combinator::map;
 /// # use pddl::parsers::{parse_problem_constraints_def, preamble::*};
 /// # use pddl::{ConGD, ProblemConstraintsDef, PrefConGDs};
 /// let input = "(:constraints (preference test (and)))";
-/// assert!(parse_problem_constraints_def(input.into()).is_value(
+/// assert!(parse_problem_constraints_def(input).is_value(
 ///     ProblemConstraintsDef::new(
 ///         PrefConGDs::new_preference(Some("test".into()), ConGD::new_and([]))
 ///     )
 /// ));
 /// ```
-pub fn parse_problem_constraints_def(input: Span) -> ParseResult<ProblemConstraintsDef> {
+pub fn parse_problem_constraints_def<'a, T: Into<Span<'a>>>(
+    input: T,
+) -> ParseResult<'a, ProblemConstraintsDef<'a>> {
     // :constraints
     map(
         prefix_expr(":constraints", parse_pref_con_gd),
         ProblemConstraintsDef::new,
-    )(input)
+    )(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for ProblemConstraintsDef<'a> {

--- a/src/parsers/problem_constraints_def.rs
+++ b/src/parsers/problem_constraints_def.rs
@@ -1,24 +1,23 @@
 //! Provides parsers for problem constraint definitions.
 
-use crate::parsers::{parse_pref_con_gd, prefix_expr};
+use crate::parsers::{parse_pref_con_gd, prefix_expr, ParseResult, Span};
 use crate::types::ProblemConstraintsDef;
 use nom::combinator::map;
-use nom::IResult;
 
 /// Parser that parses problem constraint definitions, i.e. `(:constraints <pref-con-GD>)`.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::{parse_problem_constraints_def};
+/// # use pddl::parsers::{parse_problem_constraints_def, preamble::*};
 /// # use pddl::{ConGD, ProblemConstraintsDef, PrefConGDs};
 /// let input = "(:constraints (preference test (and)))";
-/// assert_eq!(parse_problem_constraints_def(input), Ok(("",
+/// assert!(parse_problem_constraints_def(input.into()).is_value(
 ///     ProblemConstraintsDef::new(
 ///         PrefConGDs::new_preference(Some("test".into()), ConGD::new_and([]))
 ///     )
-/// )));
+/// ));
 /// ```
-pub fn parse_problem_constraints_def(input: &str) -> IResult<&str, ProblemConstraintsDef> {
+pub fn parse_problem_constraints_def(input: Span) -> ParseResult<ProblemConstraintsDef> {
     // :constraints
     map(
         prefix_expr(":constraints", parse_pref_con_gd),
@@ -30,7 +29,7 @@ impl<'a> crate::parsers::Parser<'a> for ProblemConstraintsDef<'a> {
     type Item = ProblemConstraintsDef<'a>;
 
     /// See [`parse_problem_constraints_def`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_problem_constraints_def(input)
     }
 }

--- a/src/parsers/problem_constraints_def.rs
+++ b/src/parsers/problem_constraints_def.rs
@@ -19,7 +19,7 @@ use nom::combinator::map;
 /// ```
 pub fn parse_problem_constraints_def<'a, T: Into<Span<'a>>>(
     input: T,
-) -> ParseResult<'a, ProblemConstraintsDef<'a>> {
+) -> ParseResult<'a, ProblemConstraintsDef> {
     // :constraints
     map(
         prefix_expr(":constraints", parse_pref_con_gd),
@@ -27,11 +27,11 @@ pub fn parse_problem_constraints_def<'a, T: Into<Span<'a>>>(
     )(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for ProblemConstraintsDef<'a> {
-    type Item = ProblemConstraintsDef<'a>;
+impl crate::parsers::Parser for ProblemConstraintsDef {
+    type Item = ProblemConstraintsDef;
 
     /// See [`parse_problem_constraints_def`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_problem_constraints_def(input)
     }
 }

--- a/src/parsers/problem_constraints_def.rs
+++ b/src/parsers/problem_constraints_def.rs
@@ -29,7 +29,7 @@ impl<'a> crate::parsers::Parser<'a> for ProblemConstraintsDef<'a> {
     type Item = ProblemConstraintsDef<'a>;
 
     /// See [`parse_problem_constraints_def`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_problem_constraints_def(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_problem_constraints_def(input.into())
     }
 }

--- a/src/parsers/problem_constraints_def.rs
+++ b/src/parsers/problem_constraints_def.rs
@@ -32,6 +32,6 @@ impl<'a> crate::parsers::Parser<'a> for ProblemConstraintsDef<'a> {
 
     /// See [`parse_problem_constraints_def`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_problem_constraints_def(input.into())
+        parse_problem_constraints_def(input)
     }
 }

--- a/src/parsers/requirements.rs
+++ b/src/parsers/requirements.rs
@@ -54,7 +54,7 @@ pub fn parse_require_def<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Req
 /// assert!(parse_require_key(":unknown").is_err());
 /// assert!(parse_require_key("invalid").is_err());
 ///```
-pub fn parse_require_key(input: Span) -> ParseResult<Requirement> {
+pub fn parse_require_key<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Requirement> {
     map(
         alt((
             tag(names::STRIPS),
@@ -87,7 +87,7 @@ impl<'a> crate::parsers::Parser<'a> for Requirements {
     type Item = Requirements;
 
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_require_def(input.into())
+        parse_require_def(input)
     }
 }
 
@@ -96,6 +96,6 @@ impl<'a> crate::parsers::Parser<'a> for Requirement {
 
     /// See [`parse_require_key`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_require_key(input.into())
+        parse_require_key(input)
     }
 }

--- a/src/parsers/requirements.rs
+++ b/src/parsers/requirements.rs
@@ -1,24 +1,23 @@
 //! Provides parsers for requirements.
 
-use crate::parsers::{prefix_expr, space_separated_list1};
+use crate::parsers::{prefix_expr, space_separated_list1, ParseResult, Span};
 use crate::types::requirement::{names, Requirement};
 use crate::types::Requirements;
 use nom::branch::alt;
 use nom::bytes::complete::tag;
-use nom::combinator::map_res;
-use nom::IResult;
+use nom::combinator::map;
 
 /// Parses a requirement definition, i.e. `(:requirements <require-key>)⁺`.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_require_def;
+/// # use pddl::parsers::{parse_require_def, preamble::*};
 /// # use pddl::{Requirement, Requirements};
-/// assert_eq!(parse_require_def("(:requirements :adl)"), Ok(("", Requirements::new([Requirement::Adl]))));
-/// assert_eq!(parse_require_def("(:requirements :strips :typing)"), Ok(("", Requirements::new([Requirement::Strips, Requirement::Typing]))));
-/// assert_eq!(parse_require_def("(:requirements\n:strips   :typing  )"), Ok(("", Requirements::new([Requirement::Strips, Requirement::Typing]))));
+/// assert!(parse_require_def("(:requirements :adl)".into()).is_value(Requirements::new([Requirement::Adl])));
+/// assert!(parse_require_def("(:requirements :strips :typing)".into()).is_value(Requirements::new([Requirement::Strips, Requirement::Typing])));
+/// assert!(parse_require_def("(:requirements\n:strips   :typing  )".into()).is_value(Requirements::new([Requirement::Strips, Requirement::Typing])));
 ///```
-pub fn parse_require_def(input: &str) -> IResult<&str, Requirements> {
+pub fn parse_require_def(input: Span) -> ParseResult<Requirements> {
     let (remaining, reqs) =
         prefix_expr(":requirements", space_separated_list1(parse_require_key))(input)?;
 
@@ -29,34 +28,34 @@ pub fn parse_require_def(input: &str) -> IResult<&str, Requirements> {
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_require_key;
+/// # use pddl::parsers::{parse_require_key, preamble::*};
 /// # use pddl::Requirement;
-/// assert_eq!(parse_require_key(":strips"), Ok(("", Requirement::Strips)));
-/// assert_eq!(parse_require_key(":typing"), Ok(("", Requirement::Typing)));
-/// assert_eq!(parse_require_key(":negative-preconditions"), Ok(("", Requirement::NegativePreconditions)));
-/// assert_eq!(parse_require_key(":disjunctive-preconditions"), Ok(("", Requirement::DisjunctivePreconditions)));
-/// assert_eq!(parse_require_key(":equality"), Ok(("", Requirement::Equality)));
-/// assert_eq!(parse_require_key(":existential-preconditions"), Ok(("", Requirement::ExistentialPreconditions)));
-/// assert_eq!(parse_require_key(":universal-preconditions"), Ok(("", Requirement::UniversalPreconditions)));
-/// assert_eq!(parse_require_key(":quantified-preconditions"), Ok(("", Requirement::QuantifiedPreconditions)));
-/// assert_eq!(parse_require_key(":conditional-effects"), Ok(("", Requirement::ConditionalEffects)));
-/// assert_eq!(parse_require_key(":fluents"), Ok(("", Requirement::Fluents)));
-/// assert_eq!(parse_require_key(":numeric-fluents"), Ok(("", Requirement::NumericFluents)));
-/// assert_eq!(parse_require_key(":adl"), Ok(("", Requirement::Adl)));
-/// assert_eq!(parse_require_key(":durative-actions"), Ok(("", Requirement::DurativeActions)));
-/// assert_eq!(parse_require_key(":duration-inequalities"), Ok(("", Requirement::DurationInequalities)));
-/// assert_eq!(parse_require_key(":continuous-effects"), Ok(("", Requirement::ContinuousEffects)));
-/// assert_eq!(parse_require_key(":derived-predicates"), Ok(("", Requirement::DerivedPredicates)));
-/// assert_eq!(parse_require_key(":timed-initial-literals"), Ok(("", Requirement::TimedInitialLiterals)));
-/// assert_eq!(parse_require_key(":preferences"), Ok(("", Requirement::Preferences)));
-/// assert_eq!(parse_require_key(":constraints"), Ok(("", Requirement::Constraints)));
-/// assert_eq!(parse_require_key(":action-costs"), Ok(("", Requirement::ActionCosts)));
+/// assert!(parse_require_key(":strips".into()).is_value(Requirement::Strips));
+/// assert!(parse_require_key(":typing".into()).is_value(Requirement::Typing));
+/// assert!(parse_require_key(":negative-preconditions".into()).is_value(Requirement::NegativePreconditions));
+/// assert!(parse_require_key(":disjunctive-preconditions".into()).is_value(Requirement::DisjunctivePreconditions));
+/// assert!(parse_require_key(":equality".into()).is_value(Requirement::Equality));
+/// assert!(parse_require_key(":existential-preconditions".into()).is_value(Requirement::ExistentialPreconditions));
+/// assert!(parse_require_key(":universal-preconditions".into()).is_value(Requirement::UniversalPreconditions));
+/// assert!(parse_require_key(":quantified-preconditions".into()).is_value(Requirement::QuantifiedPreconditions));
+/// assert!(parse_require_key(":conditional-effects".into()).is_value(Requirement::ConditionalEffects));
+/// assert!(parse_require_key(":fluents".into()).is_value(Requirement::Fluents));
+/// assert!(parse_require_key(":numeric-fluents".into()).is_value(Requirement::NumericFluents));
+/// assert!(parse_require_key(":adl".into()).is_value(Requirement::Adl));
+/// assert!(parse_require_key(":durative-actions".into()).is_value(Requirement::DurativeActions));
+/// assert!(parse_require_key(":duration-inequalities".into()).is_value(Requirement::DurationInequalities));
+/// assert!(parse_require_key(":continuous-effects".into()).is_value(Requirement::ContinuousEffects));
+/// assert!(parse_require_key(":derived-predicates".into()).is_value(Requirement::DerivedPredicates));
+/// assert!(parse_require_key(":timed-initial-literals".into()).is_value(Requirement::TimedInitialLiterals));
+/// assert!(parse_require_key(":preferences".into()).is_value(Requirement::Preferences));
+/// assert!(parse_require_key(":constraints".into()).is_value(Requirement::Constraints));
+/// assert!(parse_require_key(":action-costs".into()).is_value(Requirement::ActionCosts));
 ///
-/// assert!(parse_require_key(":unknown").is_err());
-/// assert!(parse_require_key("invalid").is_err());
+/// assert!(parse_require_key(":unknown".into()).is_err());
+/// assert!(parse_require_key("invalid".into()).is_err());
 ///```
-pub fn parse_require_key(input: &str) -> IResult<&str, Requirement> {
-    map_res(
+pub fn parse_require_key(input: Span) -> ParseResult<Requirement> {
+    map(
         alt((
             tag(names::STRIPS),
             tag(names::TYPING),
@@ -80,14 +79,14 @@ pub fn parse_require_key(input: &str) -> IResult<&str, Requirement> {
             tag(names::CONSTRAINTS),
             tag(names::ACTION_COSTS),
         )),
-        Requirement::try_from,
+        |x: Span| Requirement::try_from(*x.fragment()).expect("unhandled variant"),
     )(input)
 }
 
 impl<'a> crate::parsers::Parser<'a> for Requirements {
     type Item = Requirements;
 
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_require_def(input)
     }
 }
@@ -96,7 +95,7 @@ impl<'a> crate::parsers::Parser<'a> for Requirement {
     type Item = Requirement;
 
     /// See [`parse_require_key`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_require_key(input)
     }
 }

--- a/src/parsers/requirements.rs
+++ b/src/parsers/requirements.rs
@@ -83,19 +83,19 @@ pub fn parse_require_key<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Req
     )(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for Requirements {
+impl crate::parsers::Parser for Requirements {
     type Item = Requirements;
 
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_require_def(input)
     }
 }
 
-impl<'a> crate::parsers::Parser<'a> for Requirement {
+impl crate::parsers::Parser for Requirement {
     type Item = Requirement;
 
     /// See [`parse_require_key`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_require_key(input)
     }
 }

--- a/src/parsers/requirements.rs
+++ b/src/parsers/requirements.rs
@@ -13,15 +13,15 @@ use nom::combinator::map;
 /// ```
 /// # use pddl::parsers::{parse_require_def, preamble::*};
 /// # use pddl::{Requirement, Requirements};
-/// assert!(parse_require_def("(:requirements :adl)".into()).is_value(Requirements::new([Requirement::Adl])));
-/// assert!(parse_require_def("(:requirements :strips :typing)".into()).is_value(Requirements::new([Requirement::Strips, Requirement::Typing])));
-/// assert!(parse_require_def("(:requirements\n:strips   :typing  )".into()).is_value(Requirements::new([Requirement::Strips, Requirement::Typing])));
+/// assert!(parse_require_def("(:requirements :adl)").is_value(Requirements::new([Requirement::Adl])));
+/// assert!(parse_require_def("(:requirements :strips :typing)").is_value(Requirements::new([Requirement::Strips, Requirement::Typing])));
+/// assert!(parse_require_def("(:requirements\n:strips   :typing  )").is_value(Requirements::new([Requirement::Strips, Requirement::Typing])));
 ///```
-pub fn parse_require_def(input: Span) -> ParseResult<Requirements> {
-    let (remaining, reqs) =
-        prefix_expr(":requirements", space_separated_list1(parse_require_key))(input)?;
-
-    Ok((remaining, Requirements::new(reqs)))
+pub fn parse_require_def<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Requirements> {
+    map(
+        prefix_expr(":requirements", space_separated_list1(parse_require_key)),
+        Requirements::new,
+    )(input.into())
 }
 
 /// Parses a requirement key, i.e. `:strips`.
@@ -30,29 +30,29 @@ pub fn parse_require_def(input: Span) -> ParseResult<Requirements> {
 /// ```
 /// # use pddl::parsers::{parse_require_key, preamble::*};
 /// # use pddl::Requirement;
-/// assert!(parse_require_key(":strips".into()).is_value(Requirement::Strips));
-/// assert!(parse_require_key(":typing".into()).is_value(Requirement::Typing));
-/// assert!(parse_require_key(":negative-preconditions".into()).is_value(Requirement::NegativePreconditions));
-/// assert!(parse_require_key(":disjunctive-preconditions".into()).is_value(Requirement::DisjunctivePreconditions));
-/// assert!(parse_require_key(":equality".into()).is_value(Requirement::Equality));
-/// assert!(parse_require_key(":existential-preconditions".into()).is_value(Requirement::ExistentialPreconditions));
-/// assert!(parse_require_key(":universal-preconditions".into()).is_value(Requirement::UniversalPreconditions));
-/// assert!(parse_require_key(":quantified-preconditions".into()).is_value(Requirement::QuantifiedPreconditions));
-/// assert!(parse_require_key(":conditional-effects".into()).is_value(Requirement::ConditionalEffects));
-/// assert!(parse_require_key(":fluents".into()).is_value(Requirement::Fluents));
-/// assert!(parse_require_key(":numeric-fluents".into()).is_value(Requirement::NumericFluents));
-/// assert!(parse_require_key(":adl".into()).is_value(Requirement::Adl));
-/// assert!(parse_require_key(":durative-actions".into()).is_value(Requirement::DurativeActions));
-/// assert!(parse_require_key(":duration-inequalities".into()).is_value(Requirement::DurationInequalities));
-/// assert!(parse_require_key(":continuous-effects".into()).is_value(Requirement::ContinuousEffects));
-/// assert!(parse_require_key(":derived-predicates".into()).is_value(Requirement::DerivedPredicates));
-/// assert!(parse_require_key(":timed-initial-literals".into()).is_value(Requirement::TimedInitialLiterals));
-/// assert!(parse_require_key(":preferences".into()).is_value(Requirement::Preferences));
-/// assert!(parse_require_key(":constraints".into()).is_value(Requirement::Constraints));
-/// assert!(parse_require_key(":action-costs".into()).is_value(Requirement::ActionCosts));
+/// assert!(parse_require_key(":strips").is_value(Requirement::Strips));
+/// assert!(parse_require_key(":typing").is_value(Requirement::Typing));
+/// assert!(parse_require_key(":negative-preconditions").is_value(Requirement::NegativePreconditions));
+/// assert!(parse_require_key(":disjunctive-preconditions").is_value(Requirement::DisjunctivePreconditions));
+/// assert!(parse_require_key(":equality").is_value(Requirement::Equality));
+/// assert!(parse_require_key(":existential-preconditions").is_value(Requirement::ExistentialPreconditions));
+/// assert!(parse_require_key(":universal-preconditions").is_value(Requirement::UniversalPreconditions));
+/// assert!(parse_require_key(":quantified-preconditions").is_value(Requirement::QuantifiedPreconditions));
+/// assert!(parse_require_key(":conditional-effects").is_value(Requirement::ConditionalEffects));
+/// assert!(parse_require_key(":fluents").is_value(Requirement::Fluents));
+/// assert!(parse_require_key(":numeric-fluents").is_value(Requirement::NumericFluents));
+/// assert!(parse_require_key(":adl").is_value(Requirement::Adl));
+/// assert!(parse_require_key(":durative-actions").is_value(Requirement::DurativeActions));
+/// assert!(parse_require_key(":duration-inequalities").is_value(Requirement::DurationInequalities));
+/// assert!(parse_require_key(":continuous-effects").is_value(Requirement::ContinuousEffects));
+/// assert!(parse_require_key(":derived-predicates").is_value(Requirement::DerivedPredicates));
+/// assert!(parse_require_key(":timed-initial-literals").is_value(Requirement::TimedInitialLiterals));
+/// assert!(parse_require_key(":preferences").is_value(Requirement::Preferences));
+/// assert!(parse_require_key(":constraints").is_value(Requirement::Constraints));
+/// assert!(parse_require_key(":action-costs").is_value(Requirement::ActionCosts));
 ///
-/// assert!(parse_require_key(":unknown".into()).is_err());
-/// assert!(parse_require_key("invalid".into()).is_err());
+/// assert!(parse_require_key(":unknown").is_err());
+/// assert!(parse_require_key("invalid").is_err());
 ///```
 pub fn parse_require_key(input: Span) -> ParseResult<Requirement> {
     map(
@@ -80,7 +80,7 @@ pub fn parse_require_key(input: Span) -> ParseResult<Requirement> {
             tag(names::ACTION_COSTS),
         )),
         |x: Span| Requirement::try_from(*x.fragment()).expect("unhandled variant"),
-    )(input)
+    )(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for Requirements {

--- a/src/parsers/requirements.rs
+++ b/src/parsers/requirements.rs
@@ -86,8 +86,8 @@ pub fn parse_require_key(input: Span) -> ParseResult<Requirement> {
 impl<'a> crate::parsers::Parser<'a> for Requirements {
     type Item = Requirements;
 
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_require_def(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_require_def(input.into())
     }
 }
 
@@ -95,7 +95,7 @@ impl<'a> crate::parsers::Parser<'a> for Requirement {
     type Item = Requirement;
 
     /// See [`parse_require_key`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_require_key(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_require_key(input.into())
     }
 }

--- a/src/parsers/simple_duration_constraint.rs
+++ b/src/parsers/simple_duration_constraint.rs
@@ -64,7 +64,7 @@ impl<'a> crate::parsers::Parser<'a> for SimpleDurationConstraint<'a> {
     type Item = SimpleDurationConstraint<'a>;
 
     /// See [`parse_simple_duration_constraint`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_simple_duration_constraint(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_simple_duration_constraint(input.into())
     }
 }

--- a/src/parsers/simple_duration_constraint.rs
+++ b/src/parsers/simple_duration_constraint.rs
@@ -67,6 +67,6 @@ impl<'a> crate::parsers::Parser<'a> for SimpleDurationConstraint<'a> {
 
     /// See [`parse_simple_duration_constraint`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_simple_duration_constraint(input.into())
+        parse_simple_duration_constraint(input)
     }
 }

--- a/src/parsers/simple_duration_constraint.rs
+++ b/src/parsers/simple_duration_constraint.rs
@@ -36,7 +36,7 @@ use nom::sequence::{preceded, tuple};
 ///```
 pub fn parse_simple_duration_constraint<'a, T: Into<Span<'a>>>(
     input: T,
-) -> ParseResult<'a, SimpleDurationConstraint<'a>> {
+) -> ParseResult<'a, SimpleDurationConstraint> {
     let op = map(
         parens(tuple((
             parse_d_op,
@@ -62,11 +62,11 @@ pub fn parse_simple_duration_constraint<'a, T: Into<Span<'a>>>(
     alt((op, at))(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for SimpleDurationConstraint<'a> {
-    type Item = SimpleDurationConstraint<'a>;
+impl crate::parsers::Parser for SimpleDurationConstraint {
+    type Item = SimpleDurationConstraint;
 
     /// See [`parse_simple_duration_constraint`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_simple_duration_constraint(input)
     }
 }

--- a/src/parsers/simple_duration_constraint.rs
+++ b/src/parsers/simple_duration_constraint.rs
@@ -16,7 +16,7 @@ use nom::sequence::{preceded, tuple};
 /// # use pddl::parsers::{parse_simple_duration_constraint, preamble::*};
 /// # use pddl::{DOp, DurationValue, FunctionType, SimpleDurationConstraint, TimeSpecifier};
 /// let input = "(>= ?duration 1.23)";
-/// assert!(parse_simple_duration_constraint(input.into()).is_value(
+/// assert!(parse_simple_duration_constraint(input).is_value(
 ///     SimpleDurationConstraint::new_op(
 ///         DOp::GreaterOrEqual,
 ///         DurationValue::new_number(1.23)
@@ -24,7 +24,7 @@ use nom::sequence::{preceded, tuple};
 /// ));
 ///
 /// let input = "(at end (<= ?duration 1.23))";
-/// assert!(parse_simple_duration_constraint(input.into()).is_value(
+/// assert!(parse_simple_duration_constraint(input).is_value(
 ///     SimpleDurationConstraint::new_at(
 ///         TimeSpecifier::End,
 ///         SimpleDurationConstraint::Op(
@@ -34,7 +34,9 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 ///```
-pub fn parse_simple_duration_constraint(input: Span) -> ParseResult<SimpleDurationConstraint> {
+pub fn parse_simple_duration_constraint<'a, T: Into<Span<'a>>>(
+    input: T,
+) -> ParseResult<'a, SimpleDurationConstraint<'a>> {
     let op = map(
         parens(tuple((
             parse_d_op,
@@ -57,7 +59,7 @@ pub fn parse_simple_duration_constraint(input: Span) -> ParseResult<SimpleDurati
         SimpleDurationConstraint::from,
     );
 
-    alt((op, at))(input)
+    alt((op, at))(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for SimpleDurationConstraint<'a> {

--- a/src/parsers/simple_duration_constraint.rs
+++ b/src/parsers/simple_duration_constraint.rs
@@ -1,6 +1,6 @@
 //! Provides parsers for simple duration constraints.
 
-use crate::parsers::{parens, prefix_expr};
+use crate::parsers::{parens, prefix_expr, ParseResult, Span};
 use crate::parsers::{parse_d_op, parse_d_value, parse_time_specifier};
 use crate::types::SimpleDurationConstraint;
 use nom::branch::alt;
@@ -8,24 +8,23 @@ use nom::bytes::complete::tag;
 use nom::character::complete::multispace1;
 use nom::combinator::map;
 use nom::sequence::{preceded, tuple};
-use nom::IResult;
 
 /// Parses a simple duration constraint.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_simple_duration_constraint;
+/// # use pddl::parsers::{parse_simple_duration_constraint, preamble::*};
 /// # use pddl::{DOp, DurationValue, FunctionType, SimpleDurationConstraint, TimeSpecifier};
 /// let input = "(>= ?duration 1.23)";
-/// assert_eq!(parse_simple_duration_constraint(input), Ok(("",
+/// assert!(parse_simple_duration_constraint(input.into()).is_value(
 ///     SimpleDurationConstraint::new_op(
 ///         DOp::GreaterOrEqual,
 ///         DurationValue::new_number(1.23)
 ///     )
-/// )));
+/// ));
 ///
 /// let input = "(at end (<= ?duration 1.23))";
-/// assert_eq!(parse_simple_duration_constraint(input), Ok(("",
+/// assert!(parse_simple_duration_constraint(input.into()).is_value(
 ///     SimpleDurationConstraint::new_at(
 ///         TimeSpecifier::End,
 ///         SimpleDurationConstraint::Op(
@@ -33,9 +32,9 @@ use nom::IResult;
 ///             DurationValue::new_number(1.23)
 ///         )
 ///     )
-/// )));
+/// ));
 ///```
-pub fn parse_simple_duration_constraint(input: &str) -> IResult<&str, SimpleDurationConstraint> {
+pub fn parse_simple_duration_constraint(input: Span) -> ParseResult<SimpleDurationConstraint> {
     let op = map(
         parens(tuple((
             parse_d_op,
@@ -65,7 +64,7 @@ impl<'a> crate::parsers::Parser<'a> for SimpleDurationConstraint<'a> {
     type Item = SimpleDurationConstraint<'a>;
 
     /// See [`parse_simple_duration_constraint`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_simple_duration_constraint(input)
     }
 }

--- a/src/parsers/structure_def.rs
+++ b/src/parsers/structure_def.rs
@@ -19,7 +19,7 @@ use nom::combinator::map;
 ///                     :effect (not (in ?x))
 ///                 )"#;
 ///
-/// let action = parse_structure_def(input.into());
+/// let action = parse_structure_def(input);
 ///
 /// assert!(action.is_value(
 ///     StructureDef::new_action(ActionDefinition::new(
@@ -48,13 +48,13 @@ use nom::combinator::map;
 ///     )
 /// )));
 /// ```
-pub fn parse_structure_def(input: Span) -> ParseResult<StructureDef> {
+pub fn parse_structure_def<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, StructureDef<'a>> {
     let action = map(parse_action_def, StructureDef::new_action);
     // :durative-actions
     let durative = map(parse_da_def, StructureDef::new_durative_action);
     // :derived-predicates
     let derived = map(parse_derived_predicate, StructureDef::new_derived);
-    alt((derived, action, durative))(input)
+    alt((derived, action, durative))(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for StructureDef<'a> {

--- a/src/parsers/structure_def.rs
+++ b/src/parsers/structure_def.rs
@@ -62,6 +62,6 @@ impl<'a> crate::parsers::Parser<'a> for StructureDef<'a> {
 
     /// See [`parse_structure_def`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_structure_def(input.into())
+        parse_structure_def(input)
     }
 }

--- a/src/parsers/structure_def.rs
+++ b/src/parsers/structure_def.rs
@@ -48,7 +48,7 @@ use nom::combinator::map;
 ///     )
 /// )));
 /// ```
-pub fn parse_structure_def<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, StructureDef<'a>> {
+pub fn parse_structure_def<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, StructureDef> {
     let action = map(parse_action_def, StructureDef::new_action);
     // :durative-actions
     let durative = map(parse_da_def, StructureDef::new_durative_action);
@@ -57,11 +57,11 @@ pub fn parse_structure_def<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, S
     alt((derived, action, durative))(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for StructureDef<'a> {
-    type Item = StructureDef<'a>;
+impl crate::parsers::Parser for StructureDef {
+    type Item = StructureDef;
 
     /// See [`parse_structure_def`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_structure_def(input)
     }
 }

--- a/src/parsers/structure_def.rs
+++ b/src/parsers/structure_def.rs
@@ -61,7 +61,7 @@ impl<'a> crate::parsers::Parser<'a> for StructureDef<'a> {
     type Item = StructureDef<'a>;
 
     /// See [`parse_structure_def`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_structure_def(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_structure_def(input.into())
     }
 }

--- a/src/parsers/structure_def.rs
+++ b/src/parsers/structure_def.rs
@@ -1,17 +1,16 @@
 //! Provides parsers for domain structure definitions.
 
-use crate::parsers::{parse_action_def, parse_da_def, parse_derived_predicate};
+use crate::parsers::{parse_action_def, parse_da_def, parse_derived_predicate, ParseResult, Span};
 use crate::types::StructureDef;
 use nom::branch::alt;
 use nom::combinator::map;
-use nom::IResult;
 
 /// Parses a domain structure definition.
 ///
 /// ## Example
 ///
 /// ```
-/// # use pddl::parsers::{parse_structure_def};
+/// # use pddl::parsers::{parse_structure_def, preamble::*};
 /// # use pddl::{ActionDefinition, ActionSymbol, AtomicFormula, CEffect, Effects, GoalDefinition, Literal, PEffect, Predicate, Preference, PreferenceGD, PreconditionGoalDefinitions, StructureDef, Term, Variable};
 /// # use pddl::{Name, ToTyped, TypedList};
 /// let input = r#"(:action take-out
@@ -20,9 +19,9 @@ use nom::IResult;
 ///                     :effect (not (in ?x))
 ///                 )"#;
 ///
-/// let action = parse_structure_def(input);
+/// let action = parse_structure_def(input.into());
 ///
-/// assert_eq!(action, Ok(("",
+/// assert!(action.is_value(
 ///     StructureDef::new_action(ActionDefinition::new(
 ///         ActionSymbol::from("take-out"),
 ///         TypedList::from_iter([
@@ -47,9 +46,9 @@ use nom::IResult;
 ///             )
 ///         )))
 ///     )
-/// ))));
+/// )));
 /// ```
-pub fn parse_structure_def(input: &str) -> IResult<&str, StructureDef> {
+pub fn parse_structure_def(input: Span) -> ParseResult<StructureDef> {
     let action = map(parse_action_def, StructureDef::new_action);
     // :durative-actions
     let durative = map(parse_da_def, StructureDef::new_durative_action);
@@ -62,7 +61,7 @@ impl<'a> crate::parsers::Parser<'a> for StructureDef<'a> {
     type Item = StructureDef<'a>;
 
     /// See [`parse_structure_def`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_structure_def(input)
     }
 }

--- a/src/parsers/term.rs
+++ b/src/parsers/term.rs
@@ -1,21 +1,21 @@
 //! Provides parsers for terms.
 
-use crate::parsers::parse_name;
 use crate::parsers::{parse_function_term, parse_variable};
+use crate::parsers::{parse_name, ParseResult, Span};
 use crate::types::Term;
 use nom::error::ErrorKind;
-use nom::{error_position, IResult};
+use nom::error_position;
 
 /// Parses a term, i.e. `<name> | <variable> | <function-term>`.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_term;
+/// # use pddl::parsers::{parse_term, preamble::*};
 /// # use pddl::Term;
-/// assert_eq!(parse_term("abcde"), Ok(("", Term::Name("abcde".into()))));
-/// assert_eq!(parse_term("?abcde"), Ok(("", Term::Variable("abcde".into()))));
+/// assert!(parse_term("abcde".into()).is_value(Term::Name("abcde".into())));
+/// assert!(parse_term("?abcde".into()).is_value(Term::Variable("abcde".into())));
 ///```
-pub fn parse_term(input: &str) -> IResult<&str, Term> {
+pub fn parse_term(input: Span) -> ParseResult<Term> {
     if let Ok((remaining, variable)) = parse_variable(input) {
         return Ok((remaining, Term::Variable(variable)));
     }
@@ -35,7 +35,7 @@ impl<'a> crate::parsers::Parser<'a> for Term<'a> {
     type Item = Term<'a>;
 
     /// See [`parse_term`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_term(input)
     }
 }

--- a/src/parsers/term.rs
+++ b/src/parsers/term.rs
@@ -12,10 +12,10 @@ use nom::error_position;
 /// ```
 /// # use pddl::parsers::{parse_term, preamble::*};
 /// # use pddl::Term;
-/// assert!(parse_term("abcde".into()).is_value(Term::Name("abcde".into())));
-/// assert!(parse_term("?abcde".into()).is_value(Term::Variable("abcde".into())));
+/// assert!(parse_term("abcde").is_value(Term::Name("abcde".into())));
+/// assert!(parse_term("?abcde").is_value(Term::Variable("abcde".into())));
 ///```
-pub fn parse_term(input: Span) -> ParseResult<Term> {
+pub fn parse_term<'a, T: Into<Span<'a>> + Copy>(input: T) -> ParseResult<'a, Term<'a>> {
     if let Ok((remaining, variable)) = parse_variable(input) {
         return Ok((remaining, Term::Variable(variable)));
     }
@@ -28,7 +28,10 @@ pub fn parse_term(input: Span) -> ParseResult<Term> {
         return Ok((remaining, Term::Function(ft)));
     }
 
-    return Err(nom::Err::Error(error_position!(input, ErrorKind::Alt)));
+    return Err(nom::Err::Error(error_position!(
+        input.into(),
+        ErrorKind::Alt
+    )));
 }
 
 impl<'a> crate::parsers::Parser<'a> for Term<'a> {

--- a/src/parsers/term.rs
+++ b/src/parsers/term.rs
@@ -15,7 +15,9 @@ use nom::error_position;
 /// assert!(parse_term("abcde").is_value(Term::Name("abcde".into())));
 /// assert!(parse_term("?abcde").is_value(Term::Variable("abcde".into())));
 ///```
-pub fn parse_term<'a, T: Into<Span<'a>> + Copy>(input: T) -> ParseResult<'a, Term<'a>> {
+pub fn parse_term<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Term<'a>> {
+    let input = input.into();
+
     if let Ok((remaining, variable)) = parse_variable(input) {
         return Ok((remaining, Term::Variable(variable)));
     }
@@ -39,6 +41,6 @@ impl<'a> crate::parsers::Parser<'a> for Term<'a> {
 
     /// See [`parse_term`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_term(input.into())
+        parse_term(input)
     }
 }

--- a/src/parsers/term.rs
+++ b/src/parsers/term.rs
@@ -35,7 +35,7 @@ impl<'a> crate::parsers::Parser<'a> for Term<'a> {
     type Item = Term<'a>;
 
     /// See [`parse_term`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_term(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_term(input.into())
     }
 }

--- a/src/parsers/term.rs
+++ b/src/parsers/term.rs
@@ -15,7 +15,7 @@ use nom::error_position;
 /// assert!(parse_term("abcde").is_value(Term::Name("abcde".into())));
 /// assert!(parse_term("?abcde").is_value(Term::Variable("abcde".into())));
 ///```
-pub fn parse_term<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Term<'a>> {
+pub fn parse_term<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Term> {
     let input = input.into();
 
     if let Ok((remaining, variable)) = parse_variable(input) {
@@ -36,11 +36,11 @@ pub fn parse_term<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Term<'a>> 
     )));
 }
 
-impl<'a> crate::parsers::Parser<'a> for Term<'a> {
-    type Item = Term<'a>;
+impl crate::parsers::Parser for Term {
+    type Item = Term;
 
     /// See [`parse_term`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_term(input)
     }
 }

--- a/src/parsers/test_helpers.rs
+++ b/src/parsers/test_helpers.rs
@@ -9,7 +9,7 @@ pub trait UnwrapValue<V> {
     fn unwrap_value(self) -> V;
 
     /// Unwraps the value and compares it with the specified value.
-    fn is_value(self, value: V) -> bool;
+    fn is_value(&self, value: V) -> bool;
 }
 
 impl<'a, V> UnwrapValue<V> for ParseResult<'a, V>
@@ -20,7 +20,7 @@ where
         self.expect("expected a value").1
     }
 
-    fn is_value(self, value: V) -> bool {
+    fn is_value(&self, value: V) -> bool {
         match self {
             Ok((_, lhs)) => lhs.eq(&value),
             Err(_) => false,

--- a/src/parsers/test_helpers.rs
+++ b/src/parsers/test_helpers.rs
@@ -37,7 +37,7 @@ pub trait Match<V> {
     }
 
     /// Ensures the remainder value are as specified.
-    fn is_result<'a>(&'a self, remainder: &'a str, value: V) -> bool;
+    fn is_result(&self, remainder: &str, value: V) -> bool;
 }
 
 impl<'a, E> Match<Option<&str>> for ParseResult<'a, Option<Span<'a>>, E> {
@@ -75,8 +75,8 @@ where
     }
 }
 
-impl<'a, E> Match<Type<'a>> for ParseResult<'a, Type<'a>, E> {
-    fn is_result(&self, remainder: &str, value: Type<'a>) -> bool {
+impl<'a, E> Match<Type> for ParseResult<'a, Type, E> {
+    fn is_result(&self, remainder: &str, value: Type) -> bool {
         if let Ok((lhs, rhs)) = self {
             if !remainder.eq(*lhs.fragment()) {
                 false

--- a/src/parsers/test_helpers.rs
+++ b/src/parsers/test_helpers.rs
@@ -1,0 +1,107 @@
+//! Contains helper traits for dealing with [`ParseResult`] values.
+
+use crate::parsers::{ParseResult, Span};
+use crate::Type;
+
+/// A helper trait for dealing with [`ParseResult`] values.
+pub trait UnwrapValue<V> {
+    /// Unwraps the value or panicks if there was none.
+    fn unwrap_value(self) -> V;
+
+    /// Unwraps the value and compares it with the specified value.
+    fn is_value(self, value: V) -> bool;
+}
+
+impl<'a, V> UnwrapValue<V> for ParseResult<'a, V>
+where
+    V: PartialEq,
+{
+    fn unwrap_value(self) -> V {
+        self.expect("expected a value").1
+    }
+
+    fn is_value(self, value: V) -> bool {
+        match self {
+            Ok((_, lhs)) => lhs.eq(&value),
+            Err(_) => false,
+        }
+    }
+}
+
+/// A helper trait for dealing with [`ParseResult`] values.
+pub trait Match<V> {
+    /// Ensures the parser produced the specified value
+    /// and leaves no remaining value to be parsed.
+    fn is_exactly(&self, value: V) -> bool {
+        self.is_result("", value)
+    }
+
+    /// Ensures the remainder value are as specified.
+    fn is_result<'a>(&'a self, remainder: &'a str, value: V) -> bool;
+}
+
+impl<'a, E> Match<Option<&str>> for ParseResult<'a, Option<Span<'a>>, E> {
+    fn is_result(&self, remainder: &str, value: Option<&str>) -> bool {
+        if let Ok((lhs, rhs)) = self {
+            if !remainder.eq(*lhs.fragment()) {
+                false
+            } else if value.is_none() {
+                return rhs.is_none();
+            } else if let Some(rhs) = rhs {
+                value.eq(&Some(*rhs.fragment()))
+            } else {
+                false
+            }
+        } else {
+            false
+        }
+    }
+}
+
+impl<'a, T, E> Match<&'a str> for ParseResult<'a, T, E>
+where
+    T: From<&'a str> + PartialEq,
+{
+    fn is_result(&self, remainder: &str, value: &'a str) -> bool {
+        if let Ok((lhs, rhs)) = self {
+            if !remainder.eq(*lhs.fragment()) {
+                false
+            } else {
+                T::from(value).eq(rhs)
+            }
+        } else {
+            false
+        }
+    }
+}
+
+impl<'a, E> Match<Type<'a>> for ParseResult<'a, Type<'a>, E> {
+    fn is_result(&self, remainder: &str, value: Type<'a>) -> bool {
+        if let Ok((lhs, rhs)) = self {
+            if !remainder.eq(*lhs.fragment()) {
+                false
+            } else {
+                value.eq(rhs)
+            }
+        } else {
+            false
+        }
+    }
+}
+
+impl<'a, T, E> Match<Vec<T>> for ParseResult<'a, Vec<T>, E>
+where
+    T: PartialEq,
+{
+    fn is_result(&self, remainder: &str, value: Vec<T>) -> bool {
+        if let Ok((lhs, rhs)) = self {
+            if !remainder.eq(*lhs.fragment()) {
+                false
+            } else {
+                value.eq(rhs)
+            }
+        } else {
+            false
+        }
+    }
+}

--- a/src/parsers/time_specifier.rs
+++ b/src/parsers/time_specifier.rs
@@ -1,33 +1,32 @@
 //! Provides parsers for assignment operations.
 
+use crate::parsers::{ParseResult, Span};
 use crate::types::time_specifier::names;
 use crate::types::TimeSpecifier;
 use nom::branch::alt;
 use nom::bytes::complete::tag;
-use nom::combinator::map_res;
-use nom::IResult;
+use nom::combinator::map;
 
 /// Parses an assignment operation, i.e. `increase | decrease`.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_time_specifier;
+/// # use pddl::parsers::{parse_time_specifier, preamble::*};
 /// # use pddl::{TimeSpecifier};
-/// assert_eq!(parse_time_specifier("start"), Ok(("", TimeSpecifier::Start)));
-/// assert_eq!(parse_time_specifier("end"), Ok(("", TimeSpecifier::End)));
+/// assert!(parse_time_specifier("start".into()).is_value(TimeSpecifier::Start));
+/// assert!(parse_time_specifier("end".into()).is_value(TimeSpecifier::End));
 ///```
-pub fn parse_time_specifier(input: &str) -> IResult<&str, TimeSpecifier> {
-    map_res(
-        alt((tag(names::START), tag(names::END))),
-        TimeSpecifier::try_from,
-    )(input)
+pub fn parse_time_specifier(input: Span) -> ParseResult<TimeSpecifier> {
+    map(alt((tag(names::START), tag(names::END))), |x: Span| {
+        TimeSpecifier::try_from(*x.fragment()).expect("unhandled variant")
+    })(input)
 }
 
 impl<'a> crate::parsers::Parser<'a> for TimeSpecifier {
     type Item = TimeSpecifier;
 
     /// See [`parse_time_specifier`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_time_specifier(input)
     }
 }

--- a/src/parsers/time_specifier.rs
+++ b/src/parsers/time_specifier.rs
@@ -13,13 +13,13 @@ use nom::combinator::map;
 /// ```
 /// # use pddl::parsers::{parse_time_specifier, preamble::*};
 /// # use pddl::{TimeSpecifier};
-/// assert!(parse_time_specifier("start".into()).is_value(TimeSpecifier::Start));
-/// assert!(parse_time_specifier("end".into()).is_value(TimeSpecifier::End));
+/// assert!(parse_time_specifier("start").is_value(TimeSpecifier::Start));
+/// assert!(parse_time_specifier("end").is_value(TimeSpecifier::End));
 ///```
-pub fn parse_time_specifier(input: Span) -> ParseResult<TimeSpecifier> {
+pub fn parse_time_specifier<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, TimeSpecifier> {
     map(alt((tag(names::START), tag(names::END))), |x: Span| {
         TimeSpecifier::try_from(*x.fragment()).expect("unhandled variant")
-    })(input)
+    })(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for TimeSpecifier {

--- a/src/parsers/time_specifier.rs
+++ b/src/parsers/time_specifier.rs
@@ -27,6 +27,6 @@ impl<'a> crate::parsers::Parser<'a> for TimeSpecifier {
 
     /// See [`parse_time_specifier`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_time_specifier(input.into())
+        parse_time_specifier(input)
     }
 }

--- a/src/parsers/time_specifier.rs
+++ b/src/parsers/time_specifier.rs
@@ -22,11 +22,11 @@ pub fn parse_time_specifier<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, 
     })(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for TimeSpecifier {
+impl crate::parsers::Parser for TimeSpecifier {
     type Item = TimeSpecifier;
 
     /// See [`parse_time_specifier`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_time_specifier(input)
     }
 }

--- a/src/parsers/time_specifier.rs
+++ b/src/parsers/time_specifier.rs
@@ -26,7 +26,7 @@ impl<'a> crate::parsers::Parser<'a> for TimeSpecifier {
     type Item = TimeSpecifier;
 
     /// See [`parse_time_specifier`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_time_specifier(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_time_specifier(input.into())
     }
 }

--- a/src/parsers/timed_effect.rs
+++ b/src/parsers/timed_effect.rs
@@ -93,7 +93,7 @@ impl<'a> crate::parsers::Parser<'a> for TimedEffect<'a> {
 
     /// See [`parse_timed_effect`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_timed_effect(input.into())
+        parse_timed_effect(input)
     }
 }
 

--- a/src/parsers/timed_effect.rs
+++ b/src/parsers/timed_effect.rs
@@ -18,7 +18,7 @@ use nom::sequence::{preceded, tuple};
 /// # use pddl::parsers::{parse_timed_effect, preamble::*};
 /// # use pddl::{AssignOp, AssignOpT, AtomicFormula, CEffect, ConditionalEffect, EqualityAtomicFormula, FAssignDa, FExpDa, FExpT, FHead, PEffect, Term, TimedEffect, TimeSpecifier};
 /// # use pddl::FExpDa::FExp;
-/// assert!(parse_timed_effect("(at start (= x y))".into()).is_value(
+/// assert!(parse_timed_effect("(at start (= x y))").is_value(
 ///     TimedEffect::new_conditional(
 ///         TimeSpecifier::Start,
 ///         ConditionalEffect::new(
@@ -32,7 +32,7 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 ///
-/// assert!(parse_timed_effect("(at end (assign fun-sym ?duration))".into()).is_value(
+/// assert!(parse_timed_effect("(at end (assign fun-sym ?duration))").is_value(
 ///     TimedEffect::new_fluent(
 ///         TimeSpecifier::End,
 ///         FAssignDa::new(
@@ -43,7 +43,7 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 ///
-/// assert!(parse_timed_effect("(increase fun-sym #t)".into()).is_value(
+/// assert!(parse_timed_effect("(increase fun-sym #t)").is_value(
 ///     TimedEffect::new_continuous(
 ///         AssignOpT::Increase,
 ///         FHead::Simple("fun-sym".into()),
@@ -51,7 +51,7 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 /// ```
-pub fn parse_timed_effect(input: Span) -> ParseResult<TimedEffect> {
+pub fn parse_timed_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, TimedEffect<'a>> {
     let cond = map(
         prefix_expr(
             "at",
@@ -85,7 +85,7 @@ pub fn parse_timed_effect(input: Span) -> ParseResult<TimedEffect> {
         TimedEffect::from,
     );
 
-    alt((fluent, cond, continuous))(input)
+    alt((fluent, cond, continuous))(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for TimedEffect<'a> {

--- a/src/parsers/timed_effect.rs
+++ b/src/parsers/timed_effect.rs
@@ -92,8 +92,8 @@ impl<'a> crate::parsers::Parser<'a> for TimedEffect<'a> {
     type Item = TimedEffect<'a>;
 
     /// See [`parse_timed_effect`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_timed_effect(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_timed_effect(input.into())
     }
 }
 

--- a/src/parsers/timed_effect.rs
+++ b/src/parsers/timed_effect.rs
@@ -51,7 +51,7 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 /// ```
-pub fn parse_timed_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, TimedEffect<'a>> {
+pub fn parse_timed_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, TimedEffect> {
     let cond = map(
         prefix_expr(
             "at",
@@ -88,11 +88,11 @@ pub fn parse_timed_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Ti
     alt((fluent, cond, continuous))(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for TimedEffect<'a> {
-    type Item = TimedEffect<'a>;
+impl crate::parsers::Parser for TimedEffect {
+    type Item = TimedEffect;
 
     /// See [`parse_timed_effect`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_timed_effect(input)
     }
 }

--- a/src/parsers/timed_gd.rs
+++ b/src/parsers/timed_gd.rs
@@ -63,7 +63,7 @@ impl<'a> crate::parsers::Parser<'a> for TimedGD<'a> {
 
     /// See [`parse_timed_gd`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_timed_gd(input.into())
+        parse_timed_gd(input)
     }
 }
 

--- a/src/parsers/timed_gd.rs
+++ b/src/parsers/timed_gd.rs
@@ -38,7 +38,7 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 /// ```
-pub fn parse_timed_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, TimedGD<'a>> {
+pub fn parse_timed_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, TimedGD> {
     let at = map(
         prefix_expr(
             "at",
@@ -58,11 +58,11 @@ pub fn parse_timed_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, TimedG
     alt((at, over))(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for TimedGD<'a> {
-    type Item = TimedGD<'a>;
+impl crate::parsers::Parser for TimedGD {
+    type Item = TimedGD;
 
     /// See [`parse_timed_gd`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_timed_gd(input)
     }
 }

--- a/src/parsers/timed_gd.rs
+++ b/src/parsers/timed_gd.rs
@@ -62,8 +62,8 @@ impl<'a> crate::parsers::Parser<'a> for TimedGD<'a> {
     type Item = TimedGD<'a>;
 
     /// See [`parse_timed_gd`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_timed_gd(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_timed_gd(input.into())
     }
 }
 

--- a/src/parsers/timed_gd.rs
+++ b/src/parsers/timed_gd.rs
@@ -1,21 +1,20 @@
 //! Provides parsers for timed goal definitions.
 
-use crate::parsers::prefix_expr;
 use crate::parsers::{parse_gd, parse_interval, parse_time_specifier};
+use crate::parsers::{prefix_expr, ParseResult, Span};
 use crate::types::TimedGD;
 use nom::branch::alt;
 use nom::character::complete::multispace1;
 use nom::combinator::map;
 use nom::sequence::{preceded, tuple};
-use nom::IResult;
 
 /// Parser for timed goal definitions.
 ///
 /// ## Examples
 /// ```
-/// # use pddl::parsers::{parse_timed_gd};
+/// # use pddl::parsers::{parse_timed_gd, preamble::*};
 /// # use pddl::{AtomicFormula, GoalDefinition, Interval, Term, TimedGD, TimeSpecifier};
-/// assert_eq!(parse_timed_gd("(at start (= x y))"), Ok(("",
+/// assert!(parse_timed_gd("(at start (= x y))".into()).is_value(
 ///     TimedGD::new_at(
 ///         TimeSpecifier::Start,
 ///         GoalDefinition::AtomicFormula(
@@ -25,9 +24,9 @@ use nom::IResult;
 ///             )
 ///         )
 ///     )
-/// )));
+/// ));
 ///
-/// assert_eq!(parse_timed_gd("(over all (= x y))"), Ok(("",
+/// assert!(parse_timed_gd("(over all (= x y))".into()).is_value(
 ///     TimedGD::new_over(
 ///         Interval::All,
 ///         GoalDefinition::AtomicFormula(
@@ -37,9 +36,9 @@ use nom::IResult;
 ///             )
 ///         )
 ///     )
-/// )));
+/// ));
 /// ```
-pub fn parse_timed_gd(input: &str) -> IResult<&str, TimedGD> {
+pub fn parse_timed_gd(input: Span) -> ParseResult<TimedGD> {
     let at = map(
         prefix_expr(
             "at",
@@ -59,13 +58,11 @@ pub fn parse_timed_gd(input: &str) -> IResult<&str, TimedGD> {
     alt((at, over))(input)
 }
 
-#[cfg_attr(docsrs, doc(cfg(feature = "parser")))]
-#[cfg(feature = "parser")]
 impl<'a> crate::parsers::Parser<'a> for TimedGD<'a> {
     type Item = TimedGD<'a>;
 
     /// See [`parse_timed_gd`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_timed_gd(input)
     }
 }
@@ -77,6 +74,6 @@ mod tests {
     #[test]
     fn it_works() {
         let input = "(over all (can-move ?from-waypoint ?to-waypoint))";
-        let (_, _gd) = parse_timed_gd(input).unwrap();
+        let (_, _gd) = parse_timed_gd(Span::new(input)).unwrap();
     }
 }

--- a/src/parsers/timed_gd.rs
+++ b/src/parsers/timed_gd.rs
@@ -14,7 +14,7 @@ use nom::sequence::{preceded, tuple};
 /// ```
 /// # use pddl::parsers::{parse_timed_gd, preamble::*};
 /// # use pddl::{AtomicFormula, GoalDefinition, Interval, Term, TimedGD, TimeSpecifier};
-/// assert!(parse_timed_gd("(at start (= x y))".into()).is_value(
+/// assert!(parse_timed_gd("(at start (= x y))").is_value(
 ///     TimedGD::new_at(
 ///         TimeSpecifier::Start,
 ///         GoalDefinition::AtomicFormula(
@@ -26,7 +26,7 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 ///
-/// assert!(parse_timed_gd("(over all (= x y))".into()).is_value(
+/// assert!(parse_timed_gd("(over all (= x y))").is_value(
 ///     TimedGD::new_over(
 ///         Interval::All,
 ///         GoalDefinition::AtomicFormula(
@@ -38,7 +38,7 @@ use nom::sequence::{preceded, tuple};
 ///     )
 /// ));
 /// ```
-pub fn parse_timed_gd(input: Span) -> ParseResult<TimedGD> {
+pub fn parse_timed_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, TimedGD<'a>> {
     let at = map(
         prefix_expr(
             "at",
@@ -55,7 +55,7 @@ pub fn parse_timed_gd(input: Span) -> ParseResult<TimedGD> {
         TimedGD::from,
     );
 
-    alt((at, over))(input)
+    alt((at, over))(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for TimedGD<'a> {

--- a/src/parsers/timeless_def.rs
+++ b/src/parsers/timeless_def.rs
@@ -34,18 +34,18 @@ use nom::combinator::map;
 ///     ])
 /// ));
 /// ```
-pub fn parse_timeless_def<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Timeless<'a>> {
+pub fn parse_timeless_def<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Timeless> {
     map(
         prefix_expr(":timeless", space_separated_list1(literal(parse_name))),
         Timeless::from_iter,
     )(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for Timeless<'a> {
-    type Item = Timeless<'a>;
+impl crate::parsers::Parser for Timeless {
+    type Item = Timeless;
 
     /// See [`parse_timeless_def`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_timeless_def(input)
     }
 }

--- a/src/parsers/timeless_def.rs
+++ b/src/parsers/timeless_def.rs
@@ -45,7 +45,7 @@ impl<'a> crate::parsers::Parser<'a> for Timeless<'a> {
     type Item = Timeless<'a>;
 
     /// See [`parse_timeless_def`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_timeless_def(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_timeless_def(input.into())
     }
 }

--- a/src/parsers/timeless_def.rs
+++ b/src/parsers/timeless_def.rs
@@ -46,6 +46,6 @@ impl<'a> crate::parsers::Parser<'a> for Timeless<'a> {
 
     /// See [`parse_timeless_def`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_timeless_def(input.into())
+        parse_timeless_def(input)
     }
 }

--- a/src/parsers/timeless_def.rs
+++ b/src/parsers/timeless_def.rs
@@ -1,19 +1,18 @@
 //! Provides parsers for timeless definitions.
 
-use crate::parsers::{literal, parse_name, prefix_expr, space_separated_list1};
+use crate::parsers::{literal, parse_name, prefix_expr, space_separated_list1, ParseResult, Span};
 use crate::types::Timeless;
 use nom::combinator::map;
-use nom::IResult;
 
 /// Parser for timeless definitions.
 /// This is a PDDL 1.2 construct.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_timeless_def;
+/// # use pddl::parsers::{parse_timeless_def, preamble::*};
 /// # use pddl::{AtomicFormula, EqualityAtomicFormula, Literal, Name, Objects, Timeless, ToTyped, Type};
 /// let input = "(:timeless (= x y) (= a b))";
-/// assert_eq!(parse_timeless_def(input), Ok(("",
+/// assert!(parse_timeless_def(input.into()).is_value(
 ///     Timeless::from_iter([
 ///         Literal::AtomicFormula(
 ///             AtomicFormula::Equality(
@@ -33,9 +32,9 @@ use nom::IResult;
 ///             # )
 ///         )
 ///     ])
-/// )));
+/// ));
 /// ```
-pub fn parse_timeless_def(input: &str) -> IResult<&str, Timeless> {
+pub fn parse_timeless_def(input: Span) -> ParseResult<Timeless> {
     map(
         prefix_expr(":timeless", space_separated_list1(literal(parse_name))),
         Timeless::from_iter,
@@ -46,7 +45,7 @@ impl<'a> crate::parsers::Parser<'a> for Timeless<'a> {
     type Item = Timeless<'a>;
 
     /// See [`parse_timeless_def`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_timeless_def(input)
     }
 }

--- a/src/parsers/timeless_def.rs
+++ b/src/parsers/timeless_def.rs
@@ -12,7 +12,7 @@ use nom::combinator::map;
 /// # use pddl::parsers::{parse_timeless_def, preamble::*};
 /// # use pddl::{AtomicFormula, EqualityAtomicFormula, Literal, Name, Objects, Timeless, ToTyped, Type};
 /// let input = "(:timeless (= x y) (= a b))";
-/// assert!(parse_timeless_def(input.into()).is_value(
+/// assert!(parse_timeless_def(input).is_value(
 ///     Timeless::from_iter([
 ///         Literal::AtomicFormula(
 ///             AtomicFormula::Equality(
@@ -34,11 +34,11 @@ use nom::combinator::map;
 ///     ])
 /// ));
 /// ```
-pub fn parse_timeless_def(input: Span) -> ParseResult<Timeless> {
+pub fn parse_timeless_def<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Timeless<'a>> {
     map(
         prefix_expr(":timeless", space_separated_list1(literal(parse_name))),
         Timeless::from_iter,
-    )(input)
+    )(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for Timeless<'a> {

--- a/src/parsers/type.rs
+++ b/src/parsers/type.rs
@@ -36,8 +36,8 @@ impl<'a> crate::parsers::Parser<'a> for Type<'a> {
     type Item = Type<'a>;
 
     /// See [`parse_type`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_type(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_type(input.into())
     }
 }
 

--- a/src/parsers/type.rs
+++ b/src/parsers/type.rs
@@ -15,7 +15,9 @@ use nom::error_position;
 /// assert!(parse_type(Span::new("object")).is_value(Type::Exactly("object".into())));
 /// assert!(parse_type(Span::new("(either object number)")).is_value(Type::from_iter(["object", "number"])));
 ///```
-pub fn parse_type<'a, T: Into<Span<'a>> + Copy>(input: T) -> ParseResult<'a, Type<'a>> {
+pub fn parse_type<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Type<'a>> {
+    let input = input.into();
+
     if let Ok((remaining, r#type)) = parse_primitive_type(input) {
         return Ok((remaining, Type::Exactly(r#type)));
     }
@@ -40,7 +42,7 @@ impl<'a> crate::parsers::Parser<'a> for Type<'a> {
 
     /// See [`parse_type`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_type(input.into())
+        parse_type(input)
     }
 }
 

--- a/src/parsers/type.rs
+++ b/src/parsers/type.rs
@@ -15,7 +15,7 @@ use nom::error_position;
 /// assert!(parse_type(Span::new("object")).is_value(Type::Exactly("object".into())));
 /// assert!(parse_type(Span::new("(either object number)")).is_value(Type::from_iter(["object", "number"])));
 ///```
-pub fn parse_type<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Type<'a>> {
+pub fn parse_type<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Type> {
     let input = input.into();
 
     if let Ok((remaining, r#type)) = parse_primitive_type(input) {
@@ -33,15 +33,15 @@ pub fn parse_type<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Type<'a>> 
 }
 
 /// Parses a either type, i.e. `(either a b c)`.
-fn parse_either_type<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Vec<PrimitiveType<'a>>> {
+fn parse_either_type<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Vec<PrimitiveType>> {
     prefix_expr("either", space_separated_list1(parse_primitive_type))(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for Type<'a> {
-    type Item = Type<'a>;
+impl crate::parsers::Parser for Type {
+    type Item = Type;
 
     /// See [`parse_type`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_type(input)
     }
 }

--- a/src/parsers/type.rs
+++ b/src/parsers/type.rs
@@ -1,21 +1,21 @@
 //! Provides parsers for types.
 
-use crate::parsers::parse_primitive_type;
+use crate::parsers::{parse_primitive_type, ParseResult, Span};
 use crate::parsers::{prefix_expr, space_separated_list1};
 use crate::types::{PrimitiveType, Type};
 use nom::error::ErrorKind;
-use nom::{error_position, IResult};
+use nom::error_position;
 
 /// Parses a primitive type, i.e. `object | <name>`.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_type;
+/// # use pddl::parsers::{parse_type, preamble::*};
 /// # use pddl::Type;
-/// assert_eq!(parse_type("object"), Ok(("", Type::Exactly("object".into()))));
-/// assert_eq!(parse_type("(either object number)"), Ok(("", Type::from_iter(["object", "number"]))));
+/// assert!(parse_type(Span::new("object")).is_value(Type::Exactly("object".into())));
+/// assert!(parse_type(Span::new("(either object number)")).is_value(Type::from_iter(["object", "number"])));
 ///```
-pub fn parse_type(input: &str) -> IResult<&str, Type> {
+pub fn parse_type<'a>(input: Span<'a>) -> ParseResult<'a, Type> {
     if let Ok((remaining, r#type)) = parse_primitive_type(input) {
         return Ok((remaining, Type::Exactly(r#type)));
     }
@@ -28,7 +28,7 @@ pub fn parse_type(input: &str) -> IResult<&str, Type> {
 }
 
 /// Parses a either type, i.e. `(either a b c)`.
-fn parse_either_type(input: &str) -> IResult<&str, Vec<PrimitiveType>> {
+fn parse_either_type<'a>(input: Span<'a>) -> ParseResult<'a, Vec<PrimitiveType>> {
     prefix_expr("either", space_separated_list1(parse_primitive_type))(input)
 }
 
@@ -36,7 +36,7 @@ impl<'a> crate::parsers::Parser<'a> for Type<'a> {
     type Item = Type<'a>;
 
     /// See [`parse_type`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_type(input)
     }
 }
@@ -44,28 +44,26 @@ impl<'a> crate::parsers::Parser<'a> for Type<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parsers::Match;
 
     #[test]
     fn explicit_works() {
-        assert_eq!(parse_type("object"), Ok(("", Type::from("object"))));
+        assert!(parse_type(Span::new("object")).is_exactly(Type::from("object")));
     }
 
     #[test]
     fn either_works() {
-        assert_eq!(
-            parse_type("(either object number)"),
-            Ok(("", Type::from_iter(["object", "number"])))
-        );
+        assert!(parse_type(Span::new("(either object number)"))
+            .is_exactly(Type::from_iter(["object", "number"])));
     }
 
     #[test]
     fn either_specific_works() {
-        assert_eq!(
-            parse_either_type("(either object number)"),
-            Ok((
-                "",
-                vec![PrimitiveType::from("object"), PrimitiveType::from("number")]
-            ))
+        assert!(
+            parse_either_type(Span::new("(either object number)")).is_exactly(vec![
+                PrimitiveType::from("object"),
+                PrimitiveType::from("number")
+            ])
         );
     }
 }

--- a/src/parsers/types_def.rs
+++ b/src/parsers/types_def.rs
@@ -1,26 +1,25 @@
 //! Provides parsers for constant definitions.
 
-use crate::parsers::{parse_name, prefix_expr, typed_list};
+use crate::parsers::{parse_name, prefix_expr, typed_list, ParseResult, Span};
 use crate::types::Types;
 use nom::combinator::map;
-use nom::IResult;
 
 /// Parser that parses constant definitions, i.e. `(:constants <typed list (name)>)`.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_types_def;
+/// # use pddl::parsers::{parse_types_def, preamble::*};
 /// # use pddl::{Variable, AtomicFormulaSkeleton, Predicate, PredicateDefinitions};
 /// # use pddl::{Name, Type, Typed, TypedList, Types};
 /// let input = "(:types location physob)";
-/// assert_eq!(parse_types_def(input), Ok(("",
+/// assert!(parse_types_def(input.into()).is_value(
 ///     Types::new(TypedList::from_iter([
 ///         Typed::new(Name::from("location"), Type::OBJECT),
 ///         Typed::new(Name::from("physob"), Type::OBJECT),
 ///     ]))
-/// )));
+/// ));
 /// ```
-pub fn parse_types_def(input: &str) -> IResult<&str, Types> {
+pub fn parse_types_def(input: Span) -> ParseResult<Types> {
     map(prefix_expr(":types", typed_list(parse_name)), |vec| {
         Types::new(vec)
     })(input)
@@ -30,7 +29,7 @@ impl<'a> crate::parsers::Parser<'a> for Types<'a> {
     type Item = Types<'a>;
 
     /// See [`parse_types_def`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_types_def(input)
     }
 }

--- a/src/parsers/types_def.rs
+++ b/src/parsers/types_def.rs
@@ -12,17 +12,17 @@ use nom::combinator::map;
 /// # use pddl::{Variable, AtomicFormulaSkeleton, Predicate, PredicateDefinitions};
 /// # use pddl::{Name, Type, Typed, TypedList, Types};
 /// let input = "(:types location physob)";
-/// assert!(parse_types_def(input.into()).is_value(
+/// assert!(parse_types_def(input).is_value(
 ///     Types::new(TypedList::from_iter([
 ///         Typed::new(Name::from("location"), Type::OBJECT),
 ///         Typed::new(Name::from("physob"), Type::OBJECT),
 ///     ]))
 /// ));
 /// ```
-pub fn parse_types_def(input: Span) -> ParseResult<Types> {
+pub fn parse_types_def<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Types<'a>> {
     map(prefix_expr(":types", typed_list(parse_name)), |vec| {
         Types::new(vec)
-    })(input)
+    })(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for Types<'a> {

--- a/src/parsers/types_def.rs
+++ b/src/parsers/types_def.rs
@@ -29,7 +29,7 @@ impl<'a> crate::parsers::Parser<'a> for Types<'a> {
     type Item = Types<'a>;
 
     /// See [`parse_types_def`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_types_def(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_types_def(input.into())
     }
 }

--- a/src/parsers/types_def.rs
+++ b/src/parsers/types_def.rs
@@ -30,6 +30,6 @@ impl<'a> crate::parsers::Parser<'a> for Types<'a> {
 
     /// See [`parse_types_def`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_types_def(input.into())
+        parse_types_def(input)
     }
 }

--- a/src/parsers/types_def.rs
+++ b/src/parsers/types_def.rs
@@ -19,17 +19,17 @@ use nom::combinator::map;
 ///     ]))
 /// ));
 /// ```
-pub fn parse_types_def<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Types<'a>> {
+pub fn parse_types_def<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Types> {
     map(prefix_expr(":types", typed_list(parse_name)), |vec| {
         Types::new(vec)
     })(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for Types<'a> {
-    type Item = Types<'a>;
+impl crate::parsers::Parser for Types {
+    type Item = Types;
 
     /// See [`parse_types_def`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_types_def(input)
     }
 }

--- a/src/parsers/utilities.rs
+++ b/src/parsers/utilities.rs
@@ -1,29 +1,26 @@
 //! Utility parsers.
 
+use crate::parsers::{ParseResult, Span};
 use nom::bytes::complete::tag;
 use nom::character::complete::{char, multispace0, multispace1};
-use nom::error::ParseError;
 use nom::multi::{separated_list0, separated_list1};
 use nom::sequence::{delimited, preceded};
-use nom::IResult;
 
 /// A combinator that takes a parser `inner` and produces a parser that also
 /// consumes a leading `(name` and trailing `)`, returning the output of `inner`.
 #[allow(clippy::needless_lifetimes)]
-pub fn prefix_expr<'a, F, O>(name: &'a str, inner: F) -> impl FnMut(&'a str) -> IResult<&'a str, O>
+pub fn prefix_expr<'a, F, O>(name: &'a str, inner: F) -> impl FnMut(Span<'a>) -> ParseResult<'a, O>
 where
-    F: FnMut(&'a str) -> IResult<&'a str, O>,
+    F: FnMut(Span<'a>) -> ParseResult<'a, O>,
 {
     delimited(preceded(tag("("), tag(name)), ws(inner), tag(")"))
 }
 
 /// A combinator that takes a parser `inner` and produces a parser that also consumes both leading and
 /// trailing whitespace, returning the output of `inner`.
-pub fn ws<'a, F, O, E: ParseError<&'a str>>(
-    inner: F,
-) -> impl FnMut(&'a str) -> IResult<&'a str, O, E>
+pub fn ws<'a, F, O>(inner: F) -> impl FnMut(Span<'a>) -> ParseResult<'a, O>
 where
-    F: FnMut(&'a str) -> IResult<&'a str, O, E>,
+    F: FnMut(Span<'a>) -> ParseResult<'a, O>,
 {
     delimited(multispace0, inner, multispace0)
 }
@@ -31,27 +28,27 @@ where
 /// A combinator that takes a parser `inner` and produces a parser that also
 /// consumes a whitespace separated list, returning the outputs of `inner`.
 #[allow(dead_code)]
-pub fn space_separated_list0<'a, F, O>(inner: F) -> impl FnMut(&'a str) -> IResult<&'a str, Vec<O>>
+pub fn space_separated_list0<'a, F, O>(inner: F) -> impl FnMut(Span<'a>) -> ParseResult<'a, Vec<O>>
 where
-    F: FnMut(&'a str) -> IResult<&'a str, O>,
+    F: FnMut(Span<'a>) -> ParseResult<'a, O>,
 {
     ws(separated_list0(multispace1, inner))
 }
 
 /// A combinator that takes a parser `inner` and produces a parser that also
 /// consumes a whitespace separated list, returning the outputs of `inner`.
-pub fn space_separated_list1<'a, F, O>(inner: F) -> impl FnMut(&'a str) -> IResult<&'a str, Vec<O>>
+pub fn space_separated_list1<'a, F, O>(inner: F) -> impl FnMut(Span<'a>) -> ParseResult<'a, Vec<O>>
 where
-    F: FnMut(&'a str) -> IResult<&'a str, O>,
+    F: FnMut(Span<'a>) -> ParseResult<'a, O>,
 {
     ws(separated_list1(multispace1, inner))
 }
 
 /// A combinator that takes a parser `inner` and produces a parser that consumes
 /// surrounding parentheses, returning the outputs of `inner`.
-pub fn parens<'a, F, O>(inner: F) -> impl FnMut(&'a str) -> IResult<&'a str, O>
+pub fn parens<'a, F, O>(inner: F) -> impl FnMut(Span<'a>) -> ParseResult<'a, O>
 where
-    F: FnMut(&'a str) -> IResult<&'a str, O>,
+    F: FnMut(Span<'a>) -> ParseResult<'a, O>,
 {
     delimited(char('('), ws(inner), char(')'))
 }
@@ -59,37 +56,38 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nom::character::complete::alpha1;
+    use crate::parsers::{parse_name, Match};
+    use crate::Name;
     use nom::multi::separated_list1;
 
     #[test]
     fn parens_works() {
         let input = "(content)";
-        let mut parser = parens(alpha1);
-        assert_eq!(parser(input), Ok(("", "content")));
+        let mut parser = parens(parse_name);
+        assert!(parser(Span::new(input)).is_exactly("content"));
     }
 
     #[test]
     fn definition_section_works() {
         let input = "(either x y)";
-        let inner_parser = separated_list1(tag(" "), alpha1);
+        let inner_parser = separated_list1(tag(" "), parse_name);
         let mut parser = prefix_expr("either", inner_parser);
-        assert_eq!(parser(input), Ok(("", vec!["x", "y"])));
+        assert!(parser(Span::new(input)).is_exactly(vec![Name::from("x"), Name::from("y")]));
     }
 
     #[test]
     fn space_separated_list0_works() {
-        let mut parser = space_separated_list0(alpha1);
-        assert_eq!(parser("x y"), Ok(("", vec!["x", "y"])));
-        assert_eq!(parser("x"), Ok(("", vec!["x"])));
-        assert_eq!(parser(""), Ok(("", vec![])));
+        let mut parser = space_separated_list0(parse_name);
+        assert!(parser(Span::new("x y")).is_exactly(vec![Name::from("x"), Name::from("y")]));
+        assert!(parser(Span::new("x")).is_exactly(vec![Name::from("x")]));
+        assert!(parser(Span::new("")).is_exactly(vec![]));
     }
 
     #[test]
     fn space_separated_list1_works() {
-        let mut parser = space_separated_list1(alpha1);
-        assert_eq!(parser("x y"), Ok(("", vec!["x", "y"])));
-        assert_eq!(parser("x"), Ok(("", vec!["x"])));
-        assert!(parser("").is_err());
+        let mut parser = space_separated_list1(parse_name);
+        assert!(parser(Span::new("x y")).is_exactly(vec![Name::from("x"), Name::from("y")]));
+        assert!(parser(Span::new("x")).is_exactly(vec![Name::from("x")]));
+        assert!(parser(Span::new("")).is_err());
     }
 }

--- a/src/parsers/variable.rs
+++ b/src/parsers/variable.rs
@@ -1,35 +1,34 @@
 //! Provides parsers for variables.
 
-use crate::parsers::parse_name;
+use crate::parsers::{parse_name, ParseResult, Span};
 use crate::types::Variable;
 use nom::bytes::complete::tag;
+use nom::combinator::map;
 use nom::sequence::preceded;
-use nom::IResult;
 
 /// Parses a variable, i.e. `?<name>` and returns its name.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::parse_variable;
-/// assert_eq!(parse_variable("?abcde"), Ok(("", "abcde".into())));
-/// assert_eq!(parse_variable("?a-1_2"), Ok(("", "a-1_2".into())));
-/// assert_eq!(parse_variable("?Z01"), Ok(("", "Z01".into())));
-/// assert_eq!(parse_variable("?x-_-_"), Ok(("", "x-_-_".into())));
+/// # use pddl::parsers::{parse_variable, preamble::*};
+/// assert!(parse_variable(Span::new("?abcde")).is_value("abcde".into()));
+/// assert!(parse_variable(Span::new("?a-1_2")).is_value("a-1_2".into()));
+/// assert!(parse_variable(Span::new("?Z01")).is_value("Z01".into()));
+/// assert!(parse_variable(Span::new("?x-_-_")).is_value("x-_-_".into()));
 ///
-/// assert!(parse_variable("abcde").is_err());
-/// assert!(parse_variable("?-").is_err());
-/// assert!(parse_variable("?1").is_err());
+/// assert!(parse_variable(Span::new("abcde")).is_err());
+/// assert!(parse_variable(Span::new("?-")).is_err());
+/// assert!(parse_variable(Span::new("?1")).is_err());
 ///```
-pub fn parse_variable(input: &str) -> IResult<&str, Variable> {
-    let (remaining, name) = preceded(tag("?"), parse_name)(input)?;
-    Ok((remaining, Variable::from(name)))
+pub fn parse_variable<'a>(input: Span<'a>) -> ParseResult<'a, Variable> {
+    map(preceded(tag("?"), parse_name), Variable::from)(input)
 }
 
 impl<'a> crate::parsers::Parser<'a> for Variable<'a> {
     type Item = Variable<'a>;
 
     /// See [`parse_variable`].
-    fn parse(input: &'a str) -> IResult<&str, Self::Item> {
+    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
         parse_variable(input)
     }
 }

--- a/src/parsers/variable.rs
+++ b/src/parsers/variable.rs
@@ -28,7 +28,7 @@ impl<'a> crate::parsers::Parser<'a> for Variable<'a> {
     type Item = Variable<'a>;
 
     /// See [`parse_variable`].
-    fn parse(input: Span<'a>) -> ParseResult<Self::Item> {
-        parse_variable(input)
+    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+        parse_variable(input.into())
     }
 }

--- a/src/parsers/variable.rs
+++ b/src/parsers/variable.rs
@@ -20,15 +20,15 @@ use nom::sequence::preceded;
 /// assert!(parse_variable(Span::new("?-")).is_err());
 /// assert!(parse_variable(Span::new("?1")).is_err());
 ///```
-pub fn parse_variable<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Variable<'a>> {
+pub fn parse_variable<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Variable> {
     map(preceded(tag("?"), parse_name), Variable::from)(input.into())
 }
 
-impl<'a> crate::parsers::Parser<'a> for Variable<'a> {
-    type Item = Variable<'a>;
+impl crate::parsers::Parser for Variable {
+    type Item = Variable;
 
     /// See [`parse_variable`].
-    fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
+    fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_variable(input)
     }
 }

--- a/src/parsers/variable.rs
+++ b/src/parsers/variable.rs
@@ -20,8 +20,8 @@ use nom::sequence::preceded;
 /// assert!(parse_variable(Span::new("?-")).is_err());
 /// assert!(parse_variable(Span::new("?1")).is_err());
 ///```
-pub fn parse_variable<'a>(input: Span<'a>) -> ParseResult<'a, Variable> {
-    map(preceded(tag("?"), parse_name), Variable::from)(input)
+pub fn parse_variable<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Variable<'a>> {
+    map(preceded(tag("?"), parse_name), Variable::from)(input.into())
 }
 
 impl<'a> crate::parsers::Parser<'a> for Variable<'a> {

--- a/src/parsers/variable.rs
+++ b/src/parsers/variable.rs
@@ -29,6 +29,6 @@ impl<'a> crate::parsers::Parser<'a> for Variable<'a> {
 
     /// See [`parse_variable`].
     fn parse<S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_variable(input.into())
+        parse_variable(input)
     }
 }

--- a/src/types/action_definition.rs
+++ b/src/types/action_definition.rs
@@ -9,19 +9,19 @@ use crate::PreconditionGoalDefinitions;
 /// ## Usage
 /// Used by [`StructureDef`](crate::StructureDef).
 #[derive(Debug, Clone, PartialEq)]
-pub struct ActionDefinition<'a> {
-    symbol: ActionSymbol<'a>,
-    parameters: TypedVariables<'a>,
-    precondition: PreconditionGoalDefinitions<'a>,
-    effect: Option<Effects<'a>>,
+pub struct ActionDefinition {
+    symbol: ActionSymbol,
+    parameters: TypedVariables,
+    precondition: PreconditionGoalDefinitions,
+    effect: Option<Effects>,
 }
 
-impl<'a> ActionDefinition<'a> {
+impl ActionDefinition {
     pub const fn new(
-        symbol: ActionSymbol<'a>,
-        parameters: TypedVariables<'a>,
-        precondition: PreconditionGoalDefinitions<'a>,
-        effect: Option<Effects<'a>>,
+        symbol: ActionSymbol,
+        parameters: TypedVariables,
+        precondition: PreconditionGoalDefinitions,
+        effect: Option<Effects>,
     ) -> Self {
         Self {
             symbol,
@@ -31,25 +31,25 @@ impl<'a> ActionDefinition<'a> {
         }
     }
 
-    pub const fn symbol(&self) -> &ActionSymbol<'a> {
+    pub const fn symbol(&self) -> &ActionSymbol {
         &self.symbol
     }
 
-    pub const fn parameters(&self) -> &TypedVariables<'a> {
+    pub const fn parameters(&self) -> &TypedVariables {
         &self.parameters
     }
 
-    pub const fn precondition(&self) -> &PreconditionGoalDefinitions<'a> {
+    pub const fn precondition(&self) -> &PreconditionGoalDefinitions {
         &self.precondition
     }
 
-    pub const fn effect(&self) -> &Option<Effects<'a>> {
+    pub const fn effect(&self) -> &Option<Effects> {
         &self.effect
     }
 }
 
-impl<'a> AsRef<ActionSymbol<'a>> for ActionDefinition<'a> {
-    fn as_ref(&self) -> &ActionSymbol<'a> {
+impl AsRef<ActionSymbol> for ActionDefinition {
+    fn as_ref(&self) -> &ActionSymbol {
         &self.symbol
     }
 }

--- a/src/types/action_symbols.rs
+++ b/src/types/action_symbols.rs
@@ -8,28 +8,28 @@ use std::ops::Deref;
 /// ## Usage
 /// Used by [`ActionDefinition`](crate::ActionDefinition).
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Default)]
-pub struct ActionSymbol<'a>(Name<'a>);
+pub struct ActionSymbol(Name);
 
-impl<'a> ActionSymbol<'a> {
+impl ActionSymbol {
     #[inline(always)]
-    pub const fn new(name: Name<'a>) -> Self {
+    pub const fn new(name: Name) -> Self {
         Self(name)
     }
 
     #[inline(always)]
-    pub const fn from_str(name: &'a str) -> Self {
+    pub fn from_str(name: &str) -> Self {
         Self(Name::new(name))
     }
 
     #[inline(always)]
-    pub const fn from_name(name: Name<'a>) -> Self {
+    pub const fn from_name(name: Name) -> Self {
         Self(name)
     }
 }
 
-impl<'a, T> From<T> for ActionSymbol<'a>
+impl<'a, T> From<T> for ActionSymbol
 where
-    T: Into<Name<'a>>,
+    T: Into<Name>,
 {
     #[inline(always)]
     fn from(value: T) -> Self {
@@ -37,22 +37,22 @@ where
     }
 }
 
-impl<'a> AsRef<Name<'a>> for ActionSymbol<'a> {
+impl AsRef<Name> for ActionSymbol {
     #[inline(always)]
-    fn as_ref(&self) -> &Name<'a> {
+    fn as_ref(&self) -> &Name {
         &self.0
     }
 }
 
-impl<'a> AsRef<str> for ActionSymbol<'a> {
+impl AsRef<str> for ActionSymbol {
     #[inline(always)]
     fn as_ref(&self) -> &str {
         self.0.as_ref()
     }
 }
 
-impl<'a> Deref for ActionSymbol<'a> {
-    type Target = Name<'a>;
+impl Deref for ActionSymbol {
+    type Target = Name;
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target {

--- a/src/types/atomic_formula.rs
+++ b/src/types/atomic_formula.rs
@@ -9,17 +9,17 @@ use std::ops::Deref;
 /// Used by [`Literal`](crate::Literal), [`GoalDefinition`](crate::GoalDefinition) and
 /// [`PEffect`](crate::PEffect).
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub enum AtomicFormula<'a, T> {
+pub enum AtomicFormula<T> {
     Equality(EqualityAtomicFormula<T>),
-    Predicate(PredicateAtomicFormula<'a, T>),
+    Predicate(PredicateAtomicFormula<T>),
 }
 
-impl<'a, T> AtomicFormula<'a, T> {
+impl<'a, T> AtomicFormula<T> {
     pub const fn new_equality(first: T, second: T) -> Self {
         Self::Equality(EqualityAtomicFormula::new(first, second))
     }
 
-    pub fn new_predicate<V: IntoIterator<Item = T>>(predicate: Predicate<'a>, values: V) -> Self {
+    pub fn new_predicate<V: IntoIterator<Item = T>>(predicate: Predicate, values: V) -> Self {
         Self::Predicate(PredicateAtomicFormula::new(
             predicate,
             values.into_iter().collect(),
@@ -34,8 +34,8 @@ pub struct EqualityAtomicFormula<T> {
 }
 
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
-pub struct PredicateAtomicFormula<'a, T> {
-    predicate: Predicate<'a>,
+pub struct PredicateAtomicFormula<T> {
+    predicate: Predicate,
     values: Vec<T>,
 }
 
@@ -55,13 +55,13 @@ impl<T> EqualityAtomicFormula<T> {
     }
 }
 
-impl<'a, T> PredicateAtomicFormula<'a, T> {
-    pub const fn new(predicate: Predicate<'a>, values: Vec<T>) -> Self {
+impl<T> PredicateAtomicFormula<T> {
+    pub const fn new(predicate: Predicate, values: Vec<T>) -> Self {
         Self { predicate, values }
     }
 
     /// Returns the predicate.
-    pub const fn predicate(&self) -> &Predicate<'a> {
+    pub const fn predicate(&self) -> &Predicate {
         &self.predicate
     }
 
@@ -71,14 +71,14 @@ impl<'a, T> PredicateAtomicFormula<'a, T> {
     }
 }
 
-impl<'a, T> From<EqualityAtomicFormula<T>> for AtomicFormula<'a, T> {
+impl<'a, T> From<EqualityAtomicFormula<T>> for AtomicFormula<T> {
     fn from(value: EqualityAtomicFormula<T>) -> Self {
         AtomicFormula::Equality(value)
     }
 }
 
-impl<'a, T> From<PredicateAtomicFormula<'a, T>> for AtomicFormula<'a, T> {
-    fn from(value: PredicateAtomicFormula<'a, T>) -> Self {
+impl<'a, T> From<PredicateAtomicFormula<T>> for AtomicFormula<T> {
+    fn from(value: PredicateAtomicFormula<T>) -> Self {
         AtomicFormula::Predicate(value)
     }
 }
@@ -89,13 +89,13 @@ impl<T> From<(T, T)> for EqualityAtomicFormula<T> {
     }
 }
 
-impl<'a, T> From<(Predicate<'a>, Vec<T>)> for PredicateAtomicFormula<'a, T> {
-    fn from(value: (Predicate<'a>, Vec<T>)) -> Self {
+impl<'a, T> From<(Predicate, Vec<T>)> for PredicateAtomicFormula<T> {
+    fn from(value: (Predicate, Vec<T>)) -> Self {
         PredicateAtomicFormula::new(value.0, value.1)
     }
 }
 
-impl<'a, T> Deref for PredicateAtomicFormula<'a, T> {
+impl<'a, T> Deref for PredicateAtomicFormula<T> {
     type Target = [T];
 
     fn deref(&self) -> &Self::Target {

--- a/src/types/atomic_formula_skeleton.rs
+++ b/src/types/atomic_formula_skeleton.rs
@@ -8,36 +8,36 @@ use crate::types::{Name, TypedVariables};
 /// ## Usage
 /// Used by [`PredicateDefinitions`](crate::PredicateDefinitions) and [`DerivedPredicate`](crate::DerivedPredicate).
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct AtomicFormulaSkeleton<'a> {
-    predicate: Predicate<'a>,
-    variables: TypedVariables<'a>,
+pub struct AtomicFormulaSkeleton {
+    predicate: Predicate,
+    variables: TypedVariables,
 }
 
-impl<'a> AtomicFormulaSkeleton<'a> {
-    pub const fn new(predicate: Predicate<'a>, formula: TypedVariables<'a>) -> Self {
+impl AtomicFormulaSkeleton {
+    pub const fn new(predicate: Predicate, formula: TypedVariables) -> Self {
         Self {
             predicate,
             variables: formula,
         }
     }
 
-    pub fn name(&self) -> &Name<'a> {
+    pub fn name(&self) -> &Name {
         self.predicate.as_ref()
     }
 
     /// Gets a reference to the predicate.
-    pub const fn predicate(&self) -> &Predicate<'a> {
+    pub const fn predicate(&self) -> &Predicate {
         &self.predicate
     }
 
     /// Gets a reference to the variables.
-    pub fn variables(&self) -> &TypedVariables<'a> {
+    pub fn variables(&self) -> &TypedVariables {
         &self.variables
     }
 }
 
-impl<'a> From<(Predicate<'a>, TypedVariables<'a>)> for AtomicFormulaSkeleton<'a> {
-    fn from(value: (Predicate<'a>, TypedVariables<'a>)) -> Self {
+impl From<(Predicate, TypedVariables)> for AtomicFormulaSkeleton {
+    fn from(value: (Predicate, TypedVariables)) -> Self {
         AtomicFormulaSkeleton::new(value.0, value.1)
     }
 }

--- a/src/types/atomic_function_skeleton.rs
+++ b/src/types/atomic_function_skeleton.rs
@@ -31,37 +31,37 @@ use crate::types::{FunctionSymbol, TypedVariables, Variable};
 /// ## Usage
 /// Used by [`Functions`](crate::Functions).
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct AtomicFunctionSkeleton<'a> {
+pub struct AtomicFunctionSkeleton {
     /// The name of the fluent, e.g. `battery-level`.
-    symbol: FunctionSymbol<'a>,
+    symbol: FunctionSymbol,
     /// The list of parameters to the fluent, e.g. `?r - rover`.
-    variables: TypedVariables<'a>,
+    variables: TypedVariables,
 }
 
-impl<'a> AtomicFunctionSkeleton<'a> {
-    pub const fn new(symbol: FunctionSymbol<'a>, variables: TypedVariables<'a>) -> Self {
+impl AtomicFunctionSkeleton {
+    pub const fn new(symbol: FunctionSymbol, variables: TypedVariables) -> Self {
         Self { symbol, variables }
     }
 
     /// Gets a reference to the function symbol.
-    pub const fn symbol(&self) -> &FunctionSymbol<'a> {
+    pub const fn symbol(&self) -> &FunctionSymbol {
         &self.symbol
     }
 
     /// Gets a reference to the variables.
-    pub fn variables(&self) -> &TypedVariables<'a> {
+    pub fn variables(&self) -> &TypedVariables {
         &self.variables
     }
 }
 
-impl<'a> From<(FunctionSymbol<'a>, TypedVariables<'a>)> for AtomicFunctionSkeleton<'a> {
-    fn from(value: (FunctionSymbol<'a>, TypedVariables<'a>)) -> Self {
+impl From<(FunctionSymbol, TypedVariables)> for AtomicFunctionSkeleton {
+    fn from(value: (FunctionSymbol, TypedVariables)) -> Self {
         AtomicFunctionSkeleton::new(value.0, value.1)
     }
 }
 
-impl<'a> From<(FunctionSymbol<'a>, Vec<Typed<'a, Variable<'a>>>)> for AtomicFunctionSkeleton<'a> {
-    fn from(value: (FunctionSymbol<'a>, Vec<Typed<'a, Variable<'a>>>)) -> Self {
+impl From<(FunctionSymbol, Vec<Typed<Variable>>)> for AtomicFunctionSkeleton {
+    fn from(value: (FunctionSymbol, Vec<Typed<Variable>>)) -> Self {
         AtomicFunctionSkeleton::new(value.0, value.1.into())
     }
 }

--- a/src/types/basic_function_term.rs
+++ b/src/types/basic_function_term.rs
@@ -5,32 +5,32 @@ use crate::types::{FunctionSymbol, Name};
 /// ## Usage
 /// Used by [`InitElement`](crate::InitElement).
 #[derive(Debug, Clone, PartialEq)]
-pub struct BasicFunctionTerm<'a>(FunctionSymbol<'a>, Vec<Name<'a>>);
+pub struct BasicFunctionTerm(FunctionSymbol, Vec<Name>);
 
-impl<'a> BasicFunctionTerm<'a> {
-    pub fn new<N: IntoIterator<Item = Name<'a>>>(symbol: FunctionSymbol<'a>, names: N) -> Self {
+impl BasicFunctionTerm {
+    pub fn new<N: IntoIterator<Item = Name>>(symbol: FunctionSymbol, names: N) -> Self {
         Self(symbol, names.into_iter().collect())
     }
 
     /// Returns the function symbol.
-    pub const fn symbol(&self) -> &FunctionSymbol<'a> {
+    pub const fn symbol(&self) -> &FunctionSymbol {
         &self.0
     }
 
     /// Returns the associated names.
-    pub fn names(&self) -> &[Name<'a>] {
+    pub fn names(&self) -> &[Name] {
         self.1.as_slice()
     }
 }
 
-impl<'a> AsRef<FunctionSymbol<'a>> for BasicFunctionTerm<'a> {
-    fn as_ref(&self) -> &FunctionSymbol<'a> {
+impl AsRef<FunctionSymbol> for BasicFunctionTerm {
+    fn as_ref(&self) -> &FunctionSymbol {
         self.symbol()
     }
 }
 
-impl<'a> AsRef<[Name<'a>]> for BasicFunctionTerm<'a> {
-    fn as_ref(&self) -> &[Name<'a>] {
+impl AsRef<[Name]> for BasicFunctionTerm {
+    fn as_ref(&self) -> &[Name] {
         self.names()
     }
 }

--- a/src/types/c_effect.rs
+++ b/src/types/c_effect.rs
@@ -8,20 +8,20 @@ use crate::types::{ConditionalEffect, Effects, GoalDefinition, PEffect};
 /// ## Usage
 /// Used by [`Effect`](Effects).
 #[derive(Debug, Clone, PartialEq)]
-pub enum CEffect<'a> {
+pub enum CEffect {
     /// A regular effect.
-    Effect(PEffect<'a>),
+    Effect(PEffect),
     /// A universal affect that is conditioned by variables.
     ///
     /// ## Requirements
     /// Requires [Conditional Effects](crate::Requirement::ConditionalEffects).
-    Forall(ForallCEffect<'a>),
+    Forall(ForallCEffect),
     /// A conditional effect that applies only if a given
     /// precondition holds true.
     ///
     /// ## Requirements
     /// Requires [Conditional Effects](crate::Requirement::ConditionalEffects).
-    When(WhenCEffect<'a>),
+    When(WhenCEffect),
 }
 
 /// Applies the specified effects for all listed variables.
@@ -29,16 +29,16 @@ pub enum CEffect<'a> {
 /// ## Requirements
 /// Requires [Conditional Effects](crate::Requirement::ConditionalEffects).
 #[derive(Debug, Clone, PartialEq)]
-pub struct ForallCEffect<'a> {
+pub struct ForallCEffect {
     /// The (possibly empty) set of variables constraining the effects.
-    pub variables: TypedVariables<'a>,
+    pub variables: TypedVariables,
     /// The effects to apply.
-    pub effects: Effects<'a>,
+    pub effects: Effects,
 }
 
-impl<'a> ForallCEffect<'a> {
+impl ForallCEffect {
     /// Creates a new [`ForallCEffect`] value.
-    pub const fn new(variables: TypedVariables<'a>, effects: Effects<'a>) -> Self {
+    pub const fn new(variables: TypedVariables, effects: Effects) -> Self {
         ForallCEffect { variables, effects }
     }
 }
@@ -48,23 +48,23 @@ impl<'a> ForallCEffect<'a> {
 /// ## Requirements
 /// Requires [Conditional Effects](crate::Requirement::ConditionalEffects).
 #[derive(Debug, Clone, PartialEq)]
-pub struct WhenCEffect<'a> {
+pub struct WhenCEffect {
     /// The antecedent. This needs to be true for the effect to apply.
-    pub condition: GoalDefinition<'a>,
+    pub condition: GoalDefinition,
     /// The consequent. This is the effect that applies when the condition is true.
-    pub effect: ConditionalEffect<'a>,
+    pub effect: ConditionalEffect,
 }
 
-impl<'a> WhenCEffect<'a> {
+impl WhenCEffect {
     /// Creates a new [`WhenCEffect`] value.
-    pub const fn new(condition: GoalDefinition<'a>, effect: ConditionalEffect<'a>) -> Self {
+    pub const fn new(condition: GoalDefinition, effect: ConditionalEffect) -> Self {
         WhenCEffect { condition, effect }
     }
 }
 
-impl<'a> CEffect<'a> {
+impl CEffect {
     /// Crates a new effect.
-    pub const fn new_p_effect(effect: PEffect<'a>) -> Self {
+    pub const fn new_p_effect(effect: PEffect) -> Self {
         Self::Effect(effect)
     }
 
@@ -73,7 +73,7 @@ impl<'a> CEffect<'a> {
     ///
     /// ## Requirements
     /// Requires [Conditional Effects](crate::Requirement::ConditionalEffects).
-    pub const fn new_forall(variables: TypedVariables<'a>, effect: Effects<'a>) -> Self {
+    pub const fn new_forall(variables: TypedVariables, effect: Effects) -> Self {
         Self::Forall(ForallCEffect::new(variables, effect))
     }
 
@@ -81,45 +81,45 @@ impl<'a> CEffect<'a> {
     ///
     /// ## Requirements
     /// Requires [Conditional Effects](crate::Requirement::ConditionalEffects).
-    pub const fn new_when(condition: GoalDefinition<'a>, effect: ConditionalEffect<'a>) -> Self {
+    pub const fn new_when(condition: GoalDefinition, effect: ConditionalEffect) -> Self {
         Self::When(WhenCEffect::new(condition, effect))
     }
 }
 
-impl<'a> From<PEffect<'a>> for CEffect<'a> {
-    fn from(value: PEffect<'a>) -> Self {
+impl From<PEffect> for CEffect {
+    fn from(value: PEffect) -> Self {
         CEffect::new_p_effect(value)
     }
 }
 
-impl<'a> From<ForallCEffect<'a>> for CEffect<'a> {
-    fn from(value: ForallCEffect<'a>) -> Self {
+impl From<ForallCEffect> for CEffect {
+    fn from(value: ForallCEffect) -> Self {
         CEffect::Forall(value)
     }
 }
 
-impl<'a> From<WhenCEffect<'a>> for CEffect<'a> {
-    fn from(value: WhenCEffect<'a>) -> Self {
+impl From<WhenCEffect> for CEffect {
+    fn from(value: WhenCEffect) -> Self {
         CEffect::When(value)
     }
 }
 
-impl<'a> From<(TypedVariables<'a>, Effects<'a>)> for ForallCEffect<'a> {
-    fn from(value: (TypedVariables<'a>, Effects<'a>)) -> Self {
+impl From<(TypedVariables, Effects)> for ForallCEffect {
+    fn from(value: (TypedVariables, Effects)) -> Self {
         ForallCEffect::new(value.0, value.1)
     }
 }
 
-impl<'a> From<(GoalDefinition<'a>, ConditionalEffect<'a>)> for WhenCEffect<'a> {
-    fn from(value: (GoalDefinition<'a>, ConditionalEffect<'a>)) -> Self {
+impl From<(GoalDefinition, ConditionalEffect)> for WhenCEffect {
+    fn from(value: (GoalDefinition, ConditionalEffect)) -> Self {
         WhenCEffect::new(value.0, value.1)
     }
 }
 
-impl<'a> TryInto<PEffect<'a>> for CEffect<'a> {
+impl TryInto<PEffect> for CEffect {
     type Error = ();
 
-    fn try_into(self) -> Result<PEffect<'a>, Self::Error> {
+    fn try_into(self) -> Result<PEffect, Self::Error> {
         match self {
             CEffect::Effect(x) => Ok(x),
             CEffect::Forall(_) => Err(()),
@@ -128,10 +128,10 @@ impl<'a> TryInto<PEffect<'a>> for CEffect<'a> {
     }
 }
 
-impl<'a> TryInto<WhenCEffect<'a>> for CEffect<'a> {
+impl TryInto<WhenCEffect> for CEffect {
     type Error = ();
 
-    fn try_into(self) -> Result<WhenCEffect<'a>, Self::Error> {
+    fn try_into(self) -> Result<WhenCEffect, Self::Error> {
         match self {
             CEffect::Effect(_) => Err(()),
             CEffect::Forall(_) => Err(()),
@@ -140,10 +140,10 @@ impl<'a> TryInto<WhenCEffect<'a>> for CEffect<'a> {
     }
 }
 
-impl<'a> TryInto<ForallCEffect<'a>> for CEffect<'a> {
+impl TryInto<ForallCEffect> for CEffect {
     type Error = ();
 
-    fn try_into(self) -> Result<ForallCEffect<'a>, Self::Error> {
+    fn try_into(self) -> Result<ForallCEffect, Self::Error> {
         match self {
             CEffect::Effect(_) => Err(()),
             CEffect::Forall(x) => Ok(x),

--- a/src/types/con_gd.rs
+++ b/src/types/con_gd.rs
@@ -5,22 +5,22 @@ use crate::types::{GoalDefinition, Number, TypedVariables};
 /// ## Usage
 /// Used by [`ConGD`](ConGD) itself, as well as [`PrefConGD`](crate::types::PrefConGD) and [`Con2GD`](Con2GD).
 #[derive(Debug, Clone, PartialEq)]
-pub enum ConGD<'a> {
-    And(Vec<ConGD<'a>>),
-    Forall(TypedVariables<'a>, Box<ConGD<'a>>),
-    AtEnd(GoalDefinition<'a>),
-    Always(Con2GD<'a>),
-    Sometime(Con2GD<'a>),
-    Within(Number, Con2GD<'a>),
-    AtMostOnce(Con2GD<'a>),
-    SometimeAfter(Con2GD<'a>, Con2GD<'a>),
-    SometimeBefore(Con2GD<'a>, Con2GD<'a>),
-    AlwaysWithin(Number, Con2GD<'a>, Con2GD<'a>),
-    HoldDuring(Number, Number, Con2GD<'a>),
-    HoldAfter(Number, Con2GD<'a>),
+pub enum ConGD {
+    And(Vec<ConGD>),
+    Forall(TypedVariables, Box<ConGD>),
+    AtEnd(GoalDefinition),
+    Always(Con2GD),
+    Sometime(Con2GD),
+    Within(Number, Con2GD),
+    AtMostOnce(Con2GD),
+    SometimeAfter(Con2GD, Con2GD),
+    SometimeBefore(Con2GD, Con2GD),
+    AlwaysWithin(Number, Con2GD, Con2GD),
+    HoldDuring(Number, Number, Con2GD),
+    HoldAfter(Number, Con2GD),
 }
 
-impl<'a> Default for ConGD<'a> {
+impl Default for ConGD {
     fn default() -> Self {
         Self::And(Vec::default())
     }
@@ -31,58 +31,58 @@ impl<'a> Default for ConGD<'a> {
 /// ## Usage
 /// Used by [`ConGD`](ConGD).
 #[derive(Debug, Clone, PartialEq)]
-pub enum Con2GD<'a> {
-    Goal(GoalDefinition<'a>),
-    Nested(Box<ConGD<'a>>),
+pub enum Con2GD {
+    Goal(GoalDefinition),
+    Nested(Box<ConGD>),
 }
 
-impl<'a> ConGD<'a> {
-    pub fn new_and<G: IntoIterator<Item = ConGD<'a>>>(goals: G) -> Self {
+impl ConGD {
+    pub fn new_and<G: IntoIterator<Item = ConGD>>(goals: G) -> Self {
         // TODO: Flatten `(and (and a b) (and x y))` into `(and a b c y)`.
         Self::And(goals.into_iter().collect())
     }
 
-    pub fn new_forall(variables: TypedVariables<'a>, gd: ConGD<'a>) -> Self {
+    pub fn new_forall(variables: TypedVariables, gd: ConGD) -> Self {
         Self::Forall(variables, Box::new(gd))
     }
 
-    pub const fn new_at_end(gd: GoalDefinition<'a>) -> Self {
+    pub const fn new_at_end(gd: GoalDefinition) -> Self {
         Self::AtEnd(gd)
     }
 
-    pub const fn new_always(gd: Con2GD<'a>) -> Self {
+    pub const fn new_always(gd: Con2GD) -> Self {
         Self::Always(gd)
     }
 
-    pub const fn new_sometime(gd: Con2GD<'a>) -> Self {
+    pub const fn new_sometime(gd: Con2GD) -> Self {
         Self::Sometime(gd)
     }
 
-    pub const fn new_within(number: Number, gd: Con2GD<'a>) -> Self {
+    pub const fn new_within(number: Number, gd: Con2GD) -> Self {
         Self::Within(number, gd)
     }
 
-    pub const fn new_at_most_once(gd: Con2GD<'a>) -> Self {
+    pub const fn new_at_most_once(gd: Con2GD) -> Self {
         Self::AtMostOnce(gd)
     }
 
-    pub const fn new_sometime_after(first: Con2GD<'a>, then: Con2GD<'a>) -> Self {
+    pub const fn new_sometime_after(first: Con2GD, then: Con2GD) -> Self {
         Self::SometimeAfter(first, then)
     }
 
-    pub const fn new_sometime_before(later: Con2GD<'a>, earlier: Con2GD<'a>) -> Self {
+    pub const fn new_sometime_before(later: Con2GD, earlier: Con2GD) -> Self {
         Self::SometimeBefore(later, earlier)
     }
 
-    pub const fn new_always_within(number: Number, first: Con2GD<'a>, second: Con2GD<'a>) -> Self {
+    pub const fn new_always_within(number: Number, first: Con2GD, second: Con2GD) -> Self {
         Self::AlwaysWithin(number, first, second)
     }
 
-    pub const fn new_hold_during(begin: Number, end: Number, gd: Con2GD<'a>) -> Self {
+    pub const fn new_hold_during(begin: Number, end: Number, gd: Con2GD) -> Self {
         Self::HoldDuring(begin, end, gd)
     }
 
-    pub const fn new_hold_after(number: Number, gd: Con2GD<'a>) -> Self {
+    pub const fn new_hold_after(number: Number, gd: Con2GD) -> Self {
         Self::HoldAfter(number, gd)
     }
 
@@ -104,12 +104,12 @@ impl<'a> ConGD<'a> {
     }
 }
 
-impl<'a> Con2GD<'a> {
-    pub fn new_nested(gd: ConGD<'a>) -> Self {
+impl Con2GD {
+    pub fn new_nested(gd: ConGD) -> Self {
         Self::Nested(Box::new(gd))
     }
 
-    pub const fn new_goal(gd: GoalDefinition<'a>) -> Self {
+    pub const fn new_goal(gd: GoalDefinition) -> Self {
         Self::Goal(gd)
     }
 
@@ -121,14 +121,14 @@ impl<'a> Con2GD<'a> {
     }
 }
 
-impl<'a> From<ConGD<'a>> for Con2GD<'a> {
-    fn from(value: ConGD<'a>) -> Self {
+impl From<ConGD> for Con2GD {
+    fn from(value: ConGD) -> Self {
         Con2GD::new_nested(value)
     }
 }
 
-impl<'a> From<GoalDefinition<'a>> for Con2GD<'a> {
-    fn from(value: GoalDefinition<'a>) -> Self {
+impl From<GoalDefinition> for Con2GD {
+    fn from(value: GoalDefinition) -> Self {
         Con2GD::new_goal(value)
     }
 }

--- a/src/types/conditional_effect.rs
+++ b/src/types/conditional_effect.rs
@@ -8,24 +8,24 @@ use crate::types::PEffect;
 /// ## Usage
 /// Used by [`CEffect`](crate::CEffect) and [`TimedEffect`](crate::types::TimedEffect).
 #[derive(Debug, Clone, PartialEq)]
-pub enum ConditionalEffect<'a> {
+pub enum ConditionalEffect {
     /// Exactly the specified effect applies.
-    Single(PEffect<'a>), // TODO: Unify with `All`; vector is allowed to be empty.
+    Single(PEffect), // TODO: Unify with `All`; vector is allowed to be empty.
     /// Conjunction: All effects apply (i.e. a and b and c ..).
-    All(Vec<PEffect<'a>>),
+    All(Vec<PEffect>),
 }
 
-impl<'a> ConditionalEffect<'a> {
-    pub const fn new(effect: PEffect<'a>) -> Self {
+impl ConditionalEffect {
+    pub const fn new(effect: PEffect) -> Self {
         Self::Single(effect)
     }
-    pub const fn new_and(effect: Vec<PEffect<'a>>) -> Self {
+    pub const fn new_and(effect: Vec<PEffect>) -> Self {
         Self::All(effect)
     }
 }
 
-impl<'a> IntoIterator for ConditionalEffect<'a> {
-    type Item = PEffect<'a>;
+impl IntoIterator for ConditionalEffect {
+    type Item = PEffect;
     type IntoIter = FlatteningIntoIterator<Self::Item>;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -36,20 +36,20 @@ impl<'a> IntoIterator for ConditionalEffect<'a> {
     }
 }
 
-impl<'a> From<PEffect<'a>> for ConditionalEffect<'a> {
-    fn from(value: PEffect<'a>) -> Self {
+impl From<PEffect> for ConditionalEffect {
+    fn from(value: PEffect) -> Self {
         ConditionalEffect::new(value)
     }
 }
 
-impl<'a> From<Vec<PEffect<'a>>> for ConditionalEffect<'a> {
-    fn from(value: Vec<PEffect<'a>>) -> Self {
+impl From<Vec<PEffect>> for ConditionalEffect {
+    fn from(value: Vec<PEffect>) -> Self {
         ConditionalEffect::new_and(value)
     }
 }
 
-impl<'a> FromIterator<PEffect<'a>> for ConditionalEffect<'a> {
-    fn from_iter<T: IntoIterator<Item = PEffect<'a>>>(iter: T) -> Self {
+impl FromIterator<PEffect> for ConditionalEffect {
+    fn from_iter<T: IntoIterator<Item = PEffect>>(iter: T) -> Self {
         ConditionalEffect::new_and(iter.into_iter().collect())
     }
 }

--- a/src/types/conditional_effect.rs
+++ b/src/types/conditional_effect.rs
@@ -57,11 +57,12 @@ impl<'a> FromIterator<PEffect<'a>> for ConditionalEffect<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parsers::Span;
     use crate::Parser;
 
     #[test]
     fn flatten_with_single_element_works() {
-        let (_, effect_a) = PEffect::parse("(= x y)").unwrap();
+        let (_, effect_a) = PEffect::parse(Span::new("(= x y)")).unwrap();
 
         let mut iter = ConditionalEffect::new(effect_a).into_iter();
         assert!(iter.next().is_some());
@@ -70,8 +71,8 @@ mod tests {
 
     #[test]
     fn flatten_with_many_elements_works() {
-        let (_, effect_a) = PEffect::parse("(= x y)").unwrap();
-        let (_, effect_b) = PEffect::parse("(assign fun-sym 1.23)").unwrap();
+        let (_, effect_a) = PEffect::parse(Span::new("(= x y)")).unwrap();
+        let (_, effect_b) = PEffect::parse(Span::new("(assign fun-sym 1.23)")).unwrap();
 
         let mut iter = ConditionalEffect::from_iter([effect_a, effect_b]).into_iter();
         assert!(iter.next().is_some());

--- a/src/types/constants.rs
+++ b/src/types/constants.rs
@@ -8,30 +8,30 @@ use std::ops::Deref;
 /// ## Usage
 /// Used by [`Domain`](crate::Domain).
 #[derive(Debug, Default, Clone, Eq, PartialEq)]
-pub struct Constants<'a>(TypedNames<'a>);
+pub struct Constants(TypedNames);
 
-impl<'a> Constants<'a> {
-    pub const fn new(predicates: TypedNames<'a>) -> Self {
+impl Constants {
+    pub const fn new(predicates: TypedNames) -> Self {
         Self(predicates)
     }
 }
 
-impl<'a> Deref for Constants<'a> {
-    type Target = TypedNames<'a>;
+impl Deref for Constants {
+    type Target = TypedNames;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<'a> From<TypedNames<'a>> for Constants<'a> {
-    fn from(value: TypedNames<'a>) -> Self {
+impl From<TypedNames> for Constants {
+    fn from(value: TypedNames) -> Self {
         Constants::new(value)
     }
 }
 
-impl<'a> FromIterator<Typed<'a, Name<'a>>> for Constants<'a> {
-    fn from_iter<T: IntoIterator<Item = Typed<'a, Name<'a>>>>(iter: T) -> Self {
+impl FromIterator<Typed<Name>> for Constants {
+    fn from_iter<T: IntoIterator<Item = Typed<Name>>>(iter: T) -> Self {
         Constants::new(TypedNames::from_iter(iter))
     }
 }

--- a/src/types/d_value.rs
+++ b/src/types/d_value.rs
@@ -7,33 +7,33 @@ use crate::types::{FExp, Number};
 /// ## Usage
 /// Used by [`SimpleDurationConstraint`](crate::SimpleDurationConstraint).
 #[derive(Debug, Clone, PartialEq)]
-pub enum DurationValue<'a> {
+pub enum DurationValue {
     /// A numerical value.
     Number(Number),
     /// A function expression that produces the duration value.
     /// ## Requirements
     /// Requires [Numeric Fluents](crate::Requirement::NumericFluents).
-    FExp(FExp<'a>),
+    FExp(FExp),
 }
 
-impl<'a> DurationValue<'a> {
+impl DurationValue {
     pub fn new_number<I: Into<Number>>(number: I) -> Self {
         Self::Number(number.into())
     }
 
-    pub fn new_f_exp(exp: FExp<'a>) -> Self {
+    pub fn new_f_exp(exp: FExp) -> Self {
         Self::FExp(exp)
     }
 }
 
-impl<'a> From<Number> for DurationValue<'a> {
+impl From<Number> for DurationValue {
     fn from(value: Number) -> Self {
         Self::Number(value)
     }
 }
 
-impl<'a> From<FExp<'a>> for DurationValue<'a> {
-    fn from(value: FExp<'a>) -> Self {
+impl From<FExp> for DurationValue {
+    fn from(value: FExp) -> Self {
         Self::FExp(value)
     }
 }

--- a/src/types/da_def.rs
+++ b/src/types/da_def.rs
@@ -24,21 +24,21 @@ use crate::types::{
 /// ## Usage
 /// Used by [`StructureDef`](crate::StructureDef).
 #[derive(Debug, Clone, PartialEq)]
-pub struct DurativeActionDefinition<'a> {
-    symbol: DurativeActionSymbol<'a>,
-    parameters: TypedVariables<'a>,
-    duration: Option<DurationConstraint<'a>>,
-    condition: Option<DurativeActionGoalDefinition<'a>>,
-    effect: Option<DurativeActionEffect<'a>>,
+pub struct DurativeActionDefinition {
+    symbol: DurativeActionSymbol,
+    parameters: TypedVariables,
+    duration: Option<DurationConstraint>,
+    condition: Option<DurativeActionGoalDefinition>,
+    effect: Option<DurativeActionEffect>,
 }
 
-impl<'a> DurativeActionDefinition<'a> {
+impl DurativeActionDefinition {
     pub const fn new(
-        symbol: DurativeActionSymbol<'a>,
-        parameters: TypedVariables<'a>,
-        duration: Option<DurationConstraint<'a>>,
-        condition: Option<DurativeActionGoalDefinition<'a>>,
-        effect: Option<DurativeActionEffect<'a>>,
+        symbol: DurativeActionSymbol,
+        parameters: TypedVariables,
+        duration: Option<DurationConstraint>,
+        condition: Option<DurativeActionGoalDefinition>,
+        effect: Option<DurativeActionEffect>,
     ) -> Self {
         Self {
             symbol,
@@ -49,7 +49,7 @@ impl<'a> DurativeActionDefinition<'a> {
         }
     }
 
-    pub const fn symbol(&self) -> &DurativeActionSymbol<'a> {
+    pub const fn symbol(&self) -> &DurativeActionSymbol {
         &self.symbol
     }
 
@@ -81,7 +81,7 @@ impl<'a> DurativeActionDefinition<'a> {
     /// which you're trying to solve. For example here we haven't modelled the person who's
     /// actually going to perform the work, but maybe if we were the manager of a larger
     /// building site we might want to and therefore we would need to adapt my models.
-    pub const fn parameters(&self) -> &TypedVariables<'a> {
+    pub const fn parameters(&self) -> &TypedVariables {
         &self.parameters
     }
 
@@ -93,7 +93,7 @@ impl<'a> DurativeActionDefinition<'a> {
     /// ```pddl
     /// :duration (= ?duration 10)
     /// ```
-    pub const fn duration(&self) -> &Option<DurationConstraint<'a>> {
+    pub const fn duration(&self) -> &Option<DurationConstraint> {
         &self.duration
     }
 
@@ -103,44 +103,44 @@ impl<'a> DurativeActionDefinition<'a> {
     /// Because a durative action occurs over time, we may wish to express that additional
     /// conditions be met for the duration or end of the action, not just the start.
     /// This gives rise to three new keywords `at start`, `at end` and `over all`.
-    pub const fn condition(&self) -> &Option<DurativeActionGoalDefinition<'a>> {
+    pub const fn condition(&self) -> &Option<DurativeActionGoalDefinition> {
         &self.condition
     }
 
     /// An effect is a condition which is made true when an action is applied.
     /// Note that the effect is always more restrictive than an action and typically only
     /// allows `and` and `not` as logical expressions.
-    pub const fn effect(&self) -> &Option<DurativeActionEffect<'a>> {
+    pub const fn effect(&self) -> &Option<DurativeActionEffect> {
         &self.effect
     }
 }
 
-impl<'a> AsRef<DurativeActionSymbol<'a>> for DurativeActionDefinition<'a> {
-    fn as_ref(&self) -> &DurativeActionSymbol<'a> {
+impl AsRef<DurativeActionSymbol> for DurativeActionDefinition {
+    fn as_ref(&self) -> &DurativeActionSymbol {
         self.symbol()
     }
 }
 
-impl<'a> AsRef<TypedVariables<'a>> for DurativeActionDefinition<'a> {
-    fn as_ref(&self) -> &TypedVariables<'a> {
+impl AsRef<TypedVariables> for DurativeActionDefinition {
+    fn as_ref(&self) -> &TypedVariables {
         self.parameters()
     }
 }
 
-impl<'a> AsRef<Option<DurationConstraint<'a>>> for DurativeActionDefinition<'a> {
-    fn as_ref(&self) -> &Option<DurationConstraint<'a>> {
+impl AsRef<Option<DurationConstraint>> for DurativeActionDefinition {
+    fn as_ref(&self) -> &Option<DurationConstraint> {
         self.duration()
     }
 }
 
-impl<'a> AsRef<Option<DurativeActionGoalDefinition<'a>>> for DurativeActionDefinition<'a> {
-    fn as_ref(&self) -> &Option<DurativeActionGoalDefinition<'a>> {
+impl AsRef<Option<DurativeActionGoalDefinition>> for DurativeActionDefinition {
+    fn as_ref(&self) -> &Option<DurativeActionGoalDefinition> {
         self.condition()
     }
 }
 
-impl<'a> AsRef<Option<DurativeActionEffect<'a>>> for DurativeActionDefinition<'a> {
-    fn as_ref(&self) -> &Option<DurativeActionEffect<'a>> {
+impl AsRef<Option<DurativeActionEffect>> for DurativeActionDefinition {
+    fn as_ref(&self) -> &Option<DurativeActionEffect> {
         self.effect()
     }
 }

--- a/src/types/da_effect.rs
+++ b/src/types/da_effect.rs
@@ -8,53 +8,53 @@ use crate::types::{DurativeActionGoalDefinition, TimedEffect};
 /// ## Usage
 /// Used by [`DurativeActionDefinition`](crate::DurativeActionDefinition).
 #[derive(Debug, Clone, PartialEq)]
-pub enum DurativeActionEffect<'a> {
-    Timed(TimedEffect<'a>),
+pub enum DurativeActionEffect {
+    Timed(TimedEffect),
     /// Conjunction: All effects apply (i.e. a and b and c ..).
-    All(Vec<DurativeActionEffect<'a>>),
+    All(Vec<DurativeActionEffect>),
     /// ## Requirements
     /// Requires [Conditional Effects](crate::Requirement::ConditionalEffects).
-    Forall(TypedVariables<'a>, Box<DurativeActionEffect<'a>>),
+    Forall(TypedVariables, Box<DurativeActionEffect>),
     /// ## Requirements
     /// Requires [Conditional Effects](crate::Requirement::ConditionalEffects).
-    When(DurativeActionGoalDefinition<'a>, TimedEffect<'a>),
+    When(DurativeActionGoalDefinition, TimedEffect),
 }
 
-impl<'a> DurativeActionEffect<'a> {
-    pub const fn new_timed(effect: TimedEffect<'a>) -> Self {
+impl DurativeActionEffect {
+    pub const fn new_timed(effect: TimedEffect) -> Self {
         Self::Timed(effect)
     }
-    pub fn new_and<E: IntoIterator<Item = DurativeActionEffect<'a>>>(effect: E) -> Self {
+    pub fn new_and<E: IntoIterator<Item = DurativeActionEffect>>(effect: E) -> Self {
         Self::All(effect.into_iter().collect())
     }
-    pub fn new_forall(variables: TypedVariables<'a>, effect: DurativeActionEffect<'a>) -> Self {
+    pub fn new_forall(variables: TypedVariables, effect: DurativeActionEffect) -> Self {
         Self::Forall(variables, Box::new(effect))
     }
-    pub const fn new_when(gd: DurativeActionGoalDefinition<'a>, effect: TimedEffect<'a>) -> Self {
+    pub const fn new_when(gd: DurativeActionGoalDefinition, effect: TimedEffect) -> Self {
         Self::When(gd, effect)
     }
 }
 
-impl<'a> From<TimedEffect<'a>> for DurativeActionEffect<'a> {
-    fn from(value: TimedEffect<'a>) -> Self {
+impl From<TimedEffect> for DurativeActionEffect {
+    fn from(value: TimedEffect) -> Self {
         Self::new_timed(value)
     }
 }
 
-impl<'a> FromIterator<DurativeActionEffect<'a>> for DurativeActionEffect<'a> {
-    fn from_iter<T: IntoIterator<Item = DurativeActionEffect<'a>>>(iter: T) -> Self {
+impl FromIterator<DurativeActionEffect> for DurativeActionEffect {
+    fn from_iter<T: IntoIterator<Item = DurativeActionEffect>>(iter: T) -> Self {
         Self::new_and(iter)
     }
 }
 
-impl<'a> From<(TypedVariables<'a>, DurativeActionEffect<'a>)> for DurativeActionEffect<'a> {
-    fn from(value: (TypedVariables<'a>, DurativeActionEffect<'a>)) -> Self {
+impl From<(TypedVariables, DurativeActionEffect)> for DurativeActionEffect {
+    fn from(value: (TypedVariables, DurativeActionEffect)) -> Self {
         Self::new_forall(value.0, value.1)
     }
 }
 
-impl<'a> From<(DurativeActionGoalDefinition<'a>, TimedEffect<'a>)> for DurativeActionEffect<'a> {
-    fn from(value: (DurativeActionGoalDefinition<'a>, TimedEffect<'a>)) -> Self {
+impl From<(DurativeActionGoalDefinition, TimedEffect)> for DurativeActionEffect {
+    fn from(value: (DurativeActionGoalDefinition, TimedEffect)) -> Self {
         Self::new_when(value.0, value.1)
     }
 }

--- a/src/types/da_gd.rs
+++ b/src/types/da_gd.rs
@@ -9,28 +9,28 @@ use crate::types::TypedVariables;
 /// Used by [`DurativeActionGoalDefinition`] itself, as well as [`DurativeActionDefinition`](crate::DurativeActionDefinition) and
 /// [`DurativeActionEffect`](crate::DurativeActionEffect).
 #[derive(Debug, Clone, PartialEq)]
-pub enum DurativeActionGoalDefinition<'a> {
-    Timed(PrefTimedGD<'a>),
-    And(Vec<DurativeActionGoalDefinition<'a>>),
+pub enum DurativeActionGoalDefinition {
+    Timed(PrefTimedGD),
+    And(Vec<DurativeActionGoalDefinition>),
     /// ## Requirements
     /// Requires [Universal Preconditions](crate::Requirement::UniversalPreconditions).
-    Forall(TypedVariables<'a>, Box<DurativeActionGoalDefinition<'a>>),
+    Forall(TypedVariables, Box<DurativeActionGoalDefinition>),
 }
 
-impl<'a> DurativeActionGoalDefinition<'a> {
-    pub fn new_timed(pref: PrefTimedGD<'a>) -> Self {
+impl DurativeActionGoalDefinition {
+    pub fn new_timed(pref: PrefTimedGD) -> Self {
         Self::Timed(pref)
     }
-    pub fn new_and<I: IntoIterator<Item = DurativeActionGoalDefinition<'a>>>(prefs: I) -> Self {
+    pub fn new_and<I: IntoIterator<Item = DurativeActionGoalDefinition>>(prefs: I) -> Self {
         Self::And(prefs.into_iter().collect())
     }
-    pub fn new_forall(variables: TypedVariables<'a>, gd: DurativeActionGoalDefinition<'a>) -> Self {
+    pub fn new_forall(variables: TypedVariables, gd: DurativeActionGoalDefinition) -> Self {
         Self::Forall(variables, Box::new(gd))
     }
 }
 
-impl<'a> From<PrefTimedGD<'a>> for DurativeActionGoalDefinition<'a> {
-    fn from(value: PrefTimedGD<'a>) -> Self {
+impl From<PrefTimedGD> for DurativeActionGoalDefinition {
+    fn from(value: PrefTimedGD) -> Self {
         DurativeActionGoalDefinition::new_timed(value)
     }
 }

--- a/src/types/da_symbol.rs
+++ b/src/types/da_symbol.rs
@@ -8,28 +8,28 @@ use std::ops::Deref;
 /// ## Usage
 /// Used by [`DurativeActionDefinition`](crate::DurativeActionDefinition).
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Default)]
-pub struct DurativeActionSymbol<'a>(Name<'a>);
+pub struct DurativeActionSymbol(Name);
 
-impl<'a> DurativeActionSymbol<'a> {
+impl DurativeActionSymbol {
     #[inline(always)]
-    pub const fn new(name: Name<'a>) -> Self {
+    pub const fn new(name: Name) -> Self {
         Self(name)
     }
 
     #[inline(always)]
-    pub const fn from_str(name: &'a str) -> Self {
+    pub fn from_str(name: &str) -> Self {
         Self(Name::new(name))
     }
 
     #[inline(always)]
-    pub const fn from_name(name: Name<'a>) -> Self {
+    pub const fn from_name(name: Name) -> Self {
         Self(name)
     }
 }
 
-impl<'a, T> From<T> for DurativeActionSymbol<'a>
+impl<'a, T> From<T> for DurativeActionSymbol
 where
-    T: Into<Name<'a>>,
+    T: Into<Name>,
 {
     #[inline(always)]
     fn from(value: T) -> Self {
@@ -37,22 +37,22 @@ where
     }
 }
 
-impl<'a> AsRef<Name<'a>> for DurativeActionSymbol<'a> {
+impl AsRef<Name> for DurativeActionSymbol {
     #[inline(always)]
-    fn as_ref(&self) -> &Name<'a> {
+    fn as_ref(&self) -> &Name {
         &self.0
     }
 }
 
-impl<'a> AsRef<str> for DurativeActionSymbol<'a> {
+impl AsRef<str> for DurativeActionSymbol {
     #[inline(always)]
     fn as_ref(&self) -> &str {
         self.0.as_ref()
     }
 }
 
-impl<'a> Deref for DurativeActionSymbol<'a> {
-    type Target = Name<'a>;
+impl Deref for DurativeActionSymbol {
+    type Target = Name;
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target {

--- a/src/types/derived_predicate.rs
+++ b/src/types/derived_predicate.rs
@@ -7,36 +7,36 @@ use crate::types::{AtomicFormulaSkeleton, GoalDefinition};
 /// ## Usage
 /// Used by [`StructureDef`](crate::StructureDef).
 #[derive(Debug, Clone, PartialEq)]
-pub struct DerivedPredicate<'a>(AtomicFormulaSkeleton<'a>, GoalDefinition<'a>);
+pub struct DerivedPredicate(AtomicFormulaSkeleton, GoalDefinition);
 
-impl<'a> DerivedPredicate<'a> {
-    pub const fn new(formula: AtomicFormulaSkeleton<'a>, gd: GoalDefinition<'a>) -> Self {
+impl DerivedPredicate {
+    pub const fn new(formula: AtomicFormulaSkeleton, gd: GoalDefinition) -> Self {
         Self(formula, gd)
     }
 
-    pub const fn predicate(&self) -> &AtomicFormulaSkeleton<'a> {
+    pub const fn predicate(&self) -> &AtomicFormulaSkeleton {
         &self.0
     }
 
-    pub const fn expression(&self) -> &GoalDefinition<'a> {
+    pub const fn expression(&self) -> &GoalDefinition {
         &self.1
     }
 }
 
-impl<'a> From<(AtomicFormulaSkeleton<'a>, GoalDefinition<'a>)> for DerivedPredicate<'a> {
-    fn from(value: (AtomicFormulaSkeleton<'a>, GoalDefinition<'a>)) -> Self {
+impl From<(AtomicFormulaSkeleton, GoalDefinition)> for DerivedPredicate {
+    fn from(value: (AtomicFormulaSkeleton, GoalDefinition)) -> Self {
         DerivedPredicate::new(value.0, value.1)
     }
 }
 
-impl<'a> AsRef<AtomicFormulaSkeleton<'a>> for DerivedPredicate<'a> {
-    fn as_ref(&self) -> &AtomicFormulaSkeleton<'a> {
+impl AsRef<AtomicFormulaSkeleton> for DerivedPredicate {
+    fn as_ref(&self) -> &AtomicFormulaSkeleton {
         self.predicate()
     }
 }
 
-impl<'a> AsRef<GoalDefinition<'a>> for DerivedPredicate<'a> {
-    fn as_ref(&self) -> &GoalDefinition<'a> {
+impl AsRef<GoalDefinition> for DerivedPredicate {
+    fn as_ref(&self) -> &GoalDefinition {
         self.expression()
     }
 }

--- a/src/types/domain.rs
+++ b/src/types/domain.rs
@@ -11,30 +11,30 @@ use crate::types::{Name, Types};
 /// ## Usage
 /// This is the top-level type of a domain description. See also [`Problem`](crate::Problem).
 #[derive(Debug, Clone, PartialEq)]
-pub struct Domain<'a> {
-    name: Name<'a>,
+pub struct Domain {
+    name: Name,
     // TODO: PDDL 1.2 - deprecated?
-    extends: Vec<Name<'a>>,
+    extends: Vec<Name>,
     requirements: Requirements,
     /// ## Requirements
     /// Requires [Typing](crate::Requirement::Typing).
-    types: Types<'a>,
-    constants: Constants<'a>,
-    predicates: PredicateDefinitions<'a>,
+    types: Types,
+    constants: Constants,
+    predicates: PredicateDefinitions,
     /// ## Requirements
     /// Requires [Fluents](crate::Requirement::Fluents).
-    functions: Functions<'a>,
+    functions: Functions,
     /// ## Requirements
     /// Requires [Constraints](crate::Requirement::Constraints).
-    constraints: DomainConstraintsDef<'a>,
+    constraints: DomainConstraintsDef,
     // TODO: PDDL 1.2 - deprecated?
-    timeless: Timeless<'a>,
-    structure: StructureDefs<'a>,
+    timeless: Timeless,
+    structure: StructureDefs,
 }
 
-impl<'a> Domain<'a> {
+impl Domain {
     /// Creates a builder to easily construct problems.
-    pub fn builder(name: Name<'a>, structure: StructureDefs<'a>) -> Self {
+    pub fn builder(name: Name, structure: StructureDefs) -> Self {
         Self {
             name,
             extends: Vec::default(),
@@ -51,7 +51,7 @@ impl<'a> Domain<'a> {
 
     /// Adds a list of optional domain names this domain definition extends upon.
     /// This is a PDDL 1.2 construct.
-    pub fn with_extends<N: IntoIterator<Item = Name<'a>>>(mut self, names: N) -> Self {
+    pub fn with_extends<N: IntoIterator<Item = Name>>(mut self, names: N) -> Self {
         self.extends = names.into_iter().collect();
         self
     }
@@ -63,49 +63,49 @@ impl<'a> Domain<'a> {
     }
 
     /// Adds a list of optional type declarations.
-    pub fn with_types<T: Into<Types<'a>>>(mut self, types: T) -> Self {
+    pub fn with_types<T: Into<Types>>(mut self, types: T) -> Self {
         self.types = types.into();
         self
     }
 
     /// Adds a list of optional constant declarations.
-    pub fn with_constants<C: Into<Constants<'a>>>(mut self, constants: C) -> Self {
+    pub fn with_constants<C: Into<Constants>>(mut self, constants: C) -> Self {
         self.constants = constants.into();
         self
     }
 
     /// Adds a list of optional predicate definitions.
-    pub fn with_predicates<P: Into<PredicateDefinitions<'a>>>(mut self, predicates: P) -> Self {
+    pub fn with_predicates<P: Into<PredicateDefinitions>>(mut self, predicates: P) -> Self {
         self.predicates = predicates.into();
         self
     }
 
     /// Adds a list of optional function definitions.
-    pub fn with_functions<F: Into<Functions<'a>>>(mut self, functions: F) -> Self {
+    pub fn with_functions<F: Into<Functions>>(mut self, functions: F) -> Self {
         self.functions = functions.into();
         self
     }
 
     /// Adds a list of optional constraints.
-    pub fn with_constraints(mut self, constraints: DomainConstraintsDef<'a>) -> Self {
+    pub fn with_constraints(mut self, constraints: DomainConstraintsDef) -> Self {
         self.constraints = constraints;
         self
     }
 
     /// Adds a list of timeless predicates.
-    pub fn with_timeless(mut self, timeless: Timeless<'a>) -> Self {
+    pub fn with_timeless(mut self, timeless: Timeless) -> Self {
         self.timeless = timeless;
         self
     }
 
     /// Gets the domain name.
-    pub const fn name(&self) -> &Name<'a> {
+    pub const fn name(&self) -> &Name {
         &self.name
     }
 
     /// Gets the names of the domains this definition extends.
     /// This is a PDDL 1.2 construct.
-    pub fn extends(&self) -> &[Name<'a>] {
+    pub fn extends(&self) -> &[Name] {
         &self.extends.as_slice()
     }
 
@@ -118,64 +118,64 @@ impl<'a> Domain<'a> {
     /// Returns the optional type declarations.
     /// ## Requirements
     /// Requires [Typing](crate::Requirement::Typing).
-    pub const fn types(&self) -> &Types<'a> {
+    pub const fn types(&self) -> &Types {
         &self.types
     }
 
     /// Returns the optional constant definitions.
-    pub const fn constants(&self) -> &Constants<'a> {
+    pub const fn constants(&self) -> &Constants {
         &self.constants
     }
 
     /// Returns the optional predicate definitions.
-    pub const fn predicates(&self) -> &PredicateDefinitions<'a> {
+    pub const fn predicates(&self) -> &PredicateDefinitions {
         &self.predicates
     }
 
     /// Returns the optional function definitions.
     /// ## Requirements
     /// Requires [Fluents](Requirement::Fluents).
-    pub const fn functions(&self) -> &Functions<'a> {
+    pub const fn functions(&self) -> &Functions {
         &self.functions
     }
 
     /// Returns the optional constraint declaration.
-    pub const fn constraints(&self) -> &ConGD<'a> {
+    pub const fn constraints(&self) -> &ConGD {
         &self.constraints.value()
     }
 
     /// Returns the domain structure definitions.
-    pub const fn structure(&self) -> &StructureDefs<'a> {
+    pub const fn structure(&self) -> &StructureDefs {
         &self.structure
     }
 }
 
-impl<'a> AsRef<Requirements> for Domain<'a> {
+impl AsRef<Requirements> for Domain {
     fn as_ref(&self) -> &Requirements {
         &self.requirements
     }
 }
 
-impl<'a> AsRef<Types<'a>> for Domain<'a> {
-    fn as_ref(&self) -> &Types<'a> {
+impl AsRef<Types> for Domain {
+    fn as_ref(&self) -> &Types {
         &self.types
     }
 }
 
-impl<'a> AsRef<PredicateDefinitions<'a>> for Domain<'a> {
-    fn as_ref(&self) -> &PredicateDefinitions<'a> {
+impl AsRef<PredicateDefinitions> for Domain {
+    fn as_ref(&self) -> &PredicateDefinitions {
         &self.predicates
     }
 }
 
-impl<'a> AsRef<Functions<'a>> for Domain<'a> {
-    fn as_ref(&self) -> &Functions<'a> {
+impl AsRef<Functions> for Domain {
+    fn as_ref(&self) -> &Functions {
         &self.functions
     }
 }
 
-impl<'a> AsRef<StructureDefs<'a>> for Domain<'a> {
-    fn as_ref(&self) -> &StructureDefs<'a> {
+impl AsRef<StructureDefs> for Domain {
+    fn as_ref(&self) -> &StructureDefs {
         &self.structure
     }
 }

--- a/src/types/domain_constraints_def.rs
+++ b/src/types/domain_constraints_def.rs
@@ -11,41 +11,41 @@ use std::ops::Deref;
 /// ## Usage
 /// Used by [`Domain`](crate::Domain).
 #[derive(Debug, Default, Clone, PartialEq)]
-pub struct DomainConstraintsDef<'a>(ConGD<'a>);
+pub struct DomainConstraintsDef(ConGD);
 
-impl<'a> DomainConstraintsDef<'a> {
-    pub const fn new(gd: ConGD<'a>) -> Self {
+impl DomainConstraintsDef {
+    pub const fn new(gd: ConGD) -> Self {
         Self(gd)
     }
 
     /// Gets the value.
-    pub const fn value(&self) -> &ConGD<'a> {
+    pub const fn value(&self) -> &ConGD {
         &self.0
     }
 }
 
-impl<'a> PartialEq<ConGD<'a>> for DomainConstraintsDef<'a> {
-    fn eq(&self, other: &ConGD<'a>) -> bool {
+impl PartialEq<ConGD> for DomainConstraintsDef {
+    fn eq(&self, other: &ConGD) -> bool {
         self.0.eq(other)
     }
 }
 
-impl<'a> From<ConGD<'a>> for DomainConstraintsDef<'a> {
-    fn from(value: ConGD<'a>) -> Self {
+impl From<ConGD> for DomainConstraintsDef {
+    fn from(value: ConGD) -> Self {
         Self::new(value)
     }
 }
 
-impl<'a> Deref for DomainConstraintsDef<'a> {
-    type Target = ConGD<'a>;
+impl Deref for DomainConstraintsDef {
+    type Target = ConGD;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<'a> Into<ConGD<'a>> for DomainConstraintsDef<'a> {
-    fn into(self) -> ConGD<'a> {
+impl Into<ConGD> for DomainConstraintsDef {
+    fn into(self) -> ConGD {
         self.0
     }
 }

--- a/src/types/duration_constraint.rs
+++ b/src/types/duration_constraint.rs
@@ -66,11 +66,12 @@ impl<'a> FromIterator<SimpleDurationConstraint<'a>> for DurationConstraint<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parsers::Span;
     use crate::Parser;
 
     #[test]
     fn flatten_with_single_element_works() {
-        let (_, dc_a) = SimpleDurationConstraint::parse("(>= ?duration 1.23)").unwrap();
+        let (_, dc_a) = SimpleDurationConstraint::parse(Span::new("(>= ?duration 1.23)")).unwrap();
 
         let mut iter = DurationConstraint::new(dc_a).into_iter();
         assert!(iter.next().is_some());
@@ -79,8 +80,9 @@ mod tests {
 
     #[test]
     fn flatten_with_many_elements_works() {
-        let (_, dc_a) = SimpleDurationConstraint::parse("(>= ?duration 1.23)").unwrap();
-        let (_, dc_b) = SimpleDurationConstraint::parse("(at end (<= ?duration 1.23))").unwrap();
+        let (_, dc_a) = SimpleDurationConstraint::parse(Span::new("(>= ?duration 1.23)")).unwrap();
+        let (_, dc_b) =
+            SimpleDurationConstraint::parse(Span::new("(at end (<= ?duration 1.23))")).unwrap();
 
         let mut iter = DurationConstraint::from_iter([dc_a, dc_b]).into_iter();
         assert!(iter.next().is_some());

--- a/src/types/duration_constraint.rs
+++ b/src/types/duration_constraint.rs
@@ -6,15 +6,15 @@ use crate::types::SimpleDurationConstraint;
 /// ## Usage
 /// Used by [`DurativeActionDefinition`](crate::DurativeActionDefinition).
 #[derive(Debug, Clone, PartialEq)]
-pub enum DurationConstraint<'a> {
-    Single(SimpleDurationConstraint<'a>),
+pub enum DurationConstraint {
+    Single(SimpleDurationConstraint),
     /// ## Requirements
     /// Requires [Duration Inequalities](crate::Requirement::DurationInequalities).
-    All(Vec<SimpleDurationConstraint<'a>>),
+    All(Vec<SimpleDurationConstraint>),
 }
 
-impl<'a> IntoIterator for DurationConstraint<'a> {
-    type Item = SimpleDurationConstraint<'a>;
+impl IntoIterator for DurationConstraint {
+    type Item = SimpleDurationConstraint;
     type IntoIter = FlatteningIntoIterator<Self::Item>;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -25,12 +25,12 @@ impl<'a> IntoIterator for DurationConstraint<'a> {
     }
 }
 
-impl<'a> DurationConstraint<'a> {
-    pub const fn new(constraint: SimpleDurationConstraint<'a>) -> Self {
+impl DurationConstraint {
+    pub const fn new(constraint: SimpleDurationConstraint) -> Self {
         Self::Single(constraint)
     }
 
-    pub fn new_all<I: IntoIterator<Item = SimpleDurationConstraint<'a>>>(constraints: I) -> Self {
+    pub fn new_all<I: IntoIterator<Item = SimpleDurationConstraint>>(constraints: I) -> Self {
         let vec: Vec<_> = constraints.into_iter().collect();
         debug_assert!(!vec.is_empty());
         Self::All(vec)
@@ -51,14 +51,14 @@ impl<'a> DurationConstraint<'a> {
     }
 }
 
-impl<'a> From<SimpleDurationConstraint<'a>> for DurationConstraint<'a> {
-    fn from(value: SimpleDurationConstraint<'a>) -> Self {
+impl From<SimpleDurationConstraint> for DurationConstraint {
+    fn from(value: SimpleDurationConstraint) -> Self {
         DurationConstraint::new(value)
     }
 }
 
-impl<'a> FromIterator<SimpleDurationConstraint<'a>> for DurationConstraint<'a> {
-    fn from_iter<T: IntoIterator<Item = SimpleDurationConstraint<'a>>>(iter: T) -> Self {
+impl FromIterator<SimpleDurationConstraint> for DurationConstraint {
+    fn from_iter<T: IntoIterator<Item = SimpleDurationConstraint>>(iter: T) -> Self {
         DurationConstraint::new_all(iter)
     }
 }

--- a/src/types/effects.rs
+++ b/src/types/effects.rs
@@ -11,16 +11,16 @@ use std::ops::Deref;
 /// ## Usage
 /// Used by [`ActionDefinition`](crate::ActionDefinition).
 #[derive(Debug, Clone, PartialEq, Default)]
-pub struct Effects<'a>(Vec<CEffect<'a>>);
+pub struct Effects(Vec<CEffect>);
 
-impl<'a> Effects<'a> {
+impl Effects {
     /// Constructs a new instance from the value.
-    pub fn new(effect: CEffect<'a>) -> Self {
+    pub fn new(effect: CEffect) -> Self {
         Self(vec![effect])
     }
 
     /// Constructs a new instance from the provided vector of values.
-    pub fn new_and(effects: Vec<CEffect<'a>>) -> Self {
+    pub fn new_and(effects: Vec<CEffect>) -> Self {
         Self(effects)
     }
 
@@ -38,13 +38,13 @@ impl<'a> Effects<'a> {
     /// Returns an iterator over the list.
     ///
     /// The iterator yields all items from start to end.
-    pub fn iter(&'a self) -> std::slice::Iter<'a, CEffect<'a>> {
+    pub fn iter(&self) -> std::slice::Iter<CEffect> {
         self.0.iter()
     }
 
     /// Get the only element of this list if the list has
     /// exactly one element. Returns [`None`] in all other cases.
-    pub fn try_get_single(self) -> Option<CEffect<'a>> {
+    pub fn try_get_single(self) -> Option<CEffect> {
         if self.len() == 1 {
             self.into_iter().next()
         } else {
@@ -53,8 +53,8 @@ impl<'a> Effects<'a> {
     }
 }
 
-impl<'a> IntoIterator for Effects<'a> {
-    type Item = CEffect<'a>;
+impl IntoIterator for Effects {
+    type Item = CEffect;
     type IntoIter = std::vec::IntoIter<Self::Item>;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -62,42 +62,42 @@ impl<'a> IntoIterator for Effects<'a> {
     }
 }
 
-impl<'a> Deref for Effects<'a> {
-    type Target = [CEffect<'a>];
+impl Deref for Effects {
+    type Target = [CEffect];
 
     fn deref(&self) -> &Self::Target {
         self.0.as_slice()
     }
 }
 
-impl<'a> AsRef<[CEffect<'a>]> for Effects<'a> {
-    fn as_ref(&self) -> &[CEffect<'a>] {
+impl AsRef<[CEffect]> for Effects {
+    fn as_ref(&self) -> &[CEffect] {
         self.0.as_slice()
     }
 }
 
-impl<'a> From<CEffect<'a>> for Effects<'a> {
-    fn from(value: CEffect<'a>) -> Self {
+impl From<CEffect> for Effects {
+    fn from(value: CEffect) -> Self {
         Effects::new(value)
     }
 }
 
-impl<'a> From<Vec<CEffect<'a>>> for Effects<'a> {
-    fn from(value: Vec<CEffect<'a>>) -> Self {
+impl From<Vec<CEffect>> for Effects {
+    fn from(value: Vec<CEffect>) -> Self {
         Effects::new_and(value)
     }
 }
 
-impl<'a> FromIterator<CEffect<'a>> for Effects<'a> {
-    fn from_iter<T: IntoIterator<Item = CEffect<'a>>>(iter: T) -> Self {
+impl FromIterator<CEffect> for Effects {
+    fn from_iter<T: IntoIterator<Item = CEffect>>(iter: T) -> Self {
         Effects::new_and(iter.into_iter().collect())
     }
 }
 
-impl<'a> TryInto<CEffect<'a>> for Effects<'a> {
+impl TryInto<CEffect> for Effects {
     type Error = ();
 
-    fn try_into(self) -> Result<CEffect<'a>, Self::Error> {
+    fn try_into(self) -> Result<CEffect, Self::Error> {
         self.try_get_single().ok_or(())
     }
 }

--- a/src/types/f_assign_da.rs
+++ b/src/types/f_assign_da.rs
@@ -12,10 +12,10 @@ use crate::types::{AssignOp, FExpDa, FHead};
 /// ## Usage
 /// Used by [`TimedEffect`](crate::TimedEffect).
 #[derive(Debug, Clone, PartialEq)]
-pub struct FAssignDa<'a>(AssignOp, FHead<'a>, FExpDa<'a>);
+pub struct FAssignDa(AssignOp, FHead, FExpDa);
 
-impl<'a> FAssignDa<'a> {
-    pub const fn new(comp: AssignOp, head: FHead<'a>, exp: FExpDa<'a>) -> Self {
+impl FAssignDa {
+    pub const fn new(comp: AssignOp, head: FHead, exp: FExpDa) -> Self {
         Self(comp, head, exp)
     }
 
@@ -25,18 +25,18 @@ impl<'a> FAssignDa<'a> {
     }
 
     /// Returns the function head.
-    pub const fn function(&self) -> &FHead<'a> {
+    pub const fn function(&self) -> &FHead {
         &self.1
     }
 
     /// Returns the function expression of the durative action.
-    pub const fn function_expr(&self) -> &FExpDa<'a> {
+    pub const fn function_expr(&self) -> &FExpDa {
         &self.2
     }
 }
 
-impl<'a> From<(AssignOp, FHead<'a>, FExpDa<'a>)> for FAssignDa<'a> {
-    fn from(value: (AssignOp, FHead<'a>, FExpDa<'a>)) -> Self {
+impl From<(AssignOp, FHead, FExpDa)> for FAssignDa {
+    fn from(value: (AssignOp, FHead, FExpDa)) -> Self {
         FAssignDa::new(value.0, value.1, value.2)
     }
 }

--- a/src/types/f_comp.rs
+++ b/src/types/f_comp.rs
@@ -8,10 +8,10 @@ use crate::types::{BinaryComp, FExp};
 /// ## Usage
 /// Used by [`GoalDefinition`](crate::GoalDefinition).
 #[derive(Debug, Clone, PartialEq)]
-pub struct FComp<'a>(BinaryComp, FExp<'a>, FExp<'a>);
+pub struct FComp(BinaryComp, FExp, FExp);
 
-impl<'a> FComp<'a> {
-    pub const fn new(comp: BinaryComp, lhs: FExp<'a>, rhs: FExp<'a>) -> Self {
+impl FComp {
+    pub const fn new(comp: BinaryComp, lhs: FExp, rhs: FExp) -> Self {
         Self(comp, lhs, rhs)
     }
 
@@ -21,18 +21,18 @@ impl<'a> FComp<'a> {
     }
 
     /// Returns the first operand.
-    pub const fn first(&self) -> &FExp<'a> {
+    pub const fn first(&self) -> &FExp {
         &self.1
     }
 
     /// Returns the second operand.
-    pub const fn second(&self) -> &FExp<'a> {
+    pub const fn second(&self) -> &FExp {
         &self.2
     }
 }
 
-impl<'a> From<(BinaryComp, FExp<'a>, FExp<'a>)> for FComp<'a> {
-    fn from(value: (BinaryComp, FExp<'a>, FExp<'a>)) -> Self {
+impl From<(BinaryComp, FExp, FExp)> for FComp {
+    fn from(value: (BinaryComp, FExp, FExp)) -> Self {
         FComp::new(value.0, value.1, value.2)
     }
 }

--- a/src/types/f_exp.rs
+++ b/src/types/f_exp.rs
@@ -11,42 +11,38 @@ use crate::types::{BinaryOp, FHead, MultiOp, Number};
 /// Used by [`FExp`] itself, as well as [`PEffect`](crate::PEffect), [`DurationValue`](crate::DurationValue),
 /// [`FExpDa`](crate::FExpDa) and [`FExpT`](crate::FExpT).
 #[derive(Debug, Clone, PartialEq)]
-pub enum FExp<'a> {
+pub enum FExp {
     /// A numerical expression.
     Number(Number),
     /// A function that derives a value.
-    Function(FHead<'a>),
+    Function(FHead),
     /// The negative value of a function expression.
-    Negative(Box<FExp<'a>>),
+    Negative(Box<FExp>),
     /// An operation applied to two function expressions.
-    BinaryOp(BinaryOp, Box<FExp<'a>>, Box<FExp<'a>>),
+    BinaryOp(BinaryOp, Box<FExp>, Box<FExp>),
     /// An operation applied to two or more function expressions.
-    MultiOp(MultiOp, Box<FExp<'a>>, Vec<FExp<'a>>),
+    MultiOp(MultiOp, Box<FExp>, Vec<FExp>),
 }
 
-impl<'a> FExp<'a> {
+impl FExp {
     #[inline(always)]
     pub fn new_number<N: Into<Number>>(number: N) -> Self {
         Self::Number(number.into())
     }
 
-    pub fn new_binary_op(op: BinaryOp, lhs: FExp<'a>, rhs: FExp<'a>) -> Self {
+    pub fn new_binary_op(op: BinaryOp, lhs: FExp, rhs: FExp) -> Self {
         Self::BinaryOp(op, Box::new(lhs), Box::new(rhs))
     }
 
-    pub fn new_multi_op<I: IntoIterator<Item = FExp<'a>>>(
-        op: MultiOp,
-        lhs: FExp<'a>,
-        rhs: I,
-    ) -> Self {
+    pub fn new_multi_op<I: IntoIterator<Item = FExp>>(op: MultiOp, lhs: FExp, rhs: I) -> Self {
         Self::MultiOp(op, Box::new(lhs), rhs.into_iter().collect())
     }
 
-    pub fn new_negative(value: FExp<'a>) -> Self {
+    pub fn new_negative(value: FExp) -> Self {
         Self::Negative(Box::new(value))
     }
 
-    pub const fn new_function(f_head: FHead<'a>) -> Self {
+    pub const fn new_function(f_head: FHead) -> Self {
         Self::Function(f_head)
     }
 }

--- a/src/types/f_exp_da.rs
+++ b/src/types/f_exp_da.rs
@@ -5,45 +5,41 @@ use crate::types::{AssignOp, BinaryOp, FExp, FHead, MultiOp};
 /// ## Usage
 /// Used by [`FExpDa`] itself, as well as [`FAssignDa`](crate::FAssignDa).
 #[derive(Debug, Clone, PartialEq)]
-pub enum FExpDa<'a> {
-    Assign(AssignOp, FHead<'a>, Box<FExpDa<'a>>),
-    BinaryOp(BinaryOp, Box<FExpDa<'a>>, Box<FExpDa<'a>>),
-    MultiOp(MultiOp, Box<FExpDa<'a>>, Vec<FExpDa<'a>>),
-    Negative(Box<FExpDa<'a>>),
+pub enum FExpDa {
+    Assign(AssignOp, FHead, Box<FExpDa>),
+    BinaryOp(BinaryOp, Box<FExpDa>, Box<FExpDa>),
+    MultiOp(MultiOp, Box<FExpDa>, Vec<FExpDa>),
+    Negative(Box<FExpDa>),
     /// ## Requirements
     /// Requires [Duration Inequalities](crate::Requirement::DurationInequalities).
     Duration,
-    FExp(FExp<'a>),
+    FExp(FExp),
 }
 
-impl<'a> FExpDa<'a> {
+impl FExpDa {
     pub const fn new_duration() -> Self {
         Self::Duration
     }
 
-    pub fn new_binary_op(op: BinaryOp, lhs: FExpDa<'a>, rhs: FExpDa<'a>) -> Self {
+    pub fn new_binary_op(op: BinaryOp, lhs: FExpDa, rhs: FExpDa) -> Self {
         Self::BinaryOp(op, Box::new(lhs), Box::new(rhs))
     }
 
-    pub fn new_multi_op<I: IntoIterator<Item = FExpDa<'a>>>(
-        op: MultiOp,
-        lhs: FExpDa<'a>,
-        rhs: I,
-    ) -> Self {
+    pub fn new_multi_op<I: IntoIterator<Item = FExpDa>>(op: MultiOp, lhs: FExpDa, rhs: I) -> Self {
         Self::MultiOp(op, Box::new(lhs), rhs.into_iter().collect())
     }
 
-    pub fn new_negative(value: FExpDa<'a>) -> Self {
+    pub fn new_negative(value: FExpDa) -> Self {
         Self::Negative(Box::new(value))
     }
 
-    pub const fn new_f_exp(f_head: FExp<'a>) -> Self {
+    pub const fn new_f_exp(f_head: FExp) -> Self {
         Self::FExp(f_head)
     }
 }
 
-impl<'a> From<FExp<'a>> for FExpDa<'a> {
-    fn from(value: FExp<'a>) -> Self {
+impl From<FExp> for FExpDa {
+    fn from(value: FExp) -> Self {
         FExpDa::new_f_exp(value)
     }
 }

--- a/src/types/f_exp_t.rs
+++ b/src/types/f_exp_t.rs
@@ -11,29 +11,29 @@ use crate::types::FExp;
 /// ## Usage
 /// Used by [`TimedEffect`](crate::TimedEffect).
 #[derive(Debug, Clone, PartialEq)]
-pub enum FExpT<'a> {
+pub enum FExpT {
     Now,
-    Scaled(FExp<'a>),
+    Scaled(FExp),
 }
 
-impl<'a> FExpT<'a> {
+impl FExpT {
     pub const fn new() -> Self {
         Self::Now
     }
 
-    pub fn new_scaled(exp: FExp<'a>) -> Self {
+    pub fn new_scaled(exp: FExp) -> Self {
         Self::Scaled(exp)
     }
 }
 
-impl<'a> Default for FExpT<'a> {
+impl Default for FExpT {
     fn default() -> Self {
         Self::Now
     }
 }
 
-impl<'a> From<FExp<'a>> for FExpT<'a> {
-    fn from(value: FExp<'a>) -> Self {
+impl From<FExp> for FExpT {
+    fn from(value: FExp) -> Self {
         Self::Scaled(value)
     }
 }

--- a/src/types/f_head.rs
+++ b/src/types/f_head.rs
@@ -11,20 +11,17 @@ use crate::types::{FunctionSymbol, Term};
 /// Used by [`FExp`](crate::FExp), [`PEffect`](crate::PEffect), [`TimedEffect`](crate::TimedEffect)
 /// and [`FAssignDa`](crate::FAssignDa).
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub enum FHead<'a> {
-    Simple(FunctionSymbol<'a>), // TODO: Unify with `WithTerms`?
-    WithTerms(FunctionSymbol<'a>, Vec<Term<'a>>),
+pub enum FHead {
+    Simple(FunctionSymbol), // TODO: Unify with `WithTerms`?
+    WithTerms(FunctionSymbol, Vec<Term>),
 }
 
-impl<'a> FHead<'a> {
-    pub const fn new(symbol: FunctionSymbol<'a>) -> Self {
+impl FHead {
+    pub const fn new(symbol: FunctionSymbol) -> Self {
         Self::Simple(symbol)
     }
 
-    pub fn new_with_terms<I: IntoIterator<Item = Term<'a>>>(
-        symbol: FunctionSymbol<'a>,
-        terms: I,
-    ) -> Self {
+    pub fn new_with_terms<I: IntoIterator<Item = Term>>(symbol: FunctionSymbol, terms: I) -> Self {
         Self::WithTerms(symbol, terms.into_iter().collect())
     }
 }

--- a/src/types/function_symbols.rs
+++ b/src/types/function_symbols.rs
@@ -9,28 +9,28 @@ use std::ops::Deref;
 /// Used by [`FunctionTerm`](crate::FunctionTerm), [`FHead`](crate::FHead),
 /// [`BasicFunctionTerm`](crate::BasicFunctionTerm) and [`MetricFExp`](crate::MetricFExp).
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Default)]
-pub struct FunctionSymbol<'a>(Name<'a>);
+pub struct FunctionSymbol(Name);
 
-impl<'a> FunctionSymbol<'a> {
+impl FunctionSymbol {
     #[inline(always)]
-    pub fn new(name: Name<'a>) -> Self {
+    pub fn new(name: Name) -> Self {
         Self(name)
     }
 
     #[inline(always)]
-    pub const fn from_str(name: &'a str) -> Self {
+    pub fn from_str(name: &str) -> Self {
         Self(Name::new(name))
     }
 
     #[inline(always)]
-    pub const fn from_name(name: Name<'a>) -> Self {
+    pub const fn from_name(name: Name) -> Self {
         Self(name)
     }
 }
 
-impl<'a, T> From<T> for FunctionSymbol<'a>
+impl<'a, T> From<T> for FunctionSymbol
 where
-    T: Into<Name<'a>>,
+    T: Into<Name>,
 {
     #[inline(always)]
     fn from(value: T) -> Self {
@@ -38,22 +38,22 @@ where
     }
 }
 
-impl<'a> AsRef<Name<'a>> for FunctionSymbol<'a> {
+impl AsRef<Name> for FunctionSymbol {
     #[inline(always)]
-    fn as_ref(&self) -> &Name<'a> {
+    fn as_ref(&self) -> &Name {
         &self.0
     }
 }
 
-impl<'a> AsRef<str> for FunctionSymbol<'a> {
+impl AsRef<str> for FunctionSymbol {
     #[inline(always)]
     fn as_ref(&self) -> &str {
         self.0.as_ref()
     }
 }
 
-impl<'a> Deref for FunctionSymbol<'a> {
-    type Target = Name<'a>;
+impl Deref for FunctionSymbol {
+    type Target = Name;
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target {

--- a/src/types/function_term.rs
+++ b/src/types/function_term.rs
@@ -11,32 +11,32 @@ use crate::types::FunctionSymbol;
 /// ## Usage
 /// Used by [`Term`], and [`PEffect`](crate::PEffect).
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct FunctionTerm<'a>(FunctionSymbol<'a>, Vec<Term<'a>>);
+pub struct FunctionTerm(FunctionSymbol, Vec<Term>);
 
-impl<'a> FunctionTerm<'a> {
-    pub fn new<I: IntoIterator<Item = Term<'a>>>(symbol: FunctionSymbol<'a>, terms: I) -> Self {
+impl FunctionTerm {
+    pub fn new<I: IntoIterator<Item = Term>>(symbol: FunctionSymbol, terms: I) -> Self {
         Self(symbol, terms.into_iter().collect())
     }
 
     /// Gets the function symbol.
-    pub const fn symbol(&self) -> &FunctionSymbol<'a> {
+    pub const fn symbol(&self) -> &FunctionSymbol {
         &self.0
     }
 
     /// Gets the function terms.
-    pub fn terms(&self) -> &[Term<'a>] {
+    pub fn terms(&self) -> &[Term] {
         self.1.as_ref()
     }
 }
 
-impl<'a> AsRef<FunctionSymbol<'a>> for FunctionTerm<'a> {
-    fn as_ref(&self) -> &FunctionSymbol<'a> {
+impl AsRef<FunctionSymbol> for FunctionTerm {
+    fn as_ref(&self) -> &FunctionSymbol {
         &self.0
     }
 }
 
-impl<'a> AsRef<Vec<Term<'a>>> for FunctionTerm<'a> {
-    fn as_ref(&self) -> &Vec<Term<'a>> {
+impl AsRef<Vec<Term>> for FunctionTerm {
+    fn as_ref(&self) -> &Vec<Term> {
         &self.1
     }
 }

--- a/src/types/function_type.rs
+++ b/src/types/function_type.rs
@@ -14,48 +14,48 @@ use std::ops::Deref;
 /// ## Usage
 /// Used by [`FunctionTyped`](crate::FunctionTyped) in [`FunctionTypedList`](crate::FunctionTypedList).
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct FunctionType<'a>(Type<'a>);
+pub struct FunctionType(Type);
 
-impl<'a> FunctionType<'a> {
-    pub const NUMBER: FunctionType<'static> = FunctionType::from(Type::NUMBER);
+impl FunctionType {
+    pub const NUMBER: FunctionType = FunctionType::from(Type::NUMBER);
 
-    pub fn new<T: Into<Type<'a>>>(r#type: T) -> Self {
+    pub fn new<T: Into<Type>>(r#type: T) -> Self {
         Self(r#type.into())
     }
 
-    pub const fn from(r#type: Type<'a>) -> Self {
+    pub const fn from(r#type: Type) -> Self {
         Self(r#type)
     }
 }
 
-impl<'a> Default for FunctionType<'a> {
+impl Default for FunctionType {
     fn default() -> Self {
         Self(Type::NUMBER)
     }
 }
 
-impl<'a> From<&'a str> for FunctionType<'a> {
-    fn from(value: &'a str) -> Self {
+impl From<&str> for FunctionType {
+    fn from(value: &str) -> Self {
         Self(value.into())
     }
 }
 
-impl<'a> From<Vec<&'a str>> for FunctionType<'a> {
-    fn from(value: Vec<&'a str>) -> Self {
+impl From<Vec<&str>> for FunctionType {
+    fn from(value: Vec<&str>) -> Self {
         Self(Type::from_iter(
             value.iter().map(|&x| PrimitiveType::from(x)),
         ))
     }
 }
 
-impl<'a> From<Type<'a>> for FunctionType<'a> {
-    fn from(value: Type<'a>) -> Self {
+impl From<Type> for FunctionType {
+    fn from(value: Type) -> Self {
         Self(value)
     }
 }
 
-impl<'a> Deref for FunctionType<'a> {
-    type Target = Type<'a>;
+impl Deref for FunctionType {
+    type Target = Type;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/src/types/function_typed.rs
+++ b/src/types/function_typed.rs
@@ -12,10 +12,10 @@ use std::ops::Deref;
 /// ## Usage
 /// Used by [`FunctionTypedList`](crate::FunctionTypedList).
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct FunctionTyped<'a, O>(O, FunctionType<'a>);
+pub struct FunctionTyped<O>(O, FunctionType);
 
-impl<'a, O> FunctionTyped<'a, O> {
-    pub const fn new(value: O, r#type: FunctionType<'a>) -> Self {
+impl<O> FunctionTyped<O> {
+    pub const fn new(value: O, r#type: FunctionType) -> Self {
         Self(value, r#type)
     }
 
@@ -23,7 +23,7 @@ impl<'a, O> FunctionTyped<'a, O> {
         Self::new(value, FunctionType::NUMBER)
     }
 
-    pub const fn from_type(value: O, r#type: Type<'a>) -> Self {
+    pub const fn from_type(value: O, r#type: Type) -> Self {
         Self::new(value, FunctionType::from(r#type))
     }
 
@@ -31,18 +31,18 @@ impl<'a, O> FunctionTyped<'a, O> {
         &self.0
     }
 
-    pub const fn type_ref(&self) -> &FunctionType<'a> {
+    pub const fn type_ref(&self) -> &FunctionType {
         &self.1
     }
 }
 
-impl<'a, O> From<O> for FunctionTyped<'a, O> {
+impl<O> From<O> for FunctionTyped<O> {
     fn from(value: O) -> Self {
         FunctionTyped::new_number(value)
     }
 }
 
-impl<'a, O> Deref for FunctionTyped<'a, O> {
+impl<O> Deref for FunctionTyped<O> {
     type Target = O;
 
     fn deref(&self) -> &Self::Target {

--- a/src/types/function_typed_list.rs
+++ b/src/types/function_typed_list.rs
@@ -28,59 +28,59 @@ use std::ops::Deref;
 /// ## Usage
 /// Used by [`Functions`](crate::Functions).
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct FunctionTypedList<'a, T>(Vec<FunctionTyped<'a, T>>);
+pub struct FunctionTypedList<T>(Vec<FunctionTyped<T>>);
 
-impl<'a, T> Default for FunctionTypedList<'a, T> {
+impl<'a, T> Default for FunctionTypedList<T> {
     fn default() -> Self {
         Self(Vec::default())
     }
 }
 
-impl<'a, T> FunctionTypedList<'a, T> {
-    pub const fn new(list: Vec<FunctionTyped<'a, T>>) -> Self {
+impl<'a, T> FunctionTypedList<T> {
+    pub const fn new(list: Vec<FunctionTyped<T>>) -> Self {
         Self(list)
     }
 
     /// Gets the values.
-    pub fn values(&self) -> &[FunctionTyped<'a, T>] {
+    pub fn values(&self) -> &[FunctionTyped<T>] {
         self.0.as_slice()
     }
 }
 
-impl<'a, T> From<Vec<FunctionTyped<'a, T>>> for FunctionTypedList<'a, T> {
-    fn from(iter: Vec<FunctionTyped<'a, T>>) -> Self {
+impl<'a, T> From<Vec<FunctionTyped<T>>> for FunctionTypedList<T> {
+    fn from(iter: Vec<FunctionTyped<T>>) -> Self {
         FunctionTypedList::new(iter)
     }
 }
 
-impl<'a, T> FromIterator<FunctionTyped<'a, T>> for FunctionTypedList<'a, T> {
-    fn from_iter<I: IntoIterator<Item = FunctionTyped<'a, T>>>(iter: I) -> Self {
+impl<'a, T> FromIterator<FunctionTyped<T>> for FunctionTypedList<T> {
+    fn from_iter<I: IntoIterator<Item = FunctionTyped<T>>>(iter: I) -> Self {
         FunctionTypedList::new(iter.into_iter().collect())
     }
 }
 
-impl<'a, T> Deref for FunctionTypedList<'a, T> {
-    type Target = [FunctionTyped<'a, T>];
+impl<'a, T> Deref for FunctionTypedList<T> {
+    type Target = [FunctionTyped<T>];
 
     fn deref(&self) -> &Self::Target {
         self.0.as_slice()
     }
 }
 
-impl<'a, T> PartialEq<Vec<FunctionTyped<'_, T>>> for FunctionTypedList<'a, T>
+impl<'a, T> PartialEq<Vec<FunctionTyped<T>>> for FunctionTypedList<T>
 where
     T: PartialEq,
 {
-    fn eq(&self, other: &Vec<FunctionTyped<'_, T>>) -> bool {
+    fn eq(&self, other: &Vec<FunctionTyped<T>>) -> bool {
         self.0.eq(other)
     }
 }
 
-impl<'a, T> PartialEq<[FunctionTyped<'_, T>]> for FunctionTypedList<'a, T>
+impl<'a, T> PartialEq<[FunctionTyped<T>]> for FunctionTypedList<T>
 where
     T: PartialEq,
 {
-    fn eq(&self, other: &[FunctionTyped<'_, T>]) -> bool {
+    fn eq(&self, other: &[FunctionTyped<T>]) -> bool {
         self.0.eq(other)
     }
 }

--- a/src/types/functions.rs
+++ b/src/types/functions.rs
@@ -11,37 +11,35 @@ use std::ops::Deref;
 /// ## Usage
 /// Used by [`Domain`](crate::Domain).
 #[derive(Debug, Default, Clone, Eq, PartialEq)]
-pub struct Functions<'a>(FunctionTypedList<'a, AtomicFunctionSkeleton<'a>>);
+pub struct Functions(FunctionTypedList<AtomicFunctionSkeleton>);
 
-impl<'a> Functions<'a> {
-    pub const fn new(functions: FunctionTypedList<'a, AtomicFunctionSkeleton<'a>>) -> Self {
+impl Functions {
+    pub const fn new(functions: FunctionTypedList<AtomicFunctionSkeleton>) -> Self {
         Self(functions)
     }
 
     /// Gets the values.
-    pub fn values(&self) -> &FunctionTypedList<'a, AtomicFunctionSkeleton<'a>> {
+    pub fn values(&self) -> &FunctionTypedList<AtomicFunctionSkeleton> {
         &self.0
     }
 }
 
-impl<'a> Deref for Functions<'a> {
-    type Target = FunctionTypedList<'a, AtomicFunctionSkeleton<'a>>;
+impl Deref for Functions {
+    type Target = FunctionTypedList<AtomicFunctionSkeleton>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<'a> From<FunctionTypedList<'a, AtomicFunctionSkeleton<'a>>> for Functions<'a> {
-    fn from(value: FunctionTypedList<'a, AtomicFunctionSkeleton<'a>>) -> Self {
+impl From<FunctionTypedList<AtomicFunctionSkeleton>> for Functions {
+    fn from(value: FunctionTypedList<AtomicFunctionSkeleton>) -> Self {
         Functions::new(value)
     }
 }
 
-impl<'a> FromIterator<FunctionTyped<'a, AtomicFunctionSkeleton<'a>>> for Functions<'a> {
-    fn from_iter<T: IntoIterator<Item = FunctionTyped<'a, AtomicFunctionSkeleton<'a>>>>(
-        iter: T,
-    ) -> Self {
+impl FromIterator<FunctionTyped<AtomicFunctionSkeleton>> for Functions {
+    fn from_iter<T: IntoIterator<Item = FunctionTyped<AtomicFunctionSkeleton>>>(iter: T) -> Self {
         Functions::new(FunctionTypedList::from_iter(iter))
     }
 }

--- a/src/types/gd.rs
+++ b/src/types/gd.rs
@@ -10,92 +10,92 @@ use crate::types::{AtomicFormula, FComp, Term, TypedVariables};
 /// [`TimedGD`](crate::TimedGD), [`DerivedPredicate`](crate::DerivedPredicate) and
 /// [`Con2GD`](crate::Con2GD).
 #[derive(Debug, Clone, PartialEq)]
-pub enum GoalDefinition<'a> {
-    AtomicFormula(AtomicFormula<'a, Term<'a>>),
+pub enum GoalDefinition {
+    AtomicFormula(AtomicFormula<Term>),
     /// ## Requirements
     /// Requires [Negative Preconditions](crate::Requirement::NegativePreconditions).
-    Literal(TermLiteral<'a>),
-    And(Vec<GoalDefinition<'a>>),
+    Literal(TermLiteral),
+    And(Vec<GoalDefinition>),
     /// ## Requirements
     /// Requires [Disjunctive Preconditions](crate::Requirement::DisjunctivePreconditions).
-    Or(Vec<GoalDefinition<'a>>),
+    Or(Vec<GoalDefinition>),
     /// ## Requirements
     /// Requires [Disjunctive Preconditions](crate::Requirement::DisjunctivePreconditions).
-    Not(Box<GoalDefinition<'a>>),
+    Not(Box<GoalDefinition>),
     /// ## Requirements
     /// Requires [Disjunctive Preconditions](crate::Requirement::DisjunctivePreconditions).
-    Imply(Box<GoalDefinition<'a>>, Box<GoalDefinition<'a>>),
+    Imply(Box<GoalDefinition>, Box<GoalDefinition>),
     /// ## Requirements
     /// Requires [Existential Preconditions](crate::Requirement::ExistentialPreconditions).
-    Exists(TypedVariables<'a>, Box<GoalDefinition<'a>>),
+    Exists(TypedVariables, Box<GoalDefinition>),
     /// ## Requirements
     /// Requires [Universal Preconditions](crate::Requirement::UniversalPreconditions).
-    ForAll(TypedVariables<'a>, Box<GoalDefinition<'a>>),
+    ForAll(TypedVariables, Box<GoalDefinition>),
     /// ## Requirements
     /// Requires [Numeric Fluents](crate::Requirement::NumericFluents).
-    FComp(FComp<'a>),
+    FComp(FComp),
 }
 
-impl<'a> GoalDefinition<'a> {
+impl GoalDefinition {
     #[inline(always)]
-    pub const fn new_atomic_formula(value: AtomicFormula<'a, Term<'a>>) -> Self {
+    pub const fn new_atomic_formula(value: AtomicFormula<Term>) -> Self {
         Self::AtomicFormula(value)
     }
 
     #[inline(always)]
-    pub const fn new_literal(value: TermLiteral<'a>) -> Self {
+    pub const fn new_literal(value: TermLiteral) -> Self {
         Self::Literal(value)
     }
 
     #[inline(always)]
-    pub fn new_and<T: IntoIterator<Item = GoalDefinition<'a>>>(values: T) -> Self {
+    pub fn new_and<T: IntoIterator<Item = GoalDefinition>>(values: T) -> Self {
         // TODO: Flatten `(and (and a b) (and x y))` into `(and a b c y)`.
         Self::And(values.into_iter().collect())
     }
 
     #[inline(always)]
-    pub fn new_or<T: IntoIterator<Item = GoalDefinition<'a>>>(values: T) -> Self {
+    pub fn new_or<T: IntoIterator<Item = GoalDefinition>>(values: T) -> Self {
         // TODO: Flatten `(or (or a b) (or x y))` into `(or a b c y)`.
         Self::Or(values.into_iter().collect())
     }
 
     #[inline(always)]
-    pub fn new_not(value: GoalDefinition<'a>) -> Self {
+    pub fn new_not(value: GoalDefinition) -> Self {
         Self::Not(Box::new(value))
     }
 
     #[inline(always)]
-    pub fn new_imply_tuple(tuple: (GoalDefinition<'a>, GoalDefinition<'a>)) -> Self {
+    pub fn new_imply_tuple(tuple: (GoalDefinition, GoalDefinition)) -> Self {
         Self::new_imply(tuple.0, tuple.1)
     }
 
     #[inline(always)]
-    pub fn new_imply(a: GoalDefinition<'a>, b: GoalDefinition<'a>) -> Self {
+    pub fn new_imply(a: GoalDefinition, b: GoalDefinition) -> Self {
         Self::Imply(Box::new(a), Box::new(b))
     }
 
     #[inline(always)]
-    pub fn new_exists_tuple(tuple: (TypedVariables<'a>, GoalDefinition<'a>)) -> Self {
+    pub fn new_exists_tuple(tuple: (TypedVariables, GoalDefinition)) -> Self {
         Self::new_exists(tuple.0, tuple.1)
     }
 
     #[inline(always)]
-    pub fn new_exists(variables: TypedVariables<'a>, gd: GoalDefinition<'a>) -> Self {
+    pub fn new_exists(variables: TypedVariables, gd: GoalDefinition) -> Self {
         Self::Exists(variables, Box::new(gd))
     }
 
     #[inline(always)]
-    pub fn new_forall_tuple(tuple: (TypedVariables<'a>, GoalDefinition<'a>)) -> Self {
+    pub fn new_forall_tuple(tuple: (TypedVariables, GoalDefinition)) -> Self {
         Self::new_forall(tuple.0, tuple.1)
     }
 
     #[inline(always)]
-    pub fn new_forall(variables: TypedVariables<'a>, gd: GoalDefinition<'a>) -> Self {
+    pub fn new_forall(variables: TypedVariables, gd: GoalDefinition) -> Self {
         Self::ForAll(variables, Box::new(gd))
     }
 
     #[inline(always)]
-    pub const fn new_f_comp(f_comp: FComp<'a>) -> Self {
+    pub const fn new_f_comp(f_comp: FComp) -> Self {
         Self::FComp(f_comp)
     }
 

--- a/src/types/goal_def.rs
+++ b/src/types/goal_def.rs
@@ -9,53 +9,53 @@ use std::ops::Deref;
 /// ## Usage
 /// Used by [`Problem`](crate::Problem).
 #[derive(Debug, Clone, PartialEq)]
-pub struct GoalDef<'a>(PreconditionGoalDefinitions<'a>);
+pub struct GoalDef(PreconditionGoalDefinitions);
 
-impl<'a> GoalDef<'a> {
-    pub const fn new(gd: PreconditionGoalDefinitions<'a>) -> Self {
+impl GoalDef {
+    pub const fn new(gd: PreconditionGoalDefinitions) -> Self {
         Self(gd)
     }
 
     /// Gets the value.
-    pub const fn value(&self) -> &PreconditionGoalDefinitions<'a> {
+    pub const fn value(&self) -> &PreconditionGoalDefinitions {
         &self.0
     }
 }
 
-impl<'a> PartialEq<PreconditionGoalDefinitions<'a>> for GoalDef<'a> {
-    fn eq(&self, other: &PreconditionGoalDefinitions<'a>) -> bool {
+impl PartialEq<PreconditionGoalDefinitions> for GoalDef {
+    fn eq(&self, other: &PreconditionGoalDefinitions) -> bool {
         self.0.eq(other)
     }
 }
 
-impl<'a> From<PreconditionGoalDefinitions<'a>> for GoalDef<'a> {
-    fn from(value: PreconditionGoalDefinitions<'a>) -> Self {
+impl From<PreconditionGoalDefinitions> for GoalDef {
+    fn from(value: PreconditionGoalDefinitions) -> Self {
         Self::new(value)
     }
 }
 
-impl<'a> From<PreconditionGoalDefinition<'a>> for GoalDef<'a> {
-    fn from(value: PreconditionGoalDefinition<'a>) -> Self {
+impl From<PreconditionGoalDefinition> for GoalDef {
+    fn from(value: PreconditionGoalDefinition) -> Self {
         Self::new(PreconditionGoalDefinitions::from(value))
     }
 }
 
-impl<'a> FromIterator<PreconditionGoalDefinition<'a>> for GoalDef<'a> {
-    fn from_iter<T: IntoIterator<Item = PreconditionGoalDefinition<'a>>>(iter: T) -> Self {
+impl FromIterator<PreconditionGoalDefinition> for GoalDef {
+    fn from_iter<T: IntoIterator<Item = PreconditionGoalDefinition>>(iter: T) -> Self {
         GoalDef::new(PreconditionGoalDefinitions::from_iter(iter))
     }
 }
 
-impl<'a> Deref for GoalDef<'a> {
-    type Target = PreconditionGoalDefinitions<'a>;
+impl Deref for GoalDef {
+    type Target = PreconditionGoalDefinitions;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<'a> Into<PreconditionGoalDefinitions<'a>> for GoalDef<'a> {
-    fn into(self) -> PreconditionGoalDefinitions<'a> {
+impl Into<PreconditionGoalDefinitions> for GoalDef {
+    fn into(self) -> PreconditionGoalDefinitions {
         self.0
     }
 }

--- a/src/types/init_el.rs
+++ b/src/types/init_el.rs
@@ -5,33 +5,33 @@ use crate::types::{BasicFunctionTerm, Name, NameLiteral, Number};
 /// ## Usage
 /// Used by [`InitElements`](crate::InitElements) in [`Problem`](crate::Problem).
 #[derive(Debug, Clone, PartialEq)]
-pub enum InitElement<'a> {
-    Literal(NameLiteral<'a>),
+pub enum InitElement {
+    Literal(NameLiteral),
     /// ## Requirements
     /// Requires [Timed Initial Literals](crate::Requirement::TimedInitialLiterals).
-    At(Number, NameLiteral<'a>),
+    At(Number, NameLiteral),
     /// ## Requirements
     /// Requires [Numeric Fluents](crate::Requirement::NumericFluents).
-    IsValue(BasicFunctionTerm<'a>, Number),
+    IsValue(BasicFunctionTerm, Number),
     /// ## Requirements
     /// Requires [Object Fluents](crate::Requirement::ObjectFluents).
-    IsObject(BasicFunctionTerm<'a>, Name<'a>),
+    IsObject(BasicFunctionTerm, Name),
 }
 
-impl<'a> InitElement<'a> {
-    pub const fn new_literal(name: NameLiteral<'a>) -> Self {
+impl InitElement {
+    pub const fn new_literal(name: NameLiteral) -> Self {
         Self::Literal(name)
     }
 
-    pub const fn new_at(time: Number, name: NameLiteral<'a>) -> Self {
+    pub const fn new_at(time: Number, name: NameLiteral) -> Self {
         Self::At(time, name)
     }
 
-    pub const fn new_is_value(term: BasicFunctionTerm<'a>, value: Number) -> Self {
+    pub const fn new_is_value(term: BasicFunctionTerm, value: Number) -> Self {
         Self::IsValue(term, value)
     }
 
-    pub const fn new_is_object(term: BasicFunctionTerm<'a>, value: Name<'a>) -> Self {
+    pub const fn new_is_object(term: BasicFunctionTerm, value: Name) -> Self {
         Self::IsObject(term, value)
     }
 }

--- a/src/types/init_els.rs
+++ b/src/types/init_els.rs
@@ -8,29 +8,29 @@ use std::ops::Deref;
 /// ## Usage
 /// Used by [`Problem`](crate::Problem).
 #[derive(Debug, Clone, PartialEq)]
-pub struct InitElements<'a>(Vec<InitElement<'a>>);
+pub struct InitElements(Vec<InitElement>);
 
-impl<'a> InitElements<'a> {
-    pub const fn new(iter: Vec<InitElement<'a>>) -> Self {
+impl InitElements {
+    pub const fn new(iter: Vec<InitElement>) -> Self {
         Self(iter)
     }
 
     /// Gets the values.
-    pub fn values(&self) -> &[InitElement<'a>] {
+    pub fn values(&self) -> &[InitElement] {
         self.0.as_slice()
     }
 }
 
-impl<'a> Deref for InitElements<'a> {
-    type Target = [InitElement<'a>];
+impl Deref for InitElements {
+    type Target = [InitElement];
 
     fn deref(&self) -> &Self::Target {
         self.0.as_slice()
     }
 }
 
-impl<'a> FromIterator<InitElement<'a>> for InitElements<'a> {
-    fn from_iter<T: IntoIterator<Item = InitElement<'a>>>(iter: T) -> Self {
+impl FromIterator<InitElement> for InitElements {
+    fn from_iter<T: IntoIterator<Item = InitElement>>(iter: T) -> Self {
         InitElements::new(iter.into_iter().collect())
     }
 }

--- a/src/types/literal.rs
+++ b/src/types/literal.rs
@@ -35,13 +35,13 @@ impl<'a, T> From<AtomicFormula<'a, T>> for Literal<'a, T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::parsers::{atomic_formula, parse_term};
+    use crate::parsers::{atomic_formula, parse_term, Span};
     use crate::Term;
 
     #[test]
     fn from_works() {
         let input = "(= x y)";
-        let (_, effect) = atomic_formula(parse_term)(input).unwrap();
+        let (_, effect) = atomic_formula(parse_term)(Span::new(input)).unwrap();
 
         let literal: Literal<Term> = effect.into();
         assert_eq!(

--- a/src/types/literal.rs
+++ b/src/types/literal.rs
@@ -7,17 +7,17 @@ use crate::types::AtomicFormula;
 /// ## Usage
 /// Used by [`GoalDefinition`](crate::GoalDefinition) and [`InitElement`](crate::InitElement).
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub enum Literal<'a, T> {
-    AtomicFormula(AtomicFormula<'a, T>),
-    NotAtomicFormula(AtomicFormula<'a, T>),
+pub enum Literal<T> {
+    AtomicFormula(AtomicFormula<T>),
+    NotAtomicFormula(AtomicFormula<T>),
 }
 
-impl<'a, T> Literal<'a, T> {
-    pub const fn new(atomic_formula: AtomicFormula<'a, T>) -> Self {
+impl<'a, T> Literal<T> {
+    pub const fn new(atomic_formula: AtomicFormula<T>) -> Self {
         Self::AtomicFormula(atomic_formula)
     }
 
-    pub const fn new_not(atomic_formula: AtomicFormula<'a, T>) -> Self {
+    pub const fn new_not(atomic_formula: AtomicFormula<T>) -> Self {
         Self::NotAtomicFormula(atomic_formula)
     }
 
@@ -26,8 +26,8 @@ impl<'a, T> Literal<'a, T> {
     }
 }
 
-impl<'a, T> From<AtomicFormula<'a, T>> for Literal<'a, T> {
-    fn from(value: AtomicFormula<'a, T>) -> Self {
+impl<'a, T> From<AtomicFormula<T>> for Literal<T> {
+    fn from(value: AtomicFormula<T>) -> Self {
         Literal::new(value)
     }
 }

--- a/src/types/metric_f_exp.rs
+++ b/src/types/metric_f_exp.rs
@@ -10,19 +10,19 @@ use crate::types::{BinaryOp, FunctionSymbol, MultiOp, Name, Number, PreferenceNa
 /// ## Usage
 /// Used by [`MetricSpec`](crate::MetricSpec).
 #[derive(Debug, Clone, PartialEq)]
-pub enum MetricFExp<'a> {
+pub enum MetricFExp {
     BinaryOp(BinaryOp, Box<Self>, Box<Self>),
     MultiOp(MultiOp, Box<Self>, Vec<Self>),
     Negative(Box<Self>),
     Number(Number),
-    Function(FunctionSymbol<'a>, Vec<Name<'a>>),
+    Function(FunctionSymbol, Vec<Name>),
     TotalTime,
     /// ## Requirements
     /// Requires [Preferences](crate::Requirement::Preferences).
-    IsViolated(PreferenceName<'a>),
+    IsViolated(PreferenceName),
 }
 
-impl<'a> MetricFExp<'a> {
+impl MetricFExp {
     pub fn new_binary_op(op: BinaryOp, lhs: Self, rhs: Self) -> Self {
         Self::BinaryOp(op, Box::new(lhs), Box::new(rhs))
     }
@@ -44,10 +44,7 @@ impl<'a> MetricFExp<'a> {
         Self::Number(number.into())
     }
 
-    pub fn new_function<I: IntoIterator<Item = Name<'a>>>(
-        symbol: FunctionSymbol<'a>,
-        names: I,
-    ) -> Self {
+    pub fn new_function<I: IntoIterator<Item = Name>>(symbol: FunctionSymbol, names: I) -> Self {
         Self::Function(symbol, names.into_iter().collect())
     }
 
@@ -55,7 +52,7 @@ impl<'a> MetricFExp<'a> {
         Self::TotalTime
     }
 
-    pub const fn new_is_violated(pref: PreferenceName<'a>) -> Self {
+    pub const fn new_is_violated(pref: PreferenceName) -> Self {
         Self::IsViolated(pref)
     }
 }

--- a/src/types/metric_spec.rs
+++ b/src/types/metric_spec.rs
@@ -7,13 +7,13 @@ use crate::types::{MetricFExp, Optimization};
 /// ## Requirements
 /// Requires [Numeric Fluents](crate::Requirement::NumericFluents).
 #[derive(Debug, Clone, PartialEq)]
-pub struct MetricSpec<'a> {
+pub struct MetricSpec {
     optimization: Optimization,
-    exp: MetricFExp<'a>,
+    exp: MetricFExp,
 }
 
-impl<'a> MetricSpec<'a> {
-    pub const fn new(optimization: Optimization, exp: MetricFExp<'a>) -> Self {
+impl MetricSpec {
+    pub const fn new(optimization: Optimization, exp: MetricFExp) -> Self {
         Self { optimization, exp }
     }
 
@@ -23,7 +23,7 @@ impl<'a> MetricSpec<'a> {
     }
 
     /// Gets the expression to optimize.
-    pub const fn expression(&self) -> &MetricFExp<'a> {
+    pub const fn expression(&self) -> &MetricFExp {
         &self.exp
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -161,8 +161,8 @@ pub use variable::Variable;
 #[allow(unused_imports)]
 pub(crate) use r#type::{TYPE_NUMBER, TYPE_OBJECT};
 
-pub type NameLiteral<'a> = Literal<'a, Name<'a>>;
-pub type TermLiteral<'a> = Literal<'a, Term<'a>>;
+pub type NameLiteral = Literal<Name>;
+pub type TermLiteral = Literal<Term>;
 
-pub type TypedVariables<'a> = TypedList<'a, Variable<'a>>;
-pub type TypedNames<'a> = TypedList<'a, Name<'a>>;
+pub type TypedVariables = TypedList<Variable>;
+pub type TypedNames = TypedList<Name>;

--- a/src/types/objects.rs
+++ b/src/types/objects.rs
@@ -8,33 +8,33 @@ use std::ops::Deref;
 /// ## Usage
 /// Used by [`Problem`](crate::Problem).
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
-pub struct Objects<'a>(TypedNames<'a>);
+pub struct Objects(TypedNames);
 
-impl<'a> Objects<'a> {
+impl Objects {
     // TODO: Convert to const again that takes `TypedNames` directly.
-    pub fn new<I: IntoIterator<Item = Typed<'a, Name<'a>>>>(objects: I) -> Self {
+    pub fn new<I: IntoIterator<Item = Typed<Name>>>(objects: I) -> Self {
         Self(objects.into_iter().collect())
     }
 
-    pub fn values(&self) -> &TypedNames<'a> {
+    pub fn values(&self) -> &TypedNames {
         &self.0
     }
 }
 
-impl<'a> From<TypedNames<'a>> for Objects<'a> {
-    fn from(value: TypedNames<'a>) -> Self {
+impl From<TypedNames> for Objects {
+    fn from(value: TypedNames) -> Self {
         Self(value)
     }
 }
 
-impl<'a> FromIterator<Typed<'a, Name<'a>>> for Objects<'a> {
-    fn from_iter<T: IntoIterator<Item = Typed<'a, Name<'a>>>>(iter: T) -> Self {
+impl FromIterator<Typed<Name>> for Objects {
+    fn from_iter<T: IntoIterator<Item = Typed<Name>>>(iter: T) -> Self {
         Objects::new(TypedNames::from_iter(iter))
     }
 }
 
-impl<'a> Deref for Objects<'a> {
-    type Target = TypedNames<'a>;
+impl Deref for Objects {
+    type Target = TypedNames;
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target {

--- a/src/types/p_effect.rs
+++ b/src/types/p_effect.rs
@@ -8,31 +8,31 @@ use crate::types::{AssignOp, AtomicFormula, FExp, FHead, FunctionTerm, Term};
 /// ## Usage
 /// Used by [`CEffect`](crate::CEffect) and [`ConditionalEffect`](crate::ConditionalEffect).
 #[derive(Debug, Clone, PartialEq)]
-pub enum PEffect<'a> {
-    AtomicFormula(AtomicFormula<'a, Term<'a>>),
-    NotAtomicFormula(AtomicFormula<'a, Term<'a>>),
+pub enum PEffect {
+    AtomicFormula(AtomicFormula<Term>),
+    NotAtomicFormula(AtomicFormula<Term>),
     /// ## Requirements
     /// Requires [Numeric Fluents](crate::Requirement::NumericFluents).
-    AssignNumericFluent(AssignOp, FHead<'a>, FExp<'a>),
+    AssignNumericFluent(AssignOp, FHead, FExp),
     /// ## Requirements
     /// Requires [Object Fluents](crate::Requirement::ObjectFluents).
-    AssignObjectFluent(FunctionTerm<'a>, Option<Term<'a>>),
+    AssignObjectFluent(FunctionTerm, Option<Term>),
 }
 
-impl<'a> PEffect<'a> {
-    pub const fn new(atomic_formula: AtomicFormula<'a, Term<'a>>) -> Self {
+impl PEffect {
+    pub const fn new(atomic_formula: AtomicFormula<Term>) -> Self {
         Self::AtomicFormula(atomic_formula)
     }
 
-    pub const fn new_not(atomic_formula: AtomicFormula<'a, Term<'a>>) -> Self {
+    pub const fn new_not(atomic_formula: AtomicFormula<Term>) -> Self {
         Self::NotAtomicFormula(atomic_formula)
     }
 
-    pub const fn new_numeric_fluent(op: AssignOp, head: FHead<'a>, exp: FExp<'a>) -> Self {
+    pub const fn new_numeric_fluent(op: AssignOp, head: FHead, exp: FExp) -> Self {
         Self::AssignNumericFluent(op, head, exp)
     }
 
-    pub const fn new_object_fluent(f_term: FunctionTerm<'a>, term: Option<Term<'a>>) -> Self {
+    pub const fn new_object_fluent(f_term: FunctionTerm, term: Option<Term>) -> Self {
         Self::AssignObjectFluent(f_term, term)
     }
 }

--- a/src/types/pre_gd.rs
+++ b/src/types/pre_gd.rs
@@ -9,21 +9,21 @@ use std::ops::Deref;
 /// ## Usage
 /// Used by [`GoalDef`](crate::GoalDef), as well as [`ActionDefinition`](crate::ActionDefinition).
 #[derive(Debug, Clone, PartialEq, Default)]
-pub struct PreconditionGoalDefinitions<'a>(Vec<PreconditionGoalDefinition<'a>>);
+pub struct PreconditionGoalDefinitions(Vec<PreconditionGoalDefinition>);
 
-impl<'a> PreconditionGoalDefinitions<'a> {
+impl PreconditionGoalDefinitions {
     /// Constructs a new instance from the provided vector of values.
-    pub const fn new(values: Vec<PreconditionGoalDefinition<'a>>) -> Self {
+    pub const fn new(values: Vec<PreconditionGoalDefinition>) -> Self {
         Self(values)
     }
 
     /// Constructs a list containing a single [`PreconditionGoalDefinition::Preference`] variant.
-    pub fn new_preference(pref: PreferenceGD<'a>) -> Self {
+    pub fn new_preference(pref: PreferenceGD) -> Self {
         PreconditionGoalDefinition::new_preference(pref).into()
     }
 
     /// Constructs a list containing a single [`PreconditionGoalDefinition::Forall`] variant.
-    pub fn new_forall(variables: TypedVariables<'a>, gd: PreconditionGoalDefinitions<'a>) -> Self {
+    pub fn new_forall(variables: TypedVariables, gd: PreconditionGoalDefinitions) -> Self {
         PreconditionGoalDefinition::new_forall(variables, gd).into()
     }
 
@@ -41,13 +41,13 @@ impl<'a> PreconditionGoalDefinitions<'a> {
     /// Returns an iterator over the list.
     ///
     /// The iterator yields all items from start to end.
-    pub fn iter(&'a self) -> std::slice::Iter<'a, PreconditionGoalDefinition<'a>> {
+    pub fn iter(&self) -> std::slice::Iter<PreconditionGoalDefinition> {
         self.0.iter()
     }
 
     /// Get the only element of this list if the list has
     /// exactly one element. Returns [`None`] in all other cases.
-    pub fn try_get_single(self) -> Option<PreconditionGoalDefinition<'a>> {
+    pub fn try_get_single(self) -> Option<PreconditionGoalDefinition> {
         if self.len() == 1 {
             self.into_iter().next()
         } else {
@@ -56,43 +56,43 @@ impl<'a> PreconditionGoalDefinitions<'a> {
     }
 }
 
-impl<'a> FromIterator<PreconditionGoalDefinition<'a>> for PreconditionGoalDefinitions<'a> {
-    fn from_iter<T: IntoIterator<Item = PreconditionGoalDefinition<'a>>>(iter: T) -> Self {
+impl FromIterator<PreconditionGoalDefinition> for PreconditionGoalDefinitions {
+    fn from_iter<T: IntoIterator<Item = PreconditionGoalDefinition>>(iter: T) -> Self {
         PreconditionGoalDefinitions::new(iter.into_iter().collect())
     }
 }
 
-impl<'a> Deref for PreconditionGoalDefinitions<'a> {
-    type Target = [PreconditionGoalDefinition<'a>];
+impl Deref for PreconditionGoalDefinitions {
+    type Target = [PreconditionGoalDefinition];
 
     fn deref(&self) -> &Self::Target {
         self.0.as_slice()
     }
 }
 
-impl<'a> AsRef<[PreconditionGoalDefinition<'a>]> for PreconditionGoalDefinitions<'a> {
-    fn as_ref(&self) -> &[PreconditionGoalDefinition<'a>] {
+impl AsRef<[PreconditionGoalDefinition]> for PreconditionGoalDefinitions {
+    fn as_ref(&self) -> &[PreconditionGoalDefinition] {
         self.0.as_slice()
     }
 }
 
-impl<'a> IntoIterator for PreconditionGoalDefinitions<'a> {
-    type Item = PreconditionGoalDefinition<'a>;
-    type IntoIter = std::vec::IntoIter<PreconditionGoalDefinition<'a>>;
+impl IntoIterator for PreconditionGoalDefinitions {
+    type Item = PreconditionGoalDefinition;
+    type IntoIter = std::vec::IntoIter<PreconditionGoalDefinition>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
     }
 }
 
-impl<'a> From<PreconditionGoalDefinition<'a>> for PreconditionGoalDefinitions<'a> {
-    fn from(value: PreconditionGoalDefinition<'a>) -> Self {
+impl From<PreconditionGoalDefinition> for PreconditionGoalDefinitions {
+    fn from(value: PreconditionGoalDefinition) -> Self {
         PreconditionGoalDefinitions::new(vec![value])
     }
 }
 
-impl<'a> From<Option<PreconditionGoalDefinition<'a>>> for PreconditionGoalDefinitions<'a> {
-    fn from(value: Option<PreconditionGoalDefinition<'a>>) -> Self {
+impl From<Option<PreconditionGoalDefinition>> for PreconditionGoalDefinitions {
+    fn from(value: Option<PreconditionGoalDefinition>) -> Self {
         match value {
             None => PreconditionGoalDefinitions::default(),
             Some(value) => value.into(),
@@ -100,8 +100,8 @@ impl<'a> From<Option<PreconditionGoalDefinition<'a>>> for PreconditionGoalDefini
     }
 }
 
-impl<'a> From<Option<PreconditionGoalDefinitions<'a>>> for PreconditionGoalDefinitions<'a> {
-    fn from(value: Option<PreconditionGoalDefinitions<'a>>) -> Self {
+impl From<Option<PreconditionGoalDefinitions>> for PreconditionGoalDefinitions {
+    fn from(value: Option<PreconditionGoalDefinitions>) -> Self {
         match value {
             None => PreconditionGoalDefinitions::default(),
             Some(values) => values,
@@ -109,16 +109,16 @@ impl<'a> From<Option<PreconditionGoalDefinitions<'a>>> for PreconditionGoalDefin
     }
 }
 
-impl<'a> From<PreconditionGoalDefinitions<'a>> for Vec<PreconditionGoalDefinition<'a>> {
-    fn from(value: PreconditionGoalDefinitions<'a>) -> Self {
+impl From<PreconditionGoalDefinitions> for Vec<PreconditionGoalDefinition> {
+    fn from(value: PreconditionGoalDefinitions) -> Self {
         value.0
     }
 }
 
-impl<'a> TryInto<PreconditionGoalDefinition<'a>> for PreconditionGoalDefinitions<'a> {
+impl TryInto<PreconditionGoalDefinition> for PreconditionGoalDefinitions {
     type Error = ();
 
-    fn try_into(self) -> Result<PreconditionGoalDefinition<'a>, Self::Error> {
+    fn try_into(self) -> Result<PreconditionGoalDefinition, Self::Error> {
         self.try_get_single().ok_or(())
     }
 }
@@ -128,46 +128,43 @@ impl<'a> TryInto<PreconditionGoalDefinition<'a>> for PreconditionGoalDefinitions
 /// ## Usage
 /// Used by [`PreconditionGoalDefinitions`].
 #[derive(Debug, Clone, PartialEq)]
-pub enum PreconditionGoalDefinition<'a> {
+pub enum PreconditionGoalDefinition {
     /// ## Requirements
     /// None per se: this branch may expand into [`PreferenceGD::Goal`](PreferenceGD::Goal),
     /// which has no requirements.
-    Preference(PreferenceGD<'a>),
+    Preference(PreferenceGD),
     /// ## Requirements
     /// Requires [Universal Preconditions](crate::Requirement::UniversalPreconditions).
-    Forall(TypedVariables<'a>, PreconditionGoalDefinitions<'a>),
+    Forall(TypedVariables, PreconditionGoalDefinitions),
 }
 
-impl<'a> PreconditionGoalDefinition<'a> {
-    pub fn new_and<I: IntoIterator<Item = PreconditionGoalDefinition<'a>>>(
+impl PreconditionGoalDefinition {
+    pub fn new_and<I: IntoIterator<Item = PreconditionGoalDefinition>>(
         iter: I,
-    ) -> PreconditionGoalDefinitions<'a> {
+    ) -> PreconditionGoalDefinitions {
         // TODO: Flatten `(and (and a b) (and x y))` into `(and a b c y)`.
         PreconditionGoalDefinitions::from_iter(iter)
     }
 
     /// Constructs a new [`Preference`](Self::Preference) variant.
-    pub const fn new_preference(pref: PreferenceGD<'a>) -> Self {
+    pub const fn new_preference(pref: PreferenceGD) -> Self {
         Self::Preference(pref)
     }
 
     /// Constructs a new [`Forall`](Self::Forall) variant.
-    pub const fn new_forall(
-        variables: TypedVariables<'a>,
-        gd: PreconditionGoalDefinitions<'a>,
-    ) -> Self {
+    pub const fn new_forall(variables: TypedVariables, gd: PreconditionGoalDefinitions) -> Self {
         Self::Forall(variables, gd)
     }
 }
 
-impl<'a> From<PreferenceGD<'a>> for PreconditionGoalDefinition<'a> {
-    fn from(value: PreferenceGD<'a>) -> Self {
+impl From<PreferenceGD> for PreconditionGoalDefinition {
+    fn from(value: PreferenceGD) -> Self {
         PreconditionGoalDefinition::new_preference(value)
     }
 }
 
-impl<'a> From<Preference<'a>> for PreconditionGoalDefinition<'a> {
-    fn from(value: Preference<'a>) -> Self {
+impl From<Preference> for PreconditionGoalDefinition {
+    fn from(value: Preference) -> Self {
         PreconditionGoalDefinition::new_preference(PreferenceGD::from_preference(value))
     }
 }

--- a/src/types/predicate.rs
+++ b/src/types/predicate.rs
@@ -8,28 +8,33 @@ use std::ops::Deref;
 /// ## Usage
 /// Used by [`AtomicFormulaSkeleton`](crate::AtomicFormulaSkeleton) and [`AtomicFormula`](crate::AtomicFormula).
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Default)]
-pub struct Predicate<'a>(Name<'a>);
+pub struct Predicate(Name);
 
-impl<'a> Predicate<'a> {
+impl Predicate {
     #[inline(always)]
-    pub fn new(name: Name<'a>) -> Self {
+    pub const fn new(name: Name) -> Self {
         Self(name)
     }
 
     #[inline(always)]
-    pub const fn from_str(name: &'a str) -> Self {
+    pub fn from_str(name: &str) -> Self {
         Self(Name::new(name))
     }
 
     #[inline(always)]
-    pub const fn from_name(name: Name<'a>) -> Self {
+    pub const fn from_static(name: &'static str) -> Self {
+        Self(Name::new_static(name))
+    }
+
+    #[inline(always)]
+    pub const fn from_name(name: Name) -> Self {
         Self(name)
     }
 }
 
-impl<'a, T> From<T> for Predicate<'a>
+impl<'a, T> From<T> for Predicate
 where
-    T: Into<Name<'a>>,
+    T: Into<Name>,
 {
     #[inline(always)]
     fn from(value: T) -> Self {
@@ -37,22 +42,22 @@ where
     }
 }
 
-impl<'a> AsRef<Name<'a>> for Predicate<'a> {
+impl AsRef<Name> for Predicate {
     #[inline(always)]
-    fn as_ref(&self) -> &Name<'a> {
+    fn as_ref(&self) -> &Name {
         &self.0
     }
 }
 
-impl<'a> AsRef<str> for Predicate<'a> {
+impl AsRef<str> for Predicate {
     #[inline(always)]
     fn as_ref(&self) -> &str {
         self.0.as_ref()
     }
 }
 
-impl<'a> Deref for Predicate<'a> {
-    type Target = Name<'a>;
+impl Deref for Predicate {
+    type Target = Name;
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target {

--- a/src/types/predicate_definitions.rs
+++ b/src/types/predicate_definitions.rs
@@ -8,39 +8,39 @@ use std::ops::Deref;
 /// ## Usage
 /// Used by [`Domain`](crate::Domain).
 #[derive(Debug, Default, Clone, Eq, PartialEq)]
-pub struct PredicateDefinitions<'a>(Vec<AtomicFormulaSkeleton<'a>>);
+pub struct PredicateDefinitions(Vec<AtomicFormulaSkeleton>);
 
-impl<'a> PredicateDefinitions<'a> {
-    pub fn new<I: IntoIterator<Item = AtomicFormulaSkeleton<'a>>>(predicates: I) -> Self {
+impl PredicateDefinitions {
+    pub fn new<I: IntoIterator<Item = AtomicFormulaSkeleton>>(predicates: I) -> Self {
         Self::from(predicates.into_iter().collect())
     }
 
-    pub const fn from(predicates: Vec<AtomicFormulaSkeleton<'a>>) -> Self {
+    pub const fn from(predicates: Vec<AtomicFormulaSkeleton>) -> Self {
         Self(predicates)
     }
 
     /// Gets the values.
-    pub fn values(&self) -> &[AtomicFormulaSkeleton<'a>] {
+    pub fn values(&self) -> &[AtomicFormulaSkeleton] {
         self.0.as_slice()
     }
 }
 
-impl<'a> Deref for PredicateDefinitions<'a> {
-    type Target = [AtomicFormulaSkeleton<'a>];
+impl Deref for PredicateDefinitions {
+    type Target = [AtomicFormulaSkeleton];
 
     fn deref(&self) -> &Self::Target {
         self.0.as_slice()
     }
 }
 
-impl<'a> From<Vec<AtomicFormulaSkeleton<'a>>> for PredicateDefinitions<'a> {
-    fn from(value: Vec<AtomicFormulaSkeleton<'a>>) -> Self {
+impl From<Vec<AtomicFormulaSkeleton>> for PredicateDefinitions {
+    fn from(value: Vec<AtomicFormulaSkeleton>) -> Self {
         PredicateDefinitions::new(value)
     }
 }
 
-impl<'a> FromIterator<AtomicFormulaSkeleton<'a>> for PredicateDefinitions<'a> {
-    fn from_iter<T: IntoIterator<Item = AtomicFormulaSkeleton<'a>>>(iter: T) -> Self {
+impl FromIterator<AtomicFormulaSkeleton> for PredicateDefinitions {
+    fn from_iter<T: IntoIterator<Item = AtomicFormulaSkeleton>>(iter: T) -> Self {
         PredicateDefinitions::new(iter)
     }
 }

--- a/src/types/pref_con_gd.rs
+++ b/src/types/pref_con_gd.rs
@@ -12,16 +12,16 @@ use std::ops::Deref;
 /// ## Usage
 /// Used by [`ProblemConstraintsDef`](crate::ProblemConstraintsDef).
 #[derive(Debug, Clone, PartialEq, Default)]
-pub struct PrefConGDs<'a>(Vec<PrefConGD<'a>>);
+pub struct PrefConGDs(Vec<PrefConGD>);
 
-impl<'a> PrefConGDs<'a> {
+impl PrefConGDs {
     /// Constructs a new instance from the provided vector of values.
-    pub const fn new(gds: Vec<PrefConGD<'a>>) -> Self {
+    pub const fn new(gds: Vec<PrefConGD>) -> Self {
         Self(gds)
     }
 
     /// Constructs a list containing a single [`PrefConGD::Goal`] variant.
-    pub fn new_goal(gd: ConGD<'a>) -> Self {
+    pub fn new_goal(gd: ConGD) -> Self {
         Self::new(vec![PrefConGD::new_goal(gd)])
     }
 
@@ -29,7 +29,7 @@ impl<'a> PrefConGDs<'a> {
     ///
     /// ## Requirements
     /// Requires [Preferences](crate::Requirement::Preferences).
-    pub fn new_preference(name: Option<PreferenceName<'a>>, gd: ConGD<'a>) -> Self {
+    pub fn new_preference(name: Option<PreferenceName>, gd: ConGD) -> Self {
         Self::new(vec![PrefConGD::new_preference(name, gd)])
     }
 
@@ -37,7 +37,7 @@ impl<'a> PrefConGDs<'a> {
     ///
     /// ## Requirements
     /// Requires [Universal Preconditions](crate::Requirement::UniversalPreconditions).
-    pub fn new_forall(variables: TypedVariables<'a>, gd: PrefConGDs<'a>) -> Self {
+    pub fn new_forall(variables: TypedVariables, gd: PrefConGDs) -> Self {
         Self::new(vec![PrefConGD::new_forall(variables, gd)])
     }
 
@@ -55,13 +55,13 @@ impl<'a> PrefConGDs<'a> {
     /// Returns an iterator over the list.
     ///
     /// The iterator yields all items from start to end.
-    pub fn iter(&'a self) -> std::slice::Iter<'a, PrefConGD<'a>> {
+    pub fn iter(&self) -> std::slice::Iter<PrefConGD> {
         self.0.iter()
     }
 
     /// Get the only element of this list if the list has
     /// exactly one element. Returns [`None`] in all other cases.
-    pub fn try_get_single(self) -> Option<PrefConGD<'a>> {
+    pub fn try_get_single(self) -> Option<PrefConGD> {
         if self.len() == 1 {
             self.into_iter().next()
         } else {
@@ -70,55 +70,55 @@ impl<'a> PrefConGDs<'a> {
     }
 }
 
-impl<'a> Deref for PrefConGDs<'a> {
-    type Target = [PrefConGD<'a>];
+impl Deref for PrefConGDs {
+    type Target = [PrefConGD];
 
     fn deref(&self) -> &Self::Target {
         self.0.as_slice()
     }
 }
 
-impl<'a> AsRef<[PrefConGD<'a>]> for PrefConGDs<'a> {
-    fn as_ref(&self) -> &[PrefConGD<'a>] {
+impl AsRef<[PrefConGD]> for PrefConGDs {
+    fn as_ref(&self) -> &[PrefConGD] {
         self.0.as_slice()
     }
 }
 
-impl<'a> IntoIterator for PrefConGDs<'a> {
-    type Item = PrefConGD<'a>;
-    type IntoIter = std::vec::IntoIter<PrefConGD<'a>>;
+impl IntoIterator for PrefConGDs {
+    type Item = PrefConGD;
+    type IntoIter = std::vec::IntoIter<PrefConGD>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
     }
 }
 
-impl<'a> From<PrefConGDs<'a>> for Vec<PrefConGD<'a>> {
-    fn from(value: PrefConGDs<'a>) -> Self {
+impl From<PrefConGDs> for Vec<PrefConGD> {
+    fn from(value: PrefConGDs) -> Self {
         value.0
     }
 }
 
-impl<'a> From<PrefConGD<'a>> for PrefConGDs<'a> {
-    fn from(value: PrefConGD<'a>) -> Self {
+impl From<PrefConGD> for PrefConGDs {
+    fn from(value: PrefConGD) -> Self {
         PrefConGDs::new(vec![value])
     }
 }
 
-impl<'a> From<Vec<PrefConGD<'a>>> for PrefConGDs<'a> {
-    fn from(value: Vec<PrefConGD<'a>>) -> Self {
+impl From<Vec<PrefConGD>> for PrefConGDs {
+    fn from(value: Vec<PrefConGD>) -> Self {
         PrefConGDs::new(value)
     }
 }
 
-impl<'a> FromIterator<PrefConGD<'a>> for PrefConGDs<'a> {
-    fn from_iter<T: IntoIterator<Item = PrefConGD<'a>>>(iter: T) -> Self {
+impl FromIterator<PrefConGD> for PrefConGDs {
+    fn from_iter<T: IntoIterator<Item = PrefConGD>>(iter: T) -> Self {
         PrefConGDs::new(iter.into_iter().collect())
     }
 }
 
-impl<'a> From<Option<PrefConGD<'a>>> for PrefConGDs<'a> {
-    fn from(value: Option<PrefConGD<'a>>) -> Self {
+impl From<Option<PrefConGD>> for PrefConGDs {
+    fn from(value: Option<PrefConGD>) -> Self {
         match value {
             None => PrefConGDs::default(),
             Some(value) => value.into(),
@@ -126,8 +126,8 @@ impl<'a> From<Option<PrefConGD<'a>>> for PrefConGDs<'a> {
     }
 }
 
-impl<'a> From<Option<PrefConGDs<'a>>> for PrefConGDs<'a> {
-    fn from(value: Option<PrefConGDs<'a>>) -> Self {
+impl From<Option<PrefConGDs>> for PrefConGDs {
+    fn from(value: Option<PrefConGDs>) -> Self {
         match value {
             None => PrefConGDs::default(),
             Some(values) => values,
@@ -135,16 +135,16 @@ impl<'a> From<Option<PrefConGDs<'a>>> for PrefConGDs<'a> {
     }
 }
 
-impl<'a> From<ConGD<'a>> for PrefConGDs<'a> {
-    fn from(value: ConGD<'a>) -> Self {
+impl From<ConGD> for PrefConGDs {
+    fn from(value: ConGD) -> Self {
         PrefConGDs::new_goal(value)
     }
 }
 
-impl<'a> TryInto<PrefConGD<'a>> for PrefConGDs<'a> {
+impl TryInto<PrefConGD> for PrefConGDs {
     type Error = ();
 
-    fn try_into(self) -> Result<PrefConGD<'a>, Self::Error> {
+    fn try_into(self) -> Result<PrefConGD, Self::Error> {
         self.try_get_single().ok_or(())
     }
 }
@@ -155,30 +155,30 @@ impl<'a> TryInto<PrefConGD<'a>> for PrefConGDs<'a> {
 /// ## Usage
 /// Used by [`PrefConGD`] itself, as well as [`ProblemConstraintsDef`](crate::ProblemConstraintsDef).
 #[derive(Debug, Clone, PartialEq)]
-pub enum PrefConGD<'a> {
-    Goal(ConGD<'a>),
+pub enum PrefConGD {
+    Goal(ConGD),
     /// ## Requirements
     /// Requires [Universal Preconditions](crate::Requirement::UniversalPreconditions).
-    Forall(TypedVariables<'a>, PrefConGDs<'a>),
+    Forall(TypedVariables, PrefConGDs),
     /// ## Requirements
     /// Requires [Preferences](crate::Requirement::Preferences).
-    Preference(Option<PreferenceName<'a>>, ConGD<'a>),
+    Preference(Option<PreferenceName>, ConGD),
 }
 
-impl<'a> PrefConGD<'a> {
-    pub const fn new_goal(gd: ConGD<'a>) -> Self {
+impl PrefConGD {
+    pub const fn new_goal(gd: ConGD) -> Self {
         Self::Goal(gd)
     }
 
     /// ## Requirements
     /// Requires [Universal Preconditions](crate::Requirement::UniversalPreconditions).
-    pub fn new_forall(variables: TypedVariables<'a>, gd: PrefConGDs<'a>) -> Self {
+    pub fn new_forall(variables: TypedVariables, gd: PrefConGDs) -> Self {
         Self::Forall(variables, gd)
     }
 
     /// ## Requirements
     /// Requires [Preferences](crate::Requirement::Preferences).
-    pub const fn new_preference(name: Option<PreferenceName<'a>>, gd: ConGD<'a>) -> Self {
+    pub const fn new_preference(name: Option<PreferenceName>, gd: ConGD) -> Self {
         Self::Preference(name, gd)
     }
 

--- a/src/types/pref_gd.rs
+++ b/src/types/pref_gd.rs
@@ -7,31 +7,31 @@ use crate::types::{GoalDefinition, Preference};
 /// ## Usage
 /// Used by [`PreconditionGoalDefinition`](crate::PreconditionGoalDefinition).
 #[derive(Debug, Clone, PartialEq)]
-pub enum PreferenceGD<'a> {
-    Goal(GoalDefinition<'a>),
+pub enum PreferenceGD {
+    Goal(GoalDefinition),
     /// ## Requirements
     /// Requires [Preferences](crate::Requirement::Preferences).
-    Preference(Preference<'a>),
+    Preference(Preference),
 }
 
-impl<'a> PreferenceGD<'a> {
-    pub const fn from_gd(gd: GoalDefinition<'a>) -> Self {
+impl PreferenceGD {
+    pub const fn from_gd(gd: GoalDefinition) -> Self {
         Self::Goal(gd)
     }
 
-    pub fn from_preference(pref: Preference<'a>) -> Self {
+    pub fn from_preference(pref: Preference) -> Self {
         Self::Preference(pref)
     }
 }
 
-impl<'a> From<GoalDefinition<'a>> for PreferenceGD<'a> {
-    fn from(value: GoalDefinition<'a>) -> Self {
+impl From<GoalDefinition> for PreferenceGD {
+    fn from(value: GoalDefinition) -> Self {
         PreferenceGD::from_gd(value)
     }
 }
 
-impl<'a> From<Preference<'a>> for PreferenceGD<'a> {
-    fn from(value: Preference<'a>) -> Self {
+impl From<Preference> for PreferenceGD {
+    fn from(value: Preference) -> Self {
         PreferenceGD::from_preference(value)
     }
 }

--- a/src/types/pref_name.rs
+++ b/src/types/pref_name.rs
@@ -9,36 +9,41 @@ use std::ops::Deref;
 /// Used by [`PrefGD`](crate::PreferenceGD), [`PrefTimedGD`](crate::PrefTimedGD),
 /// [`PrefConGD`](crate::PrefConGD) and [`MetricFExp`](crate::MetricFExp).
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct PreferenceName<'a>(Name<'a>);
+pub struct PreferenceName(Name);
 
-impl<'a> PreferenceName<'a> {
+impl PreferenceName {
     #[inline(always)]
-    pub fn new<N: Into<Name<'a>>>(name: N) -> Self {
+    pub fn new<N: Into<Name>>(name: N) -> Self {
         Self(name.into())
     }
 
     #[inline(always)]
-    pub const fn from_str(name: &'a str) -> Self {
+    pub fn from_str(name: &str) -> Self {
         Self(Name::new(name))
     }
 
     #[inline(always)]
-    pub const fn from_name(name: Name<'a>) -> Self {
+    pub const fn from_static(name: &'static str) -> Self {
+        Self(Name::new_static(name))
+    }
+
+    #[inline(always)]
+    pub const fn from_name(name: Name) -> Self {
         Self(name)
     }
 }
 
-impl<'a> Deref for PreferenceName<'a> {
-    type Target = Name<'a>;
+impl Deref for PreferenceName {
+    type Target = Name;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<'a, T> From<T> for PreferenceName<'a>
+impl<'a, T> From<T> for PreferenceName
 where
-    T: Into<Name<'a>>,
+    T: Into<Name>,
 {
     fn from(value: T) -> Self {
         PreferenceName::new(value.into())

--- a/src/types/pref_timed_gd.rs
+++ b/src/types/pref_timed_gd.rs
@@ -7,31 +7,31 @@ use crate::types::{PreferenceName, TimedGD};
 /// ## Usage
 /// Used by [`DurativeActionGoalDefinition`](crate::DurativeActionGoalDefinition).
 #[derive(Debug, Clone, PartialEq)]
-pub enum PrefTimedGD<'a> {
-    Required(TimedGD<'a>),
+pub enum PrefTimedGD {
+    Required(TimedGD),
     /// ## Requirements
     /// Requires [Preferences](crate::Requirement::Preferences).
-    Preference(Option<PreferenceName<'a>>, TimedGD<'a>),
+    Preference(Option<PreferenceName>, TimedGD),
 }
 
-impl<'a> PrefTimedGD<'a> {
-    pub const fn new_required(gd: TimedGD<'a>) -> Self {
+impl PrefTimedGD {
+    pub const fn new_required(gd: TimedGD) -> Self {
         Self::Required(gd)
     }
 
-    pub const fn new_preference(name: Option<PreferenceName<'a>>, gd: TimedGD<'a>) -> Self {
+    pub const fn new_preference(name: Option<PreferenceName>, gd: TimedGD) -> Self {
         Self::Preference(name, gd)
     }
 }
 
-impl<'a> From<TimedGD<'a>> for PrefTimedGD<'a> {
-    fn from(value: TimedGD<'a>) -> Self {
+impl From<TimedGD> for PrefTimedGD {
+    fn from(value: TimedGD) -> Self {
         PrefTimedGD::Required(value)
     }
 }
 
-impl<'a> From<(Option<PreferenceName<'a>>, TimedGD<'a>)> for PrefTimedGD<'a> {
-    fn from(value: (Option<PreferenceName<'a>>, TimedGD<'a>)) -> Self {
+impl From<(Option<PreferenceName>, TimedGD)> for PrefTimedGD {
+    fn from(value: (Option<PreferenceName>, TimedGD)) -> Self {
         PrefTimedGD::Preference(value.0, value.1)
     }
 }

--- a/src/types/preference.rs
+++ b/src/types/preference.rs
@@ -10,20 +10,20 @@ use crate::types::{GoalDefinition, PreferenceName};
 /// ## Usage
 /// Used by [`PreferenceGD`](crate::PreferenceGD).
 #[derive(Debug, Clone, PartialEq)]
-pub struct Preference<'a>(Option<PreferenceName<'a>>, GoalDefinition<'a>); // TODO: A similar type is used for PrefConGD
+pub struct Preference(Option<PreferenceName>, GoalDefinition); // TODO: A similar type is used for PrefConGD
 
-impl<'a> Preference<'a> {
-    pub const fn new(name: Option<PreferenceName<'a>>, gd: GoalDefinition<'a>) -> Self {
+impl Preference {
+    pub const fn new(name: Option<PreferenceName>, gd: GoalDefinition) -> Self {
         Self(name, gd)
     }
 
     /// Gets the optional preference name.
-    pub fn name(&self) -> &Option<PreferenceName<'a>> {
+    pub fn name(&self) -> &Option<PreferenceName> {
         &self.0
     }
 
     /// Gets the goal definition.
-    pub fn goal(&self) -> &GoalDefinition<'a> {
+    pub fn goal(&self) -> &GoalDefinition {
         &self.1
     }
 
@@ -32,20 +32,20 @@ impl<'a> Preference<'a> {
     }
 }
 
-impl<'a> From<(Option<PreferenceName<'a>>, GoalDefinition<'a>)> for Preference<'a> {
-    fn from(value: (Option<PreferenceName<'a>>, GoalDefinition<'a>)) -> Self {
+impl From<(Option<PreferenceName>, GoalDefinition)> for Preference {
+    fn from(value: (Option<PreferenceName>, GoalDefinition)) -> Self {
         Self::new(value.0, value.1)
     }
 }
 
-impl<'a> From<(PreferenceName<'a>, GoalDefinition<'a>)> for Preference<'a> {
-    fn from(value: (PreferenceName<'a>, GoalDefinition<'a>)) -> Self {
+impl From<(PreferenceName, GoalDefinition)> for Preference {
+    fn from(value: (PreferenceName, GoalDefinition)) -> Self {
         Self::new(Some(value.0), value.1)
     }
 }
 
-impl<'a> From<GoalDefinition<'a>> for Preference<'a> {
-    fn from(value: GoalDefinition<'a>) -> Self {
+impl From<GoalDefinition> for Preference {
+    fn from(value: GoalDefinition) -> Self {
         Self::new(None, value)
     }
 }

--- a/src/types/problem.rs
+++ b/src/types/problem.rs
@@ -11,33 +11,33 @@ use crate::{PreconditionGoalDefinitions, PrefConGDs};
 /// ## Usages
 /// This is the top-level type of a problem description within a [`Domain`](crate::Domain).
 #[derive(Debug, Clone, PartialEq)]
-pub struct Problem<'a> {
-    name: Name<'a>,
-    domain: Name<'a>,
+pub struct Problem {
+    name: Name,
+    domain: Name,
     requires: Requirements,
-    objects: Objects<'a>,
-    init: InitElements<'a>,
-    goal: GoalDef<'a>,
+    objects: Objects,
+    init: InitElements,
+    goal: GoalDef,
     /// ## Requirements
     /// Requires [Constraints](crate::Requirement::Constraints).
-    constraints: ProblemConstraintsDef<'a>,
+    constraints: ProblemConstraintsDef,
     /// ## Requirements
     /// Requires [Numeric Fluents](crate::Requirement::NumericFluents).
-    metric_spec: Option<MetricSpec<'a>>,
+    metric_spec: Option<MetricSpec>,
     /// Deprecated since PDDL 2.1.
     length_spec: Option<LengthSpec>,
 }
 
-impl<'a> Problem<'a> {
+impl Problem {
     pub const fn new(
-        name: Name<'a>,
-        domain: Name<'a>,
+        name: Name,
+        domain: Name,
         requires: Requirements,
-        objects: Objects<'a>,
-        init: InitElements<'a>,
-        goal: GoalDef<'a>,
-        constraints: ProblemConstraintsDef<'a>,
-        metric_spec: Option<MetricSpec<'a>>,
+        objects: Objects,
+        init: InitElements,
+        goal: GoalDef,
+        constraints: ProblemConstraintsDef,
+        metric_spec: Option<MetricSpec>,
         length_spec: Option<LengthSpec>,
     ) -> Self {
         Self {
@@ -54,11 +54,11 @@ impl<'a> Problem<'a> {
     }
 
     /// Creates a builder to easily construct problems.
-    pub fn builder<P: Into<Name<'a>>, D: Into<Name<'a>>>(
+    pub fn builder<P: Into<Name>, D: Into<Name>>(
         problem_name: P,
         domain_name: D,
-        init: InitElements<'a>,
-        goal: GoalDef<'a>,
+        init: InitElements,
+        goal: GoalDef,
     ) -> Self {
         Self {
             name: problem_name.into(),
@@ -80,19 +80,19 @@ impl<'a> Problem<'a> {
     }
 
     /// Adds a list of object declarations to the problem.
-    pub fn with_objects<O: Into<Objects<'a>>>(mut self, objects: O) -> Self {
+    pub fn with_objects<O: Into<Objects>>(mut self, objects: O) -> Self {
         self.objects = objects.into();
         self
     }
 
     /// Adds a list of constraints to the problem.
-    pub fn with_constraints<C: Into<ProblemConstraintsDef<'a>>>(mut self, constraints: C) -> Self {
+    pub fn with_constraints<C: Into<ProblemConstraintsDef>>(mut self, constraints: C) -> Self {
         self.constraints = constraints.into();
         self
     }
 
     /// Adds a list of metric specifications to the problem.
-    pub fn with_metric_spec<M: Into<MetricSpec<'a>>>(mut self, metric: M) -> Self {
+    pub fn with_metric_spec<M: Into<MetricSpec>>(mut self, metric: M) -> Self {
         self.metric_spec = Some(metric.into());
         self
     }
@@ -104,12 +104,12 @@ impl<'a> Problem<'a> {
     }
 
     /// Returns the problem name.
-    pub const fn name(&self) -> &Name<'a> {
+    pub const fn name(&self) -> &Name {
         &self.name
     }
 
     /// Returns the domain name.
-    pub const fn domain(&self) -> &Name<'a> {
+    pub const fn domain(&self) -> &Name {
         &self.domain
     }
 
@@ -119,31 +119,31 @@ impl<'a> Problem<'a> {
     }
 
     /// Returns the optional object declarations.
-    pub const fn objects(&self) -> &Objects<'a> {
+    pub const fn objects(&self) -> &Objects {
         &self.objects
     }
 
     /// Returns the initialization of the problem.
-    pub const fn init(&self) -> &InitElements<'a> {
+    pub const fn init(&self) -> &InitElements {
         &self.init
     }
 
     /// Returns the goal statement of the problem.
-    pub const fn goal(&self) -> &PreconditionGoalDefinitions<'a> {
+    pub const fn goal(&self) -> &PreconditionGoalDefinitions {
         &self.goal.value()
     }
 
     /// Returns the optional constraints of the problem.
     /// ## Requirements
     /// Requires [Constraints](crate::Requirement::Constraints).
-    pub const fn constraints(&self) -> &PrefConGDs<'a> {
+    pub const fn constraints(&self) -> &PrefConGDs {
         &self.constraints.value()
     }
 
     /// Returns the optional metric specification of the problem.
     /// ## Requirements
     /// Requires [Numeric Fluents](crate::Requirement::NumericFluents).
-    pub const fn metric_spec(&self) -> &Option<MetricSpec<'a>> {
+    pub const fn metric_spec(&self) -> &Option<MetricSpec> {
         &self.metric_spec
     }
 

--- a/src/types/problem_constraints_def.rs
+++ b/src/types/problem_constraints_def.rs
@@ -8,41 +8,41 @@ use std::ops::Deref;
 /// ## Requirements
 /// Requires [Constraints](crate::Requirement::Constraints).
 #[derive(Debug, Default, Clone, PartialEq)]
-pub struct ProblemConstraintsDef<'a>(PrefConGDs<'a>);
+pub struct ProblemConstraintsDef(PrefConGDs);
 
-impl<'a> ProblemConstraintsDef<'a> {
-    pub const fn new(gd: PrefConGDs<'a>) -> Self {
+impl ProblemConstraintsDef {
+    pub const fn new(gd: PrefConGDs) -> Self {
         Self(gd)
     }
 
     /// Gets the value.
-    pub const fn value(&self) -> &PrefConGDs<'a> {
+    pub const fn value(&self) -> &PrefConGDs {
         &self.0
     }
 }
 
-impl<'a> PartialEq<PrefConGDs<'a>> for ProblemConstraintsDef<'a> {
-    fn eq(&self, other: &PrefConGDs<'a>) -> bool {
+impl PartialEq<PrefConGDs> for ProblemConstraintsDef {
+    fn eq(&self, other: &PrefConGDs) -> bool {
         self.0.eq(other)
     }
 }
 
-impl<'a> From<PrefConGDs<'a>> for ProblemConstraintsDef<'a> {
-    fn from(value: PrefConGDs<'a>) -> Self {
+impl From<PrefConGDs> for ProblemConstraintsDef {
+    fn from(value: PrefConGDs) -> Self {
         Self::new(value)
     }
 }
 
-impl<'a> Deref for ProblemConstraintsDef<'a> {
-    type Target = PrefConGDs<'a>;
+impl Deref for ProblemConstraintsDef {
+    type Target = PrefConGDs;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<'a> Into<PrefConGDs<'a>> for ProblemConstraintsDef<'a> {
-    fn into(self) -> PrefConGDs<'a> {
+impl Into<PrefConGDs> for ProblemConstraintsDef {
+    fn into(self) -> PrefConGDs {
         self.0
     }
 }

--- a/src/types/simple_duration_constraint.rs
+++ b/src/types/simple_duration_constraint.rs
@@ -7,31 +7,31 @@ use crate::types::{DOp, DurationValue, TimeSpecifier};
 /// ## Usage
 /// Used by [`SimpleDurationConstraint`] itself, as well as [`DurationConstraint`](crate::DurationConstraint).
 #[derive(Debug, Clone, PartialEq)]
-pub enum SimpleDurationConstraint<'a> {
+pub enum SimpleDurationConstraint {
     /// A comparison operation against a duration value.
-    Op(DOp, DurationValue<'a>),
+    Op(DOp, DurationValue),
     /// A specific time at or after which a constraint applies.
-    At(TimeSpecifier, Box<SimpleDurationConstraint<'a>>),
+    At(TimeSpecifier, Box<SimpleDurationConstraint>),
 }
 
-impl<'a> SimpleDurationConstraint<'a> {
-    pub const fn new_op(op: DOp, value: DurationValue<'a>) -> Self {
+impl SimpleDurationConstraint {
+    pub const fn new_op(op: DOp, value: DurationValue) -> Self {
         Self::Op(op, value)
     }
 
-    pub fn new_at(time: TimeSpecifier, constraint: SimpleDurationConstraint<'a>) -> Self {
+    pub fn new_at(time: TimeSpecifier, constraint: SimpleDurationConstraint) -> Self {
         Self::At(time, Box::new(constraint))
     }
 }
 
-impl<'a> From<(DOp, DurationValue<'a>)> for SimpleDurationConstraint<'a> {
-    fn from(value: (DOp, DurationValue<'a>)) -> Self {
+impl From<(DOp, DurationValue)> for SimpleDurationConstraint {
+    fn from(value: (DOp, DurationValue)) -> Self {
         SimpleDurationConstraint::new_op(value.0, value.1)
     }
 }
 
-impl<'a> From<(TimeSpecifier, SimpleDurationConstraint<'a>)> for SimpleDurationConstraint<'a> {
-    fn from(value: (TimeSpecifier, SimpleDurationConstraint<'a>)) -> Self {
+impl From<(TimeSpecifier, SimpleDurationConstraint)> for SimpleDurationConstraint {
+    fn from(value: (TimeSpecifier, SimpleDurationConstraint)) -> Self {
         SimpleDurationConstraint::new_at(value.0, value.1)
     }
 }

--- a/src/types/structure_def.rs
+++ b/src/types/structure_def.rs
@@ -7,42 +7,42 @@ use crate::types::{ActionDefinition, DerivedPredicate, DurativeActionDefinition}
 /// ## Usage
 /// Used by [`StructureDefs`](crate::StructureDefs) in [`Domain`](crate::Domain).
 #[derive(Debug, Clone, PartialEq)]
-pub enum StructureDef<'a> {
-    Action(ActionDefinition<'a>),
+pub enum StructureDef {
+    Action(ActionDefinition),
     /// ## Requirements
     /// Requires [Durative Actions](crate::Requirement::DurativeActions).
-    DurativeAction(DurativeActionDefinition<'a>),
+    DurativeAction(DurativeActionDefinition),
     /// ## Requirements
     /// Requires [Derived Predicates](crate::Requirement::DerivedPredicates).
-    Derived(DerivedPredicate<'a>),
+    Derived(DerivedPredicate),
 }
 
-impl<'a> StructureDef<'a> {
-    pub const fn new_action(action: ActionDefinition<'a>) -> Self {
+impl StructureDef {
+    pub const fn new_action(action: ActionDefinition) -> Self {
         Self::Action(action)
     }
-    pub const fn new_durative_action(action: DurativeActionDefinition<'a>) -> Self {
+    pub const fn new_durative_action(action: DurativeActionDefinition) -> Self {
         Self::DurativeAction(action)
     }
-    pub const fn new_derived(predicate: DerivedPredicate<'a>) -> Self {
+    pub const fn new_derived(predicate: DerivedPredicate) -> Self {
         Self::Derived(predicate)
     }
 }
 
-impl<'a> From<ActionDefinition<'a>> for StructureDef<'a> {
-    fn from(value: ActionDefinition<'a>) -> Self {
+impl From<ActionDefinition> for StructureDef {
+    fn from(value: ActionDefinition) -> Self {
         StructureDef::new_action(value)
     }
 }
 
-impl<'a> From<DurativeActionDefinition<'a>> for StructureDef<'a> {
-    fn from(value: DurativeActionDefinition<'a>) -> Self {
+impl From<DurativeActionDefinition> for StructureDef {
+    fn from(value: DurativeActionDefinition) -> Self {
         StructureDef::new_durative_action(value)
     }
 }
 
-impl<'a> From<DerivedPredicate<'a>> for StructureDef<'a> {
-    fn from(value: DerivedPredicate<'a>) -> Self {
+impl From<DerivedPredicate> for StructureDef {
+    fn from(value: DerivedPredicate) -> Self {
         StructureDef::new_derived(value)
     }
 }

--- a/src/types/structure_defs.rs
+++ b/src/types/structure_defs.rs
@@ -8,35 +8,35 @@ use std::ops::Deref;
 /// ## Usage
 /// Used by [`Domain`](crate::Domain).
 #[derive(Debug, Default, Clone, PartialEq)]
-pub struct StructureDefs<'a>(Vec<StructureDef<'a>>);
+pub struct StructureDefs(Vec<StructureDef>);
 
-impl<'a> StructureDefs<'a> {
-    pub fn new<I: IntoIterator<Item = StructureDef<'a>>>(defs: I) -> Self {
+impl StructureDefs {
+    pub fn new<I: IntoIterator<Item = StructureDef>>(defs: I) -> Self {
         Self(defs.into_iter().collect())
     }
 
     /// Gets the values.
-    pub fn values(&self) -> &[StructureDef<'a>] {
+    pub fn values(&self) -> &[StructureDef] {
         self.0.as_slice()
     }
 }
 
-impl<'a> Deref for StructureDefs<'a> {
-    type Target = [StructureDef<'a>];
+impl Deref for StructureDefs {
+    type Target = [StructureDef];
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<'a> From<Vec<StructureDef<'a>>> for StructureDefs<'a> {
-    fn from(value: Vec<StructureDef<'a>>) -> Self {
+impl From<Vec<StructureDef>> for StructureDefs {
+    fn from(value: Vec<StructureDef>) -> Self {
         StructureDefs::new(value)
     }
 }
 
-impl<'a> FromIterator<StructureDef<'a>> for StructureDefs<'a> {
-    fn from_iter<T: IntoIterator<Item = StructureDef<'a>>>(iter: T) -> Self {
+impl FromIterator<StructureDef> for StructureDefs {
+    fn from_iter<T: IntoIterator<Item = StructureDef>>(iter: T) -> Self {
         StructureDefs::new(iter)
     }
 }

--- a/src/types/term.rs
+++ b/src/types/term.rs
@@ -8,40 +8,40 @@ use crate::types::Variable;
 /// Used by [`GoalDefinition`](crate::GoalDefinition), [`FunctionTerm`](FunctionTerm),
 /// [`FHead`](crate::FHead), [`PEffect`](crate::PEffect) and [`InitElement`](crate::InitElement).
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub enum Term<'a> {
-    Name(Name<'a>),
-    Variable(Variable<'a>),
-    Function(FunctionTerm<'a>),
+pub enum Term {
+    Name(Name),
+    Variable(Variable),
+    Function(FunctionTerm),
 }
 
-impl<'a> Term<'a> {
-    pub const fn new_name(name: Name<'a>) -> Self {
+impl Term {
+    pub const fn new_name(name: Name) -> Self {
         Self::Name(name)
     }
 
-    pub const fn new_variable(var: Variable<'a>) -> Self {
+    pub const fn new_variable(var: Variable) -> Self {
         Self::Variable(var)
     }
 
-    pub const fn new_function(fun: FunctionTerm<'a>) -> Self {
+    pub const fn new_function(fun: FunctionTerm) -> Self {
         Self::Function(fun)
     }
 }
 
-impl<'a> From<Name<'a>> for Term<'a> {
-    fn from(value: Name<'a>) -> Self {
+impl From<Name> for Term {
+    fn from(value: Name) -> Self {
         Self::Name(value)
     }
 }
 
-impl<'a> From<Variable<'a>> for Term<'a> {
-    fn from(value: Variable<'a>) -> Self {
+impl From<Variable> for Term {
+    fn from(value: Variable) -> Self {
         Self::Variable(value)
     }
 }
 
-impl<'a> From<FunctionTerm<'a>> for Term<'a> {
-    fn from(value: FunctionTerm<'a>) -> Self {
+impl From<FunctionTerm> for Term {
+    fn from(value: FunctionTerm) -> Self {
         Self::Function(value)
     }
 }

--- a/src/types/timed_effect.rs
+++ b/src/types/timed_effect.rs
@@ -20,49 +20,45 @@ use crate::types::{AssignOpT, ConditionalEffect, FAssignDa, FExpT, FHead, TimeSp
 /// ## Usage
 /// Used by [`DurativeActionEffect`](crate::DurativeActionEffect).
 #[derive(Debug, Clone, PartialEq)]
-pub enum TimedEffect<'a> {
-    Conditional(TimeSpecifier, ConditionalEffect<'a>),
+pub enum TimedEffect {
+    Conditional(TimeSpecifier, ConditionalEffect),
     /// ## Requirements
     /// Requires [Numeric Fluents](crate::Requirement::NumericFluents).
-    NumericFluent(TimeSpecifier, FAssignDa<'a>),
+    NumericFluent(TimeSpecifier, FAssignDa),
     /// ## Requirements
     /// Requires [Continuous Effects](crate::Requirement::ContinuousEffects) and
     /// [Numeric Fluents](crate::Requirement::NumericFluents).
-    ContinuousEffect(AssignOpT, FHead<'a>, FExpT<'a>),
+    ContinuousEffect(AssignOpT, FHead, FExpT),
 }
 
-impl<'a> TimedEffect<'a> {
-    pub const fn new_conditional(at: TimeSpecifier, effect: ConditionalEffect<'a>) -> Self {
+impl TimedEffect {
+    pub const fn new_conditional(at: TimeSpecifier, effect: ConditionalEffect) -> Self {
         Self::Conditional(at, effect)
     }
 
-    pub const fn new_fluent(at: TimeSpecifier, action: FAssignDa<'a>) -> Self {
+    pub const fn new_fluent(at: TimeSpecifier, action: FAssignDa) -> Self {
         Self::NumericFluent(at, action)
     }
 
-    pub const fn new_continuous(
-        operation: AssignOpT,
-        f_head: FHead<'a>,
-        f_exp_t: FExpT<'a>,
-    ) -> Self {
+    pub const fn new_continuous(operation: AssignOpT, f_head: FHead, f_exp_t: FExpT) -> Self {
         Self::ContinuousEffect(operation, f_head, f_exp_t)
     }
 }
 
-impl<'a> From<(TimeSpecifier, ConditionalEffect<'a>)> for TimedEffect<'a> {
-    fn from(value: (TimeSpecifier, ConditionalEffect<'a>)) -> Self {
+impl From<(TimeSpecifier, ConditionalEffect)> for TimedEffect {
+    fn from(value: (TimeSpecifier, ConditionalEffect)) -> Self {
         TimedEffect::Conditional(value.0, value.1)
     }
 }
 
-impl<'a> From<(TimeSpecifier, FAssignDa<'a>)> for TimedEffect<'a> {
-    fn from(value: (TimeSpecifier, FAssignDa<'a>)) -> Self {
+impl From<(TimeSpecifier, FAssignDa)> for TimedEffect {
+    fn from(value: (TimeSpecifier, FAssignDa)) -> Self {
         TimedEffect::NumericFluent(value.0, value.1)
     }
 }
 
-impl<'a> From<(AssignOpT, FHead<'a>, FExpT<'a>)> for TimedEffect<'a> {
-    fn from(value: (AssignOpT, FHead<'a>, FExpT<'a>)) -> Self {
+impl From<(AssignOpT, FHead, FExpT)> for TimedEffect {
+    fn from(value: (AssignOpT, FHead, FExpT)) -> Self {
         TimedEffect::ContinuousEffect(value.0, value.1, value.2)
     }
 }

--- a/src/types/timed_gd.rs
+++ b/src/types/timed_gd.rs
@@ -5,7 +5,7 @@ use crate::types::{GoalDefinition, Interval, TimeSpecifier};
 /// ## Usage
 /// Used by [`PrefTimedGD`](crate::PrefTimedGD).
 #[derive(Debug, Clone, PartialEq)]
-pub enum TimedGD<'a> {
+pub enum TimedGD {
     /// ## `at start`
     /// An expression or predicate with `at start` prefixed to it means that the condition
     /// must be true at the start of the action in order for the action to be applied. e.g.
@@ -31,7 +31,7 @@ pub enum TimedGD<'a> {
     /// expresses that whilst this fact doesn't have to be true at the start or during the action,
     /// it must be true at the end. In this case, we're expressing that the battery amount at the
     /// end of the action must be greater than zero.
-    At(TimeSpecifier, GoalDefinition<'a>),
+    At(TimeSpecifier, GoalDefinition),
     /// ## `over all`
     /// An expression or predicate with an overall prefixed to it, means that the condition
     /// must be true throughout the action, including at the start and end. e.g.
@@ -44,27 +44,27 @@ pub enum TimedGD<'a> {
     /// In the case above, we are expressing that it must be possible to move from the from
     /// waypoint to the to waypoint all the way through the action. I.e. we don't want to get
     /// half way through the action to find that after a certain point a path has become blocked.
-    Over(Interval, GoalDefinition<'a>),
+    Over(Interval, GoalDefinition),
 }
 
-impl<'a> TimedGD<'a> {
-    pub const fn new_at(time: TimeSpecifier, gd: GoalDefinition<'a>) -> Self {
+impl TimedGD {
+    pub const fn new_at(time: TimeSpecifier, gd: GoalDefinition) -> Self {
         Self::At(time, gd)
     }
 
-    pub const fn new_over(interval: Interval, gd: GoalDefinition<'a>) -> Self {
+    pub const fn new_over(interval: Interval, gd: GoalDefinition) -> Self {
         Self::Over(interval, gd)
     }
 }
 
-impl<'a> From<(TimeSpecifier, GoalDefinition<'a>)> for TimedGD<'a> {
-    fn from(value: (TimeSpecifier, GoalDefinition<'a>)) -> Self {
+impl From<(TimeSpecifier, GoalDefinition)> for TimedGD {
+    fn from(value: (TimeSpecifier, GoalDefinition)) -> Self {
         TimedGD::At(value.0, value.1)
     }
 }
 
-impl<'a> From<(Interval, GoalDefinition<'a>)> for TimedGD<'a> {
-    fn from(value: (Interval, GoalDefinition<'a>)) -> Self {
+impl From<(Interval, GoalDefinition)> for TimedGD {
+    fn from(value: (Interval, GoalDefinition)) -> Self {
         TimedGD::Over(value.0, value.1)
     }
 }

--- a/src/types/timeless.rs
+++ b/src/types/timeless.rs
@@ -15,27 +15,27 @@ use std::ops::Deref;
 /// ## Usage
 /// Used by [`Domain`](crate::Domain).
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
-pub struct Timeless<'a>(Vec<NameLiteral<'a>>);
+pub struct Timeless(Vec<NameLiteral>);
 
-impl<'a> Timeless<'a> {
-    pub fn new(literal: Vec<NameLiteral<'a>>) -> Self {
+impl Timeless {
+    pub fn new(literal: Vec<NameLiteral>) -> Self {
         Self(literal)
     }
 
     /// Gets the literals.
-    pub fn values(&self) -> &[NameLiteral<'a>] {
+    pub fn values(&self) -> &[NameLiteral] {
         &self.0.as_slice()
     }
 }
 
-impl<'a> FromIterator<NameLiteral<'a>> for Timeless<'a> {
-    fn from_iter<T: IntoIterator<Item = NameLiteral<'a>>>(iter: T) -> Self {
+impl FromIterator<NameLiteral> for Timeless {
+    fn from_iter<T: IntoIterator<Item = NameLiteral>>(iter: T) -> Self {
         Timeless::new(iter.into_iter().collect())
     }
 }
 
-impl<'a> Deref for Timeless<'a> {
-    type Target = [NameLiteral<'a>];
+impl Deref for Timeless {
+    type Target = [NameLiteral];
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target {

--- a/src/types/type.rs
+++ b/src/types/type.rs
@@ -136,11 +136,12 @@ impl<'a> IntoIterator for Type<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parsers::Span;
     use crate::Parser;
 
     #[test]
     fn flatten_with_single_element_works() {
-        let (_, t) = Type::parse("object").unwrap();
+        let (_, t) = Type::parse(Span::new("object")).unwrap();
 
         let mut iter = t.into_iter();
         assert!(iter.next().is_some());
@@ -149,7 +150,7 @@ mod tests {
 
     #[test]
     fn flatten_with_many_elements_works() {
-        let (_, t) = Type::parse("(either object number)").unwrap();
+        let (_, t) = Type::parse(Span::new("(either object number)")).unwrap();
 
         let mut iter = t.into_iter();
         assert!(iter.next().is_some());

--- a/src/types/type.rs
+++ b/src/types/type.rs
@@ -5,11 +5,11 @@ use crate::types::Name;
 use std::ops::Deref;
 
 /// The `object` type.
-pub const TYPE_OBJECT: PrimitiveType<'static> = PrimitiveType(Name::new("object"));
+pub const TYPE_OBJECT: PrimitiveType = PrimitiveType(Name::new_static("object"));
 
 /// The `number` type.
 #[allow(dead_code)]
-pub const TYPE_NUMBER: PrimitiveType<'static> = PrimitiveType(Name::new("number"));
+pub const TYPE_NUMBER: PrimitiveType = PrimitiveType(Name::new_static("number"));
 
 /// A primitive type.
 ///
@@ -19,7 +19,7 @@ pub const TYPE_NUMBER: PrimitiveType<'static> = PrimitiveType(Name::new("number"
 /// ## Usage
 /// Used by [`Type`].
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Default)]
-pub struct PrimitiveType<'a>(Name<'a>);
+pub struct PrimitiveType(Name);
 
 /// A type selection from `<primitive-type> | (either <primitive-type>)`.
 ///
@@ -30,19 +30,19 @@ pub struct PrimitiveType<'a>(Name<'a>);
 /// Used by [`Typed`](crate::Typed) in [`TypedList`](crate::TypedList),
 /// [`FunctionType`](crate::FunctionType).
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub enum Type<'a> {
+pub enum Type {
     /// The type is exactly this named type.
-    Exactly(PrimitiveType<'a>),
+    Exactly(PrimitiveType),
     /// The type is either of these named types..
-    EitherOf(Vec<PrimitiveType<'a>>),
+    EitherOf(Vec<PrimitiveType>),
 }
 
-impl<'a> Type<'a> {
+impl Type {
     /// The predefined type `object`.
-    pub const OBJECT: Type<'a> = Type::Exactly(TYPE_OBJECT);
+    pub const OBJECT: Type = Type::Exactly(TYPE_OBJECT);
 
     /// The predefined type `number`.
-    pub const NUMBER: Type<'a> = Type::Exactly(TYPE_NUMBER);
+    pub const NUMBER: Type = Type::Exactly(TYPE_NUMBER);
 
     pub fn len(&self) -> usize {
         match self {
@@ -52,54 +52,54 @@ impl<'a> Type<'a> {
     }
 }
 
-impl<'a> PrimitiveType<'a> {
-    pub fn new(name: Name<'a>) -> Self {
+impl PrimitiveType {
+    pub fn new(name: Name) -> Self {
         Self(name)
     }
 }
 
-impl<'a> Default for Type<'a> {
+impl Default for Type {
     fn default() -> Self {
         Self::Exactly(TYPE_OBJECT)
     }
 }
 
-impl<'a> From<&'a str> for Type<'a> {
-    fn from(value: &'a str) -> Self {
+impl From<&str> for Type {
+    fn from(value: &str) -> Self {
         Self::Exactly(value.into())
     }
 }
 
-impl<'a> From<Vec<&'a str>> for Type<'a> {
-    fn from(value: Vec<&'a str>) -> Self {
+impl From<Vec<&str>> for Type {
+    fn from(value: Vec<&str>) -> Self {
         Self::EitherOf(value.iter().map(|&x| PrimitiveType::from(x)).collect())
     }
 }
 
-impl<'a> From<PrimitiveType<'a>> for Type<'a> {
-    fn from(value: PrimitiveType<'a>) -> Self {
+impl From<PrimitiveType> for Type {
+    fn from(value: PrimitiveType) -> Self {
         Self::Exactly(value)
     }
 }
 
-impl<'a> From<Vec<PrimitiveType<'a>>> for Type<'a> {
-    fn from(value: Vec<PrimitiveType<'a>>) -> Self {
+impl From<Vec<PrimitiveType>> for Type {
+    fn from(value: Vec<PrimitiveType>) -> Self {
         Self::EitherOf(value)
     }
 }
 
-impl<'a, P> FromIterator<P> for Type<'a>
+impl<'a, P> FromIterator<P> for Type
 where
-    P: Into<PrimitiveType<'a>>,
+    P: Into<PrimitiveType>,
 {
     fn from_iter<T: IntoIterator<Item = P>>(iter: T) -> Self {
         Self::EitherOf(iter.into_iter().map(|x| x.into()).collect())
     }
 }
 
-impl<'a, T> From<T> for PrimitiveType<'a>
+impl<'a, T> From<T> for PrimitiveType
 where
-    T: Into<Name<'a>>,
+    T: Into<Name>,
 {
     #[inline(always)]
     fn from(value: T) -> Self {
@@ -107,13 +107,13 @@ where
     }
 }
 
-impl<'a> AsRef<str> for PrimitiveType<'a> {
+impl AsRef<str> for PrimitiveType {
     fn as_ref(&self) -> &str {
         &self.0
     }
 }
 
-impl<'a> Deref for PrimitiveType<'a> {
+impl Deref for PrimitiveType {
     type Target = str;
 
     fn deref(&self) -> &Self::Target {
@@ -121,8 +121,8 @@ impl<'a> Deref for PrimitiveType<'a> {
     }
 }
 
-impl<'a> IntoIterator for Type<'a> {
-    type Item = PrimitiveType<'a>;
+impl IntoIterator for Type {
+    type Item = PrimitiveType;
     type IntoIter = FlatteningIntoIterator<Self::Item>;
 
     fn into_iter(self) -> Self::IntoIter {

--- a/src/types/typed.rs
+++ b/src/types/typed.rs
@@ -8,10 +8,10 @@ use std::ops::Deref;
 /// ## Usage
 /// Used by [`TypedList`](crate::TypedList).
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct Typed<'a, O>(O, Type<'a>);
+pub struct Typed<O>(O, Type);
 
-impl<'a, O> Typed<'a, O> {
-    pub const fn new(value: O, r#type: Type<'a>) -> Self {
+impl<O> Typed<O> {
+    pub const fn new(value: O, r#type: Type) -> Self {
         Self(value, r#type)
     }
 
@@ -25,12 +25,12 @@ impl<'a, O> Typed<'a, O> {
     }
 
     /// Gets the assigned type.
-    pub const fn type_(&self) -> &Type<'a> {
+    pub const fn type_(&self) -> &Type {
         &self.1
     }
 }
 
-pub trait ToTyped<'a, T> {
+pub trait ToTyped<T> {
     /// Wraps the value into a [`Typed`] as [`Type::Exactly`] the specified type.
     ///
     /// ## Example
@@ -41,7 +41,7 @@ pub trait ToTyped<'a, T> {
     ///     Typed::new(Name::from("kitchen"), Type::Exactly(PrimitiveType::from("room")))
     /// );
     /// ```
-    fn to_typed<I: Into<Type<'a>>>(self, r#type: I) -> Typed<'a, T>;
+    fn to_typed<I: Into<Type>>(self, r#type: I) -> Typed<T>;
 
     /// Wraps the value into a [`Typed`] as [`Type::EitherOf`] the specified types.
     ///
@@ -58,19 +58,19 @@ pub trait ToTyped<'a, T> {
     ///     )
     /// );
     /// ```
-    fn to_typed_either<I: IntoIterator<Item = P>, P: Into<PrimitiveType<'a>>>(
+    fn to_typed_either<I: IntoIterator<Item = P>, P: Into<PrimitiveType>>(
         self,
         r#type: I,
-    ) -> Typed<'a, T>;
+    ) -> Typed<T>;
 }
 
-impl<'a, O> From<O> for Typed<'a, O> {
+impl<'a, O> From<O> for Typed<O> {
     fn from(value: O) -> Self {
         Typed::new_object(value)
     }
 }
 
-impl<'a, O> Deref for Typed<'a, O> {
+impl<'a, O> Deref for Typed<O> {
     type Target = O;
 
     fn deref(&self) -> &Self::Target {

--- a/src/types/typed_list.rs
+++ b/src/types/typed_list.rs
@@ -25,60 +25,60 @@ use std::ops::Deref;
 /// [`Objects`](crate::Objects) in [`Problem`](crate::Problem), [`PrefConGD`](crate::PrefConGD) and
 /// [`ConGD`](crate::ConGD).
 #[derive(Debug, Default, Clone, Eq, PartialEq)]
-pub struct TypedList<'a, T>(Vec<Typed<'a, T>>);
+pub struct TypedList<T>(Vec<Typed<T>>);
 
-impl<'a, T> TypedList<'a, T> {
-    pub const fn new(list: Vec<Typed<'a, T>>) -> Self {
+impl<T> TypedList<T> {
+    pub const fn new(list: Vec<Typed<T>>) -> Self {
         Self(list)
     }
 
     /// Gets the values.
-    pub fn value(&self) -> &[Typed<'a, T>] {
+    pub fn value(&self) -> &[Typed<T>] {
         self.0.as_slice()
     }
 }
 
-impl<'a, T> From<Vec<Typed<'a, T>>> for TypedList<'a, T> {
-    fn from(iter: Vec<Typed<'a, T>>) -> Self {
+impl<T> From<Vec<Typed<T>>> for TypedList<T> {
+    fn from(iter: Vec<Typed<T>>) -> Self {
         TypedList::new(iter)
     }
 }
 
-impl<'a, T> FromIterator<Typed<'a, T>> for TypedList<'a, T> {
-    fn from_iter<I: IntoIterator<Item = Typed<'a, T>>>(iter: I) -> Self {
+impl<T> FromIterator<Typed<T>> for TypedList<T> {
+    fn from_iter<I: IntoIterator<Item = Typed<T>>>(iter: I) -> Self {
         TypedList::new(iter.into_iter().collect())
     }
 }
 
-impl<'a, T> Deref for TypedList<'a, T> {
-    type Target = [Typed<'a, T>];
+impl<T> Deref for TypedList<T> {
+    type Target = [Typed<T>];
 
     fn deref(&self) -> &Self::Target {
         self.0.as_slice()
     }
 }
 
-impl<'a, T> PartialEq<Vec<Typed<'_, T>>> for TypedList<'a, T>
+impl<T> PartialEq<Vec<Typed<T>>> for TypedList<T>
 where
     T: PartialEq,
 {
-    fn eq(&self, other: &Vec<Typed<'_, T>>) -> bool {
+    fn eq(&self, other: &Vec<Typed<T>>) -> bool {
         self.0.eq(other)
     }
 }
 
-impl<'a, T> PartialEq<[Typed<'_, T>]> for TypedList<'a, T>
+impl<T> PartialEq<[Typed<T>]> for TypedList<T>
 where
     T: PartialEq,
 {
-    fn eq(&self, other: &[Typed<'_, T>]) -> bool {
+    fn eq(&self, other: &[Typed<T>]) -> bool {
         self.0.eq(other)
     }
 }
 
-impl<'a, T> IntoIterator for TypedList<'a, T> {
-    type Item = Typed<'a, T>;
-    type IntoIter = std::vec::IntoIter<Typed<'a, T>>;
+impl<T> IntoIterator for TypedList<T> {
+    type Item = Typed<T>;
+    type IntoIter = std::vec::IntoIter<Typed<T>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()

--- a/src/types/types.rs
+++ b/src/types/types.rs
@@ -8,29 +8,29 @@ use std::ops::Deref;
 /// ## Usage
 /// Used by [`Domain`](crate::Domain).
 #[derive(Debug, Default, Clone, Eq, PartialEq)]
-pub struct Types<'a>(TypedNames<'a>);
+pub struct Types(TypedNames);
 
-impl<'a> Types<'a> {
-    pub const fn new(predicates: TypedNames<'a>) -> Self {
+impl Types {
+    pub const fn new(predicates: TypedNames) -> Self {
         Self(predicates)
     }
 
     /// Gets the values.
-    pub fn values(&self) -> &TypedNames<'a> {
+    pub fn values(&self) -> &TypedNames {
         &self.0
     }
 }
 
-impl<'a> Deref for Types<'a> {
-    type Target = TypedNames<'a>;
+impl Deref for Types {
+    type Target = TypedNames;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<'a> From<TypedNames<'a>> for Types<'a> {
-    fn from(value: TypedNames<'a>) -> Self {
+impl From<TypedNames> for Types {
+    fn from(value: TypedNames) -> Self {
         Types::new(value)
     }
 }

--- a/src/types/variable.rs
+++ b/src/types/variable.rs
@@ -13,40 +13,45 @@ use std::ops::Deref;
 /// [`DurativeActionGoalDefinition`](crate::DurativeActionGoalDefinition), [`DurativeActionEffect`](crate::DurativeActionEffect),
 /// [`PrefConGD`](crate::PrefConGD) and [`ConGD`](crate::ConGD).
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Default)]
-pub struct Variable<'a>(Name<'a>);
+pub struct Variable(Name);
 
-impl<'a> Variable<'a> {
+impl Variable {
     #[inline(always)]
-    pub const fn new(name: Name<'a>) -> Self {
+    pub const fn new(name: Name) -> Self {
         Self(name)
     }
 
     #[inline(always)]
-    pub const fn from_str(name: &'a str) -> Self {
+    pub fn from_str(name: &str) -> Self {
         Self(Name::new(name))
     }
 
     #[inline(always)]
-    pub const fn from_name(name: Name<'a>) -> Self {
+    pub const fn from_static(name: &'static str) -> Self {
+        Self(Name::new_static(name))
+    }
+
+    #[inline(always)]
+    pub const fn from_name(name: Name) -> Self {
         Self(name)
     }
 }
 
-impl<'a> ToTyped<'a, Variable<'a>> for Variable<'a> {
-    fn to_typed<I: Into<Type<'a>>>(self, r#type: I) -> Typed<'a, Variable<'a>> {
+impl ToTyped<Variable> for Variable {
+    fn to_typed<I: Into<Type>>(self, r#type: I) -> Typed<Variable> {
         Typed::new(self, r#type.into())
     }
-    fn to_typed_either<I: IntoIterator<Item = P>, P: Into<PrimitiveType<'a>>>(
+    fn to_typed_either<I: IntoIterator<Item = P>, P: Into<PrimitiveType>>(
         self,
         types: I,
-    ) -> Typed<'a, Variable<'a>> {
+    ) -> Typed<Variable> {
         Typed::new(self, Type::from_iter(types))
     }
 }
 
-impl<'a, T> From<T> for Variable<'a>
+impl<'a, T> From<T> for Variable
 where
-    T: Into<Name<'a>>,
+    T: Into<Name>,
 {
     #[inline(always)]
     fn from(value: T) -> Self {
@@ -54,22 +59,22 @@ where
     }
 }
 
-impl<'a> AsRef<Name<'a>> for Variable<'a> {
+impl AsRef<Name> for Variable {
     #[inline(always)]
-    fn as_ref(&self) -> &Name<'a> {
+    fn as_ref(&self) -> &Name {
         &self.0
     }
 }
 
-impl<'a> AsRef<str> for Variable<'a> {
+impl AsRef<str> for Variable {
     #[inline(always)]
     fn as_ref(&self) -> &str {
         self.0.as_ref()
     }
 }
 
-impl<'a> Deref for Variable<'a> {
-    type Target = Name<'a>;
+impl Deref for Variable {
+    type Target = Name;
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target {

--- a/tests/briefcase_world.rs
+++ b/tests/briefcase_world.rs
@@ -44,10 +44,10 @@ pub const BRIEFCASE_WORLD_PROBLEM: &'static str = r#"
 
 #[test]
 fn parse_domain_works() {
-    let (remainder, domain) = Domain::parse(BRIEFCASE_WORLD).unwrap();
+    let (remainder, domain) = Domain::parse(BRIEFCASE_WORLD.into()).unwrap();
 
     // The input was parsed completely, nothing followed the domain definition.
-    assert_eq!(remainder, "");
+    assert!(remainder.is_empty());
 
     // All elements were parsed.
     assert_eq!(domain.name(), &"briefcase-world".into());
@@ -60,10 +60,10 @@ fn parse_domain_works() {
 
 #[test]
 fn parse_problem_works() {
-    let (remainder, problem) = Problem::parse(BRIEFCASE_WORLD_PROBLEM).unwrap();
+    let (remainder, problem) = Problem::parse(BRIEFCASE_WORLD_PROBLEM.into()).unwrap();
 
     // The input was parsed completely, nothing followed the problem definition.
-    assert_eq!(remainder, "");
+    assert!(remainder.is_empty());
 
     // All elements were parsed.
     assert_eq!(problem.name(), &"get-paid".into());

--- a/tests/briefcase_world.rs
+++ b/tests/briefcase_world.rs
@@ -44,7 +44,7 @@ pub const BRIEFCASE_WORLD_PROBLEM: &'static str = r#"
 
 #[test]
 fn parse_domain_works() {
-    let (remainder, domain) = Domain::parse(BRIEFCASE_WORLD.into()).unwrap();
+    let (remainder, domain) = Domain::parse(BRIEFCASE_WORLD).unwrap();
 
     // The input was parsed completely, nothing followed the domain definition.
     assert!(remainder.is_empty());
@@ -60,7 +60,7 @@ fn parse_domain_works() {
 
 #[test]
 fn parse_problem_works() {
-    let (remainder, problem) = Problem::parse(BRIEFCASE_WORLD_PROBLEM.into()).unwrap();
+    let (remainder, problem) = Problem::parse(BRIEFCASE_WORLD_PROBLEM).unwrap();
 
     // The input was parsed completely, nothing followed the problem definition.
     assert!(remainder.is_empty());


### PR DESCRIPTION
This changes the parsers to use [nom-greedyerror](https://github.com/dalance/nom-greedyerror) and [nom_locate](https://github.com/fflorent/nom_locate) to improve error handling.

The `'a` lifetime annotation was removed from `Name`. `Name` now uses an internal variant for switching between a `String` value and a `&'static str` value to allow const creation (e.g. in `Type::OBJECT`) as well as dynamic strings.

This PR also adds the `Parser::from_str` implementation for easier string handling. It uses `Parser::parse` to process the input and, if successful, discards the remaining unparsed input and directly returns the value. A direct implementation of `FromStr` is sadly not possible due to lifetime mismatches with `ParseError<'a>`.