### PR TITLE
Add string interning for generic Name values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Internal
 
 - The `thiserror` dependency is now only brought in with the `parser` crate feature.
+- Use string interning to reduce the number of allocations required for `Name` types.
 
 ## [0.0.5] - 2023-05-05
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ default = ["parser"]
 parser = ["dep:nom", "dep:nom-greedyerror", "dep:nom_locate", "dep:thiserror"]
 
 [dependencies]
+lazy_static = "1.4.0"
 nom = { version = "7.1.3", optional = true }
 nom-greedyerror = { version = "0.5.0", optional = true }
 nom_locate = { version = "4.1.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,12 @@ edition = "2021"
 rust-version = "1.68.0"
 
 [features]
-default = ["parser"]
+default = ["parser", "interning"]
 parser = ["dep:nom", "dep:nom-greedyerror", "dep:nom_locate", "dep:thiserror"]
+interning = ["dep:lazy_static"]
 
 [dependencies]
-lazy_static = "1.4.0"
+lazy_static = { version = "1.4.0", optional = true }
 nom = { version = "7.1.3", optional = true }
 nom-greedyerror = { version = "0.5.0", optional = true }
 nom_locate = { version = "4.1.0", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,11 @@
 //!
 //! This crates provides a PDDL 3.1 parser implementation based on [nom](https://crates.io/crates/nom).
 //!
+//! ## Default crate features
+//!
+//! * `parser` - Enables parsing of PDDL types through the [`Parser`] trait.
+//! * `interning` - Enables string interning for [`Name`] types to reduce memory footprint.
+//!
 //! ## Example
 //!
 //! The two core types of a PDDL are [`Domain`] and [`Problem`]. This example shows how to

--- a/src/parsers/atomic_formula_skeleton.rs
+++ b/src/parsers/atomic_formula_skeleton.rs
@@ -6,7 +6,7 @@ use crate::types::AtomicFormulaSkeleton;
 use nom::combinator::map;
 use nom::sequence::tuple;
 
-/// Parser that parses an atomic formula skeleton, i.e. `(<predicate> <typed list (variable)>)`.
+/// Parses an atomic formula skeleton, i.e. `(<predicate> <typed list (variable)>)`.
 ///
 /// ## Example
 /// ```
@@ -34,7 +34,7 @@ pub fn parse_atomic_formula_skeleton<'a, T: Into<Span<'a>>>(
 impl crate::parsers::Parser for AtomicFormulaSkeleton {
     type Item = AtomicFormulaSkeleton;
 
-    /// Parser that parses an atomic formula skeleton.
+    /// Parses an atomic formula skeleton.
     ///
     /// ## Example
     /// ```

--- a/src/parsers/atomic_function_skeleton.rs
+++ b/src/parsers/atomic_function_skeleton.rs
@@ -6,7 +6,7 @@ use crate::types::AtomicFunctionSkeleton;
 use nom::combinator::map;
 use nom::sequence::tuple;
 
-/// Parser that parses an atomic function skeleton, i.e. `(<function-symbol> <typed list (variable)>)`.
+/// Parses an atomic function skeleton, i.e. `(<function-symbol> <typed list (variable)>)`.
 ///
 /// ## Example
 /// ```
@@ -36,7 +36,7 @@ pub fn parse_atomic_function_skeleton<'a, T: Into<Span<'a>>>(
 impl crate::parsers::Parser for AtomicFunctionSkeleton {
     type Item = AtomicFunctionSkeleton;
 
-    /// Parser that parses an atomic function skeleton, i.e. `(<function-symbol> <typed list (variable)>)`.
+    /// Parses an atomic function skeleton, i.e. `(<function-symbol> <typed list (variable)>)`.
     ///
     /// ## Example
     /// ```

--- a/src/parsers/c_effect.rs
+++ b/src/parsers/c_effect.rs
@@ -9,7 +9,7 @@ use nom::character::complete::multispace1;
 use nom::combinator::map;
 use nom::sequence::{preceded, tuple};
 
-/// Parser that parses c-effects.
+/// Parses c-effects.
 ///
 /// ## Example
 /// ```
@@ -99,7 +99,7 @@ pub fn parse_c_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, CEffec
     alt((forall, when, p_effect))(input.into())
 }
 
-/// Parser that parses [`ForallCEffect`] values.
+/// Parses [`ForallCEffect`] values.
 ///
 /// ## Example
 /// ```
@@ -136,7 +136,7 @@ pub fn parse_forall_c_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a,
     )(input.into())
 }
 
-/// Parser that parses c-effects.
+/// Parses c-effects.
 ///
 /// ## Example
 /// ```
@@ -194,7 +194,7 @@ pub fn parse_when_c_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, W
 impl crate::parsers::Parser for CEffect {
     type Item = CEffect;
 
-    /// Parser that parses c-effects.
+    /// Parses c-effects.
     ///
     /// ## Example
     /// ```
@@ -246,7 +246,7 @@ impl crate::parsers::Parser for CEffect {
 impl crate::parsers::Parser for ForallCEffect {
     type Item = ForallCEffect;
 
-    /// Parser that parses [`ForallCEffect`] values.
+    /// Parses [`ForallCEffect`] values.
     ///
     /// ## Example
     /// ```
@@ -273,7 +273,7 @@ impl crate::parsers::Parser for ForallCEffect {
 impl crate::parsers::Parser for WhenCEffect {
     type Item = WhenCEffect;
 
-    /// Parser that parses c-effects.
+    /// Parses c-effects.
     ///
     /// ## Example
     /// ```

--- a/src/parsers/constants_def.rs
+++ b/src/parsers/constants_def.rs
@@ -4,7 +4,7 @@ use crate::parsers::{parse_name, prefix_expr, typed_list, ParseResult, Span};
 use crate::types::Constants;
 use nom::combinator::map;
 
-/// Parser that parses constant definitions, i.e. `(:constants <typed list (name)>)`.
+/// Parses constant definitions, i.e. `(:constants <typed list (name)>)`.
 ///
 /// ## Example
 /// ```

--- a/src/parsers/domain_constraints_def.rs
+++ b/src/parsers/domain_constraints_def.rs
@@ -4,7 +4,7 @@ use crate::parsers::{parse_con_gd, prefix_expr, ParseResult, Span};
 use crate::types::DomainConstraintsDef;
 use nom::combinator::map;
 
-/// Parser that parses domain constraint definitions, i.e. `(:constraints <con-gd>)`.
+/// Parses domain constraint definitions, i.e. `(:constraints <con-gd>)`.
 ///
 /// ## Example
 /// ```

--- a/src/parsers/effects.rs
+++ b/src/parsers/effects.rs
@@ -52,7 +52,7 @@ pub fn parse_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Effects>
         Effects::from,
     );
 
-    alt((exactly, all))(input.into())
+    alt((all, exactly))(input.into())
 }
 
 impl crate::parsers::Parser for Effects {

--- a/src/parsers/function_symbol.rs
+++ b/src/parsers/function_symbol.rs
@@ -2,6 +2,7 @@
 
 use crate::parsers::{parse_name, ParseResult, Span};
 use crate::types::FunctionSymbol;
+use nom::combinator::map;
 
 /// Parses a function symbol, i.e. `<name>`.
 ///
@@ -20,8 +21,7 @@ use crate::types::FunctionSymbol;
 /// assert!(parse_function_symbol("-1").is_err());
 ///```
 pub fn parse_function_symbol<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FunctionSymbol> {
-    let (remaining, name) = parse_name(input)?;
-    Ok((remaining, name.into()))
+    map(parse_name, FunctionSymbol::new)(input.into())
 }
 
 impl crate::parsers::Parser for FunctionSymbol {

--- a/src/parsers/functions_def.rs
+++ b/src/parsers/functions_def.rs
@@ -5,7 +5,7 @@ use crate::parsers::{prefix_expr, ParseResult, Span};
 use crate::types::Functions;
 use nom::combinator::map;
 
-/// Parser that parses constant definitions, i.e. `(:constants <typed list (name)>)`.
+/// Parses constant definitions, i.e. `(:constants <typed list (name)>)`.
 ///
 /// ## Example
 /// ```

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -110,6 +110,7 @@ pub type ParseError<'a> = nom_greedyerror::GreedyError<Span<'a>, nom::error::Err
 /// A result from a parser.
 pub type ParseResult<'a, T, E = ParseError<'a>> = nom::IResult<Span<'a>, T, E>;
 
+/// Re-exports commonly used types.
 pub mod preamble {
     pub use crate::parsers::test_helpers::UnwrapValue;
     pub use crate::parsers::Parser;

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -1,4 +1,4 @@
-//! Parser logic.
+//! Provides parsing functions, as well as the [`Parser`] trait.
 
 mod action_def;
 mod action_symbol;

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -81,7 +81,7 @@ mod variable;
 pub(crate) use test_helpers::Match;
 pub use test_helpers::UnwrapValue;
 
-/// Provides the `parse` method.
+/// Provides the [`Parser::parse`] and [`Parser::from_str`] methods.
 pub trait Parser {
     type Item;
 

--- a/src/parsers/p_effect.rs
+++ b/src/parsers/p_effect.rs
@@ -98,7 +98,7 @@ pub fn parse_p_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, PEffec
         |(f_term, term)| PEffect::new_object_fluent(f_term, Some(term)),
     );
 
-    alt((object_undefined, object, numeric, is_not, is))(input.into())
+    alt((is_not, object_undefined, object, numeric, is))(input.into())
 }
 
 impl crate::parsers::Parser for PEffect {
@@ -118,5 +118,16 @@ mod tests {
     fn it_works() {
         let input = "(can-move ?from-waypoint ?to-waypoint)";
         let (_, _effect) = parse_p_effect(Span::new(input)).unwrap();
+    }
+
+    #[test]
+    fn not_works() {
+        let input = "(not (at B ?m))";
+        let mut is_not = map(prefix_expr("not", atomic_formula(parse_term)), |af| {
+            PEffect::new_not(af)
+        });
+
+        let result = is_not(input.into());
+        assert!(result.is_ok());
     }
 }

--- a/src/parsers/predicates_def.rs
+++ b/src/parsers/predicates_def.rs
@@ -5,7 +5,7 @@ use crate::parsers::{prefix_expr, space_separated_list1};
 use crate::types::PredicateDefinitions;
 use nom::combinator::map;
 
-/// Parser that parses predicate definitions, i.e. `(:predicates <atomic formula skeleton>⁺)`.
+/// Parses predicate definitions, i.e. `(:predicates <atomic formula skeleton>⁺)`.
 ///
 /// ## Example
 /// ```

--- a/src/parsers/problem_constraints_def.rs
+++ b/src/parsers/problem_constraints_def.rs
@@ -4,7 +4,7 @@ use crate::parsers::{parse_pref_con_gd, prefix_expr, ParseResult, Span};
 use crate::types::ProblemConstraintsDef;
 use nom::combinator::map;
 
-/// Parser that parses problem constraint definitions, i.e. `(:constraints <pref-con-GD>)`.
+/// Parses problem constraint definitions, i.e. `(:constraints <pref-con-GD>)`.
 ///
 /// ## Example
 /// ```

--- a/src/parsers/timed_effect.rs
+++ b/src/parsers/timed_effect.rs
@@ -11,7 +11,7 @@ use nom::character::complete::multispace1;
 use nom::combinator::map;
 use nom::sequence::{preceded, tuple};
 
-/// Parser that parses timed effects.
+/// Parses timed effects.
 ///
 /// ## Example
 /// ```

--- a/src/parsers/types_def.rs
+++ b/src/parsers/types_def.rs
@@ -4,7 +4,7 @@ use crate::parsers::{parse_name, prefix_expr, typed_list, ParseResult, Span};
 use crate::types::Types;
 use nom::combinator::map;
 
-/// Parser that parses constant definitions, i.e. `(:constants <typed list (name)>)`.
+/// Parses constant definitions, i.e. `(:constants <typed list (name)>)`.
 ///
 /// ## Example
 /// ```

--- a/src/types/domain.rs
+++ b/src/types/domain.rs
@@ -10,6 +10,48 @@ use crate::types::{Name, Types};
 ///
 /// ## Usage
 /// This is the top-level type of a domain description. See also [`Problem`](crate::Problem).
+///
+/// ## Example
+/// ```
+/// # use pddl::{Domain, Name, Parser};
+/// let input = r#"(define (domain briefcase-world)
+///       (:requirements :strips :equality :typing :conditional-effects)
+///       (:types location physob)
+///       (:constants B P D - physob)
+///       (:predicates (at ?x - physob ?y - location)
+///                    (in ?x ?y - physob))
+///       (:constraints (and))
+///
+///       (:action mov-B
+///            :parameters (?m ?l - location)
+///            :precondition (and (at B ?m) (not (= ?m ?l)))
+///            :effect (and (at B ?l) (not (at B ?m))
+///                         (forall (?z)
+///                             (when (and (in ?z) (not (= ?z B)))
+///                                   (and (at ?z ?l) (not (at ?z ?m)))))) )
+///
+///       (:action put-in
+///            :parameters (?x - physob ?l - location)
+///            :precondition (not (= ?x B))
+///            :effect (when (and (at ?x ?l) (at B ?l))
+///                  (in ?x)) )
+///
+///       (:action take-out
+///            :parameters (?x - physob)
+///            :precondition (not (= ?x B))
+///            :effect (not (in ?x)) )
+///     )"#;
+///
+/// let domain = Domain::from_str(input).unwrap();
+///
+/// assert_eq!(domain.name(), "briefcase-world");
+/// assert_eq!(domain.requirements().len(), 4);
+/// assert_eq!(domain.types().len(), 2);
+/// assert_eq!(domain.constants().len(), 3);
+/// assert_eq!(domain.predicates().len(), 2);
+/// assert!(domain.constraints().is_empty());
+/// assert_eq!(domain.structure().len(), 3);
+/// ```
 #[derive(Debug, Clone, PartialEq)]
 pub struct Domain {
     name: Name,

--- a/src/types/name.rs
+++ b/src/types/name.rs
@@ -40,6 +40,10 @@ type InternedString = String;
 impl Name {
     /// Constructs a new [`Name`] from a provided string.
     ///
+    /// ## Interning
+    /// If the `interning` crate feature is enabled, strings passed to this
+    /// method will be deduplicated, reducing memory footprint.
+    ///
     /// ## Arguments
     /// * `name` - The name to wrap.
     ///
@@ -56,6 +60,12 @@ impl Name {
 
     /// Like [`new`] but makes use of the fact that if the string provided
     /// is `'static`, the method can be `const`.
+    ///
+    /// ## Interning
+    /// Note that strings passed to this method are not themselves interned
+    /// even if the create feature `interning` is enabled, and they will be invisible
+    /// to other strings partaking in interning. To ensure that a name value
+    /// exists exactly once, use the (non-const) [`Name::new`] function instead.
     ///
     /// ## Arguments
     /// * `name` - The name to wrap.
@@ -113,8 +123,8 @@ impl Name {
     /// Maps the provided to a well-known `'static` string if possible.
     fn map_to_static<'a>(value: &'a str) -> Option<&'static str> {
         match value {
-            well_known::OBJECT => Some(well_known::OBJECT),
-            well_known::NUMBER => Some(well_known::NUMBER),
+            "object" => Some(well_known::OBJECT),
+            "number" => Some(well_known::NUMBER),
             _ => None,
         }
     }
@@ -122,8 +132,8 @@ impl Name {
 
 /// Provides well-known names for string interning.
 mod well_known {
-    pub const OBJECT: &'static str = "object";
-    pub const NUMBER: &'static str = "number";
+    pub static OBJECT: &'static str = "object";
+    pub static NUMBER: &'static str = "number";
 }
 
 impl<T> From<T> for Name
@@ -242,5 +252,19 @@ impl Display for NameVariant {
             NameVariant::String(str) => write!(f, "{}", str),
             NameVariant::Static(str) => write!(f, "{}", str),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nom_greedyerror::AsStr;
+
+    #[test]
+    fn map_to_static_works() {
+        let object = Name::map_to_static("object").expect("mapping works");
+        let number = Name::map_to_static("number").expect("mapping works");
+        assert!(std::ptr::eq(object.as_str(), well_known::OBJECT));
+        assert!(std::ptr::eq(number.as_str(), well_known::NUMBER));
     }
 }

--- a/src/types/name.rs
+++ b/src/types/name.rs
@@ -1,8 +1,15 @@
 //! Contains names via the [`Name`] type.
 
 use crate::types::{PrimitiveType, ToTyped, Type, Typed};
+use lazy_static::lazy_static;
 use std::fmt::{Debug, Display, Formatter};
 use std::ops::Deref;
+use std::sync::{Arc, Mutex};
+
+lazy_static! {
+    /// Used in [`Name::new_string_interned`] to deduplicate string occurrences.
+    static ref STRING_INTERNING: Mutex<Vec<Arc<String>>> = Mutex::new(Vec::default());
+}
 
 /// A name.
 ///
@@ -18,7 +25,7 @@ pub struct Name(NameVariant);
 
 #[derive(Clone, PartialEq, Eq, Hash)]
 enum NameVariant {
-    String(String),
+    String(Arc<String>),
     Static(&'static str),
 }
 
@@ -35,7 +42,7 @@ impl Name {
         if let Some(str) = Self::map_to_static(name.as_ref()) {
             Self::new_static(str)
         } else {
-            Self(NameVariant::String(name.into()))
+            Self::new_string_interned(name)
         }
     }
 
@@ -56,6 +63,25 @@ impl Name {
     #[inline(always)]
     pub const fn new_static(name: &'static str) -> Self {
         Self(NameVariant::Static(name))
+    }
+
+    /// Takes the provided `name` and interns the string.
+    ///
+    /// This uses a simple binary search approach to identify the correct position of
+    /// the input in question and inserts the element if it wasn't found before.
+    fn new_string_interned<S: Into<String> + AsRef<str>>(name: S) -> Self {
+        let mut guard = STRING_INTERNING.lock().expect("failed to obtain lock");
+        let name_ref = name.as_ref();
+        let pos = guard.binary_search_by(|name| name_ref.cmp(name.as_str()));
+        let pos = match pos {
+            Ok(pos) => pos,
+            Err(pos) => {
+                guard.insert(pos, Arc::new(name.into()));
+                pos
+            }
+        };
+
+        Self(NameVariant::String(guard[pos].clone()))
     }
 
     pub fn is_empty(&self) -> bool {
@@ -172,7 +198,7 @@ impl Deref for NameVariant {
 impl PartialEq<str> for NameVariant {
     fn eq(&self, other: &str) -> bool {
         match self {
-            NameVariant::String(str) => str.eq(other),
+            NameVariant::String(str) => str.as_ref().eq(other),
             NameVariant::Static(str) => (*str).eq(other),
         }
     }

--- a/src/types/problem.rs
+++ b/src/types/problem.rs
@@ -10,6 +10,26 @@ use crate::{PreconditionGoalDefinitions, PrefConGDs};
 ///
 /// ## Usages
 /// This is the top-level type of a problem description within a [`Domain`](crate::Domain).
+///
+/// ## Example
+/// ```
+/// # use pddl::{Name, Parser, Problem};
+/// let input = r#"(define (problem get-paid)
+///         (:domain briefcase-world)
+///         (:init (place home) (place office)
+///                (object p) (object d) (object b)
+///                (at B home) (at P home) (at D home) (in P))
+///         (:goal (and (at B office) (at D office) (at P home)))
+///     )"#;
+///
+/// let problem = Problem::from_str(input).unwrap();
+///
+/// assert_eq!(problem.name(), "get-paid");
+/// assert_eq!(problem.domain(), "briefcase-world");
+/// assert!(problem.requirements().is_empty());
+/// assert_eq!(problem.init().len(), 9);
+/// assert_eq!(problem.goals().len(), 3);
+/// ```
 #[derive(Debug, Clone, PartialEq)]
 pub struct Problem {
     name: Name,


### PR DESCRIPTION
In #79, the well-known names `object` and `number` were interned (outside of `const` contexts). This PR introduces an additional `interning` crate feature that allows interning of any `Name` value. Since names are at the core of types, variables, predicates and more, this reduces memory footprint quite a bit.

---

In addition, a parsing order bug was fixed that would treat `and` in c-effects as a predicate rather than a combinator.