### PR TITLE
Rename Problem::goal to Problem::goals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Renamed `Problem::goal` to `Problem::goals` to reflect the fact that it is iterable.
+
 ## [0.0.5] - 2023-05-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ pub const BRIEFCASE_WORLD_PROBLEM: &'static str = r#"
     "#;
 
 fn main() {
-    let (_, problem) = Problem::parse(BRIEFCASE_WORLD_PROBLEM).unwrap();
+    let problem = Problem::from_str(BRIEFCASE_WORLD_PROBLEM).unwrap();
 
     assert_eq!(problem.name(), &"get-paid".into());
     assert_eq!(problem.domain(), &"briefcase-world".into());
     assert!(problem.requirements().is_empty());
     assert_eq!(problem.init().len(), 9);
-    assert!(matches! { problem.goal(), pddl::PreconditionGoalDefinition::And(_) });
+    assert_eq!(problem.goal().len(), 3);
 }
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,8 +49,8 @@
 //!     )
 //!     "#;
 //!
-//! let (_, domain) = Domain::parse(BRIEFCASE_WORLD).unwrap();
-//! let (_, problem) = Problem::parse(BRIEFCASE_WORLD_PROBLEM).unwrap();
+//! let domain = Domain::from_str(BRIEFCASE_WORLD).unwrap();
+//! let problem = Problem::from_str(BRIEFCASE_WORLD_PROBLEM).unwrap();
 //!
 //! // All elements were parsed.
 //! assert_eq!(domain.name(), &"briefcase-world".into());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@
 //! assert_eq!(problem.domain(), &"briefcase-world".into());
 //! assert!(problem.requirements().is_empty());
 //! assert_eq!(problem.init().len(), 9);
-//! assert_eq!(problem.goal().len(), 3);
+//! assert_eq!(problem.goals().len(), 3);
 //! ```
 
 // only enables the `doc_cfg` feature when

--- a/src/parsers/problem.rs
+++ b/src/parsers/problem.rs
@@ -33,7 +33,7 @@ use nom::sequence::{preceded, tuple};
 /// assert_eq!(problem.domain(), &Name::new("briefcase-world"));
 /// assert!(problem.requirements().is_empty());
 /// assert_eq!(problem.init().len(), 9);
-/// assert_eq!(problem.goal().len(), 3);
+/// assert_eq!(problem.goals().len(), 3);
 /// ```
 pub fn parse_problem<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Problem> {
     map(
@@ -92,7 +92,7 @@ impl crate::parsers::Parser for Problem {
     /// assert_eq!(problem.domain(), &Name::new("briefcase-world"));
     /// assert!(problem.requirements().is_empty());
     /// assert_eq!(problem.init().len(), 9);
-    /// assert_eq!(problem.goal().len(), 3);
+    /// assert_eq!(problem.goals().len(), 3);
     /// ```
     ///
     /// ## See also

--- a/src/types/problem.rs
+++ b/src/types/problem.rs
@@ -129,7 +129,7 @@ impl Problem {
     }
 
     /// Returns the goal statement of the problem.
-    pub const fn goal(&self) -> &PreconditionGoalDefinitions {
+    pub const fn goals(&self) -> &PreconditionGoalDefinitions {
         &self.goal.value()
     }
 

--- a/tests/briefcase_world.rs
+++ b/tests/briefcase_world.rs
@@ -70,10 +70,10 @@ fn parse_problem_works() {
     assert_eq!(problem.domain(), &"briefcase-world".into());
     assert!(problem.requirements().is_empty());
     assert_eq!(problem.init().len(), 9);
-    assert_eq!(problem.goal().len(), 3);
+    assert_eq!(problem.goals().len(), 3);
 
     let mut atomic_formulas = 0;
-    for goal in problem.goal().iter() {
+    for goal in problem.goals().iter() {
         match goal {
             PreconditionGoalDefinition::Preference(pref) => match pref {
                 PreferenceGD::Goal(goal) => match goal {


### PR DESCRIPTION
Problems can have multiple goals (now) and this name change reflects that fact.