### PR TITLE
Add a line comment parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- [#81](https://github.com/sunsided/pddl-rs/issues/81): Added support for PDDL line comments.
+
 ## [0.0.6] - 2023-05-07
 
 ### Added

--- a/src/parsers/atomic_formula.rs
+++ b/src/parsers/atomic_formula.rs
@@ -5,9 +5,9 @@ use crate::parsers::{parse_predicate, ParseResult, Span};
 use crate::types::AtomicFormula;
 use nom::branch::alt;
 use nom::bytes::complete::tag;
-use nom::character::complete::{char, multispace1};
+use nom::character::complete::char;
 use nom::combinator::map;
-use nom::sequence::{delimited, preceded, tuple};
+use nom::sequence::{delimited, tuple};
 
 /// Parses an atomic formula, i.e. `(<predicate> t*) | (= t t)`.
 ///
@@ -31,12 +31,9 @@ where
 {
     let equality = map(
         delimited(
-            tag("(="),
-            preceded(
-                multispace1,
-                tuple((inner.clone(), preceded(multispace1, inner.clone()))),
-            ),
-            char(')'),
+            ws(tag("(=")),
+            tuple((ws(inner.clone()), ws(inner.clone()))),
+            ws(char(')')),
         ),
         |tuple| AtomicFormula::Equality(tuple.into()),
     );

--- a/src/parsers/comments.rs
+++ b/src/parsers/comments.rs
@@ -1,0 +1,63 @@
+use crate::parsers::{ParseResult, Span};
+use nom::character::complete::{char, multispace0};
+use nom::combinator::opt;
+use nom::sequence::{terminated, tuple};
+use nom::{bytes::complete::is_not, combinator::value, sequence::pair};
+
+/// Parses a comment and swallows trailing whitespace / newline.
+///
+/// ## Example
+///
+/// Comments are parsed and trailing whitespace is suppressed:
+///
+/// ```
+/// # use pddl::parsers::{ignore_eol_comment};
+/// let input = "; nothing\n\t; and this line\n\tthen more";
+///
+/// let (remainder, comment) = ignore_eol_comment(input).unwrap();
+///
+/// assert_eq!(comment, ());
+/// assert_eq!(remainder.to_ascii_lowercase().trim(), "then more");
+/// ```
+///
+/// If no comments are found, the text parses as expected, although leading whitespace is still suppressed.
+///
+/// ```
+/// # use pddl::parsers::{ignore_eol_comment};
+/// let input = "then more";
+///
+/// let (remainder, comment) = ignore_eol_comment(input).unwrap();
+///
+/// assert_eq!(comment, ());
+/// assert_eq!(remainder.to_ascii_lowercase().trim(), "then more");
+/// ```
+pub fn ignore_eol_comment<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, ()> {
+    value(
+        (), // Output is thrown away.
+        opt(terminated(
+            pair(char(';'), is_not("\r\n")),
+            tuple((multispace0, opt(ignore_eol_comment))),
+        )),
+    )(input.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_line() {
+        let input = "; nothing";
+        let (remainder, comment) = ignore_eol_comment(input).unwrap();
+        assert_eq!(comment, ());
+        assert!(remainder.is_empty());
+    }
+
+    #[test]
+    fn precedes_text() {
+        let input = "; nothing\n\r\tlast line";
+        let (remainder, comment) = ignore_eol_comment(input).unwrap();
+        assert_eq!(comment, ());
+        assert_eq!(remainder.to_ascii_lowercase(), "last line");
+    }
+}

--- a/src/parsers/domain.rs
+++ b/src/parsers/domain.rs
@@ -4,7 +4,7 @@ use crate::parsers::{
     parse_constants_def, parse_domain_constraints_def, parse_functions_def, parse_predicates_def,
     parse_require_def, parse_structure_def, ParseResult, Span,
 };
-use crate::parsers::{parse_name, parse_types_def, prefix_expr, space_separated_list1, ws};
+use crate::parsers::{parse_name, parse_types_def, prefix_expr, space_separated_list1, ws2};
 use crate::types::{
     Constants, Domain, Functions, PredicateDefinitions, Requirements, StructureDefs,
 };
@@ -60,7 +60,7 @@ use nom::sequence::{preceded, tuple};
 /// ```
 pub fn parse_domain<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Domain> {
     map(
-        ws(prefix_expr(
+        ws2(prefix_expr(
             "define",
             tuple((
                 prefix_expr("domain", parse_name),
@@ -117,14 +117,18 @@ impl crate::parsers::Parser for Domain {
     /// ## Example
     /// ```
     /// # use pddl::{Domain, Name, Parser};
-    /// let input = r#"(define (domain briefcase-world)
+    /// let input = r#"
+    ///  ; A toy domain.
+    ///  (define (domain briefcase-world)
+    ///       ; If no requirements are provided, :strips is implied.
     ///       (:requirements :strips :equality :typing :conditional-effects)
-    ///       (:types location physob)
+    ///       (:types location physob) ; type definitions could also be represented as predicates
     ///       (:constants B P D - physob)
     ///       (:predicates (at ?x - physob ?y - location)
     ///                    (in ?x ?y - physob))
     ///       (:constraints (and))
     ///
+    ///       ; Move briefcase from one location to another.
     ///       (:action mov-B
     ///            :parameters (?m ?l - location)
     ///            :precondition (and (at B ?m) (not (= ?m ?l)))
@@ -133,12 +137,14 @@ impl crate::parsers::Parser for Domain {
     ///                             (when (and (in ?z) (not (= ?z B)))
     ///                                   (and (at ?z ?l) (not (at ?z ?m)))))) )
     ///
+    ///       ; Put the item in the briefcase if it is not already in there.
     ///       (:action put-in
     ///            :parameters (?x - physob ?l - location)
     ///            :precondition (not (= ?x B))
     ///            :effect (when (and (at ?x ?l) (at B ?l))
     ///                  (in ?x)) )
     ///
+    ///       ; Take the item out of the briefcase if it is in there.
     ///       (:action take-out
     ///            :parameters (?x - physob)
     ///            :precondition (not (= ?x B))

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -11,6 +11,7 @@ mod basic_function_term;
 mod binary_comp;
 mod binary_op;
 mod c_effect;
+mod comments;
 mod con_gd;
 mod cond_effect;
 mod constants_def;
@@ -128,6 +129,7 @@ pub use basic_function_term::parse_basic_function_term;
 pub use binary_comp::parse_binary_comp;
 pub use binary_op::parse_binary_op;
 pub use c_effect::{parse_c_effect, parse_forall_c_effect, parse_when_c_effect};
+pub use comments::ignore_eol_comment;
 pub use con_gd::parse_con_gd;
 pub use cond_effect::parse_cond_effect;
 pub use constants_def::parse_constants_def;
@@ -197,4 +199,6 @@ pub use typed_list::typed_list;
 
 // Utility parser combinators.
 #[allow(unused_imports)]
-pub(crate) use utilities::{parens, prefix_expr, space_separated_list0, space_separated_list1, ws};
+pub(crate) use utilities::{
+    parens, prefix_expr, space_separated_list0, space_separated_list1, ws, ws2,
+};

--- a/src/parsers/name.rs
+++ b/src/parsers/name.rs
@@ -1,6 +1,6 @@
 //! Provides parsers for names.
 
-use crate::parsers::{ParseResult, Span};
+use crate::parsers::{ws, ParseResult, Span};
 use crate::types::Name;
 use nom::branch::alt;
 use nom::bytes::complete::tag;
@@ -27,7 +27,7 @@ use nom::sequence::tuple;
 ///```
 pub fn parse_name<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Name> {
     map(
-        recognize(tuple((alpha1, many0(parse_any_char)))),
+        ws(recognize(tuple((alpha1, many0(parse_any_char))))),
         |x: Span| Name::from(*x.fragment()),
     )(input.into())
 }

--- a/src/parsers/problem.rs
+++ b/src/parsers/problem.rs
@@ -1,6 +1,6 @@
 //! Provides parsers for problem definitions.
 
-use crate::parsers::{parse_name, prefix_expr, ws, ParseResult, Span};
+use crate::parsers::{parse_name, prefix_expr, ws2, ParseResult, Span};
 use crate::parsers::{
     parse_problem_constraints_def, parse_problem_goal_def, parse_problem_init_def,
     parse_problem_length_spec, parse_problem_metric_spec, parse_problem_objects_declaration,
@@ -37,7 +37,7 @@ use nom::sequence::{preceded, tuple};
 /// ```
 pub fn parse_problem<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Problem> {
     map(
-        ws(prefix_expr(
+        ws2(prefix_expr(
             "define",
             tuple((
                 prefix_expr("problem", parse_name),

--- a/src/types/domain.rs
+++ b/src/types/domain.rs
@@ -17,11 +17,16 @@ use crate::types::{Name, Types};
 /// let input = r#"(define (domain briefcase-world)
 ///       (:requirements :strips :equality :typing :conditional-effects)
 ///       (:types location physob)
-///       (:constants B P D - physob)
-///       (:predicates (at ?x - physob ?y - location)
-///                    (in ?x ?y - physob))
+///       (:constants
+///             B ; the briefcase
+///             P ; the paycheck
+///             D
+///             - physob)
+///       (:predicates (at ?x - physob ?y - location) ; an item is at a location
+///                    (in ?x ?y - physob))           ; an item is in another item
 ///       (:constraints (and))
 ///
+///       ; Move briefcase from one location to another.
 ///       (:action mov-B
 ///            :parameters (?m ?l - location)
 ///            :precondition (and (at B ?m) (not (= ?m ?l)))
@@ -30,15 +35,17 @@ use crate::types::{Name, Types};
 ///                             (when (and (in ?z) (not (= ?z B)))
 ///                                   (and (at ?z ?l) (not (at ?z ?m)))))) )
 ///
+///       ; Put the item in the briefcase.
 ///       (:action put-in
 ///            :parameters (?x - physob ?l - location)
-///            :precondition (not (= ?x B))
+///            :precondition (not (= ?x B))  ; the item must not be the briefcase itself
 ///            :effect (when (and (at ?x ?l) (at B ?l))
 ///                  (in ?x)) )
 ///
+///       ; Take the item out of the briefcase.
 ///       (:action take-out
 ///            :parameters (?x - physob)
-///            :precondition (not (= ?x B))
+///            :precondition (not (= ?x B)) ; the item must be the briefcase itself
 ///            :effect (not (in ?x)) )
 ///     )"#;
 ///

--- a/tests/briefcase_world.rs
+++ b/tests/briefcase_world.rs
@@ -7,10 +7,15 @@ pub const BRIEFCASE_WORLD: &'static str = r#"
     (define (domain briefcase-world)
       (:requirements :strips :equality :typing :conditional-effects)
       (:types location physob)
-      (:constants B P D - physob)
+      (:constants
+            B ; the briefcase
+            P ; the paycheck
+            D
+            - physob)
       (:predicates (at ?x - physob ?y - location)
                    (in ?x ?y - physob))
 
+      ; Move briefcase from one location to another.
       (:action mov-B
            :parameters (?m ?l - location)
            :precondition (and (at B ?m) (not (= ?m ?l)))
@@ -19,16 +24,19 @@ pub const BRIEFCASE_WORLD: &'static str = r#"
                             (when (and (in ?z) (not (= ?z B)))
                                   (and (at ?z ?l) (not (at ?z ?m)))))) )
 
+      ; Put the item in the briefcase.
       (:action put-in
            :parameters (?x - physob ?l - location)
-           :precondition (not (= ?x B))
-           :effect (when (and (at ?x ?l) (at B ?l))
-                 (in ?x)) )
+           :precondition (not (= ?x B))     ; the item must not be the briefcase itself
+           :effect (when
+                 (and (at ?x ?l) (at B ?l)) ; briefcase and item are at the same location
+                 (in ?x)) )                 ; ... then the item is in the briefcase.
 
+      ; Take the item out of the briefcase.
       (:action take-out
            :parameters (?x - physob)
-           :precondition (not (= ?x B))
-           :effect (not (in ?x)) )
+           :precondition (not (= ?x B))     ; the item must be the briefcase itself
+           :effect (not (in ?x)) )          ; the item is not in the briefcase anymore.
     )
     "#;
 
@@ -63,7 +71,7 @@ fn parse_problem_works() {
     let (remainder, problem) = Problem::parse(BRIEFCASE_WORLD_PROBLEM).unwrap();
 
     // The input was parsed completely, nothing followed the problem definition.
-    assert!(remainder.is_empty());
+    assert!(remainder.is_empty(), "{}", remainder);
 
     // All elements were parsed.
     assert_eq!(problem.name(), "get-paid");


### PR DESCRIPTION
This adds a parser for `;` line comments. PDDL descriptions like this are now supported:

```pddl
(define (problem get-paid)
    (:domain briefcase-world)
    (:init
            ; types: locations
            (place home) (place office)
            ; types: objects
            (object p) (object d) (object b)
            ; setup
            (at B home) (at P home) (at D home) (in P))
    (:goal (and (at B office) (at D office) (at P home)))
)
```

Fixes #81.