### PR TITLE
Intern "object" and "number" names to 'static str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,15 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+
+- Added a `PartialEq` for `Name` that allows comparison with `str` and `String` directly.
+
 ### Changed
 
 - Renamed `Problem::goal` to `Problem::goals` to reflect the fact that it is iterable.
+- If well-known names such as `object` or `number` are used for a `Name`, these values
+  will be interned to a `'static str`.
 
 ### Internal
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ pub const BRIEFCASE_WORLD_PROBLEM: &'static str = r#"
 fn main() {
     let problem = Problem::from_str(BRIEFCASE_WORLD_PROBLEM).unwrap();
 
-    assert_eq!(problem.name(), &"get-paid".into());
-    assert_eq!(problem.domain(), &"briefcase-world".into());
+    assert_eq!(problem.name(), "get-paid");
+    assert_eq!(problem.domain(), "briefcase-world");
     assert!(problem.requirements().is_empty());
     assert_eq!(problem.init().len(), 9);
     assert_eq!(problem.goal().len(), 3);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@
 //! let problem = Problem::from_str(BRIEFCASE_WORLD_PROBLEM).unwrap();
 //!
 //! // All elements were parsed.
-//! assert_eq!(domain.name(), &"briefcase-world".into());
+//! assert_eq!(domain.name(), "briefcase-world");
 //! assert_eq!(domain.requirements().len(), 4);
 //! assert_eq!(domain.types().len(), 2);
 //! assert_eq!(domain.constants().len(), 3);
@@ -61,8 +61,8 @@
 //! assert_eq!(domain.structure().len(), 3);
 //!
 //! // All elements were parsed.
-//! assert_eq!(problem.name(), &"get-paid".into());
-//! assert_eq!(problem.domain(), &"briefcase-world".into());
+//! assert_eq!(problem.name(), "get-paid");
+//! assert_eq!(problem.domain(), "briefcase-world");
 //! assert!(problem.requirements().is_empty());
 //! assert_eq!(problem.init().len(), 9);
 //! assert_eq!(problem.goals().len(), 3);

--- a/src/parsers/derived_predicate.rs
+++ b/src/parsers/derived_predicate.rs
@@ -21,7 +21,7 @@ use nom::sequence::{preceded, tuple};
 ///                 )"#;
 ///
 /// let (remaining, predicate) = parse_derived_predicate(input).unwrap();
-/// assert_eq!(predicate.predicate().name(), &"train-usable".into());
+/// assert_eq!(predicate.predicate().name(), "train-usable");
 /// assert!(matches!(predicate.expression(), &GoalDefinition::And(..)));
 ///```
 pub fn parse_derived_predicate<'a, T: Into<Span<'a>>>(

--- a/src/types/name.rs
+++ b/src/types/name.rs
@@ -23,16 +23,36 @@ enum NameVariant {
 }
 
 impl Name {
+    /// Constructs a new [`Name`] from a provided string.
+    ///
+    /// ## Arguments
+    /// * `name` - The name to wrap.
+    ///
+    /// ## Returns
+    /// A new [`Name`].
     #[inline(always)]
-    pub fn new(name: &str) -> Self {
-        Self::new_string(name.into())
+    pub fn new<S: Into<String> + AsRef<str>>(name: S) -> Self {
+        if let Some(str) = Self::map_to_static(name.as_ref()) {
+            Self::new_static(str)
+        } else {
+            Self(NameVariant::String(name.into()))
+        }
     }
 
-    #[inline(always)]
-    pub const fn new_string(name: String) -> Self {
-        Self(NameVariant::String(name))
-    }
-
+    /// Like [`new`] but makes use of the fact that if the string provided
+    /// is `'static`, the method can be `const`.
+    ///
+    /// ## Arguments
+    /// * `name` - The name to wrap.
+    ///
+    /// ## Returns
+    /// A new [`Name`].
+    ///
+    /// ## Example
+    /// ```
+    /// # use pddl::Name;
+    /// assert_eq!(Name::new("name"), "name");
+    /// ```
     #[inline(always)]
     pub const fn new_static(name: &'static str) -> Self {
         Self(NameVariant::Static(name))
@@ -42,8 +62,93 @@ impl Name {
         self.0.is_empty()
     }
 
+    /// Gets the length of the name, in chars.
     pub fn len(&self) -> usize {
         self.0.len()
+    }
+
+    /// Maps the provided to a well-known `'static` string if possible.
+    fn map_to_static<'a>(value: &'a str) -> Option<&'static str> {
+        match value {
+            well_known::OBJECT => Some(well_known::OBJECT),
+            well_known::NUMBER => Some(well_known::NUMBER),
+            _ => None,
+        }
+    }
+}
+
+/// Provides well-known names for string interning.
+mod well_known {
+    pub const OBJECT: &'static str = "object";
+    pub const NUMBER: &'static str = "number";
+}
+
+impl<T> From<T> for Name
+where
+    T: Into<String> + AsRef<str>,
+{
+    #[inline(always)]
+    fn from(value: T) -> Self {
+        Self::new(value)
+    }
+}
+
+impl AsRef<str> for Name {
+    #[inline(always)]
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Deref for Name {
+    type Target = str;
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl PartialEq<str> for Name {
+    #[inline(always)]
+    fn eq(&self, other: &str) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl PartialEq<&str> for Name {
+    #[inline(always)]
+    fn eq(&self, other: &&str) -> bool {
+        self.0.eq(*other)
+    }
+}
+
+impl PartialEq<String> for Name {
+    #[inline(always)]
+    fn eq(&self, other: &String) -> bool {
+        self.0.eq(other.as_str())
+    }
+}
+
+impl ToTyped<Name> for Name {
+    fn to_typed<I: Into<Type>>(self, r#type: I) -> Typed<Name> {
+        Typed::new(self, r#type.into())
+    }
+    fn to_typed_either<I: IntoIterator<Item = P>, P: Into<PrimitiveType>>(
+        self,
+        types: I,
+    ) -> Typed<Name> {
+        Typed::new(self, Type::from_iter(types))
+    }
+}
+
+impl NameVariant {
+    /// Gets the length of the name, in chars.
+    fn len(&self) -> usize {
+        match self {
+            NameVariant::String(s) => s.chars().count(),
+            NameVariant::Static(s) => s.chars().count(),
+        }
     }
 }
 
@@ -85,40 +190,5 @@ impl Display for NameVariant {
             NameVariant::String(str) => write!(f, "{}", str),
             NameVariant::Static(str) => write!(f, "{}", str),
         }
-    }
-}
-
-impl ToTyped<Name> for Name {
-    fn to_typed<I: Into<Type>>(self, r#type: I) -> Typed<Name> {
-        Typed::new(self, r#type.into())
-    }
-    fn to_typed_either<I: IntoIterator<Item = P>, P: Into<PrimitiveType>>(
-        self,
-        types: I,
-    ) -> Typed<Name> {
-        Typed::new(self, Type::from_iter(types))
-    }
-}
-
-impl From<&str> for Name {
-    #[inline(always)]
-    fn from(value: &str) -> Self {
-        Self::new(value)
-    }
-}
-
-impl AsRef<str> for Name {
-    #[inline(always)]
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
-}
-
-impl Deref for Name {
-    type Target = str;
-
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
     }
 }

--- a/tests/briefcase_world.rs
+++ b/tests/briefcase_world.rs
@@ -50,7 +50,7 @@ fn parse_domain_works() {
     assert!(remainder.is_empty());
 
     // All elements were parsed.
-    assert_eq!(domain.name(), &"briefcase-world".into());
+    assert_eq!(domain.name(), "briefcase-world");
     assert_eq!(domain.requirements().len(), 4);
     assert_eq!(domain.types().len(), 2);
     assert_eq!(domain.constants().len(), 3);
@@ -66,8 +66,8 @@ fn parse_problem_works() {
     assert!(remainder.is_empty());
 
     // All elements were parsed.
-    assert_eq!(problem.name(), &"get-paid".into());
-    assert_eq!(problem.domain(), &"briefcase-world".into());
+    assert_eq!(problem.name(), "get-paid");
+    assert_eq!(problem.domain(), "briefcase-world");
     assert!(problem.requirements().is_empty());
     assert_eq!(problem.init().len(), 9);
     assert_eq!(problem.goals().len(), 3);


### PR DESCRIPTION
If well-known names such as `object` or `number` are used for a `Name`, these values will be interned to a `'static str`.
This allows for `const` creation of `Type::OBJECT` and `FunctionType::NUMBER`.