### PR TITLE
Improve parser test coverage

### DIFF
--- a/src/parsers/action_symbol.rs
+++ b/src/parsers/action_symbol.rs
@@ -1,8 +1,9 @@
 //! Provides parsers for action symbols.
 
+use nom::combinator::map;
+
 use crate::parsers::{parse_name, ParseResult, Span};
 use crate::types::ActionSymbol;
-use nom::combinator::map;
 
 /// Parses an action symbol, i.e. `<name>`.
 ///
@@ -40,5 +41,16 @@ impl crate::parsers::Parser for ActionSymbol {
     /// See [`parse_action_symbol`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_action_symbol(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{ActionSymbol, Parser};
+
+    #[test]
+    fn test_parse() {
+        let (_, action_symbol) = ActionSymbol::parse("abcde").unwrap();
+        assert_eq!(action_symbol, "abcde".into());
     }
 }

--- a/src/parsers/assign_op.rs
+++ b/src/parsers/assign_op.rs
@@ -1,11 +1,12 @@
 //! Provides parsers for assignment operations.
 
-use crate::parsers::{ParseResult, Span};
-use crate::types::assign_op::names;
-use crate::types::AssignOp;
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::combinator::map;
+
+use crate::parsers::{ParseResult, Span};
+use crate::types::assign_op::names;
+use crate::types::AssignOp;
 
 /// Parses an assignment operation, i.e. `assign | scale-up | scale-down | increase | decrease`.
 ///
@@ -47,5 +48,19 @@ impl crate::parsers::Parser for AssignOp {
     ///```
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_assign_op(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{AssignOp, Parser};
+
+    #[test]
+    fn test_parse() {
+        let (_, assign_op) = AssignOp::parse("assign").unwrap();
+        assert_eq!(assign_op, AssignOp::Assign);
+
+        let (_, assign_op) = AssignOp::parse("scale-up").unwrap();
+        assert_eq!(assign_op, AssignOp::ScaleUp);
     }
 }

--- a/src/parsers/assign_op_t.rs
+++ b/src/parsers/assign_op_t.rs
@@ -1,11 +1,12 @@
 //! Provides parsers for assignment operations.
 
-use crate::parsers::{ParseResult, Span};
-use crate::types::assign_op_t::names;
-use crate::types::AssignOpT;
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::combinator::map;
+
+use crate::parsers::{ParseResult, Span};
+use crate::types::assign_op_t::names;
+use crate::types::AssignOpT;
 
 /// Parses an assignment operation, i.e. `increase | decrease`.
 ///
@@ -39,5 +40,16 @@ impl crate::parsers::Parser for AssignOpT {
     /// See [`parse_assign_op_t`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_assign_op_t(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{AssignOpT, Parser};
+
+    #[test]
+    fn test_parse() {
+        let (_, value) = AssignOpT::parse("increase").unwrap();
+        assert_eq!(value, AssignOpT::Increase);
     }
 }

--- a/src/parsers/atomic_formula.rs
+++ b/src/parsers/atomic_formula.rs
@@ -49,11 +49,24 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::parsers::parse_term;
+    use crate::parsers::{parse_name, parse_term, UnwrapValue};
+    use crate::{EqualityAtomicFormula, Predicate, PredicateAtomicFormula};
 
     #[test]
     fn it_works() {
         let input = "(can-move ?from-waypoint ?to-waypoint)";
         let (_, _effect) = atomic_formula(parse_term)(Span::new(input)).unwrap();
+    }
+
+    #[test]
+    fn test_parse() {
+        assert!(atomic_formula(parse_name)(Span::new("(= x y)")).is_value(
+            AtomicFormula::Equality(EqualityAtomicFormula::new("x".into(), "y".into()))
+        ));
+        assert!(
+            atomic_formula(parse_name)(Span::new("(move a b)")).is_value(AtomicFormula::Predicate(
+                PredicateAtomicFormula::new(Predicate::from("move"), vec!["a".into(), "b".into()])
+            ))
+        );
     }
 }

--- a/src/parsers/atomic_formula_skeleton.rs
+++ b/src/parsers/atomic_formula_skeleton.rs
@@ -27,7 +27,7 @@ pub fn parse_atomic_formula_skeleton<'a, T: Into<Span<'a>>>(
 ) -> ParseResult<'a, AtomicFormulaSkeleton> {
     map(
         parens(tuple((parse_predicate, ws(typed_list(parse_variable))))),
-        |tuple| AtomicFormulaSkeleton::from(tuple),
+        AtomicFormulaSkeleton::from,
     )(input.into())
 }
 

--- a/src/parsers/atomic_formula_skeleton.rs
+++ b/src/parsers/atomic_formula_skeleton.rs
@@ -59,3 +59,25 @@ impl crate::parsers::Parser for AtomicFormulaSkeleton {
         parse_atomic_formula_skeleton(input)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{AtomicFormulaSkeleton, Parser, Predicate, Variable};
+    use crate::{ToTyped, TypedList};
+
+    #[test]
+    fn test_parse() {
+        let (_, value) = AtomicFormulaSkeleton::parse("(at ?x - physob ?y - location)").unwrap();
+
+        assert_eq!(
+            value,
+            AtomicFormulaSkeleton::new(
+                Predicate::from("at"),
+                TypedList::from_iter([
+                    Variable::from("x").to_typed("physob"),
+                    Variable::from("y").to_typed("location")
+                ])
+            )
+        );
+    }
+}

--- a/src/parsers/atomic_function_skeleton.rs
+++ b/src/parsers/atomic_function_skeleton.rs
@@ -29,7 +29,7 @@ pub fn parse_atomic_function_skeleton<'a, T: Into<Span<'a>>>(
             parse_function_symbol,
             ws(typed_list(parse_variable)),
         ))),
-        |tuple| AtomicFunctionSkeleton::from(tuple),
+        AtomicFunctionSkeleton::from,
     )(input.into())
 }
 

--- a/src/parsers/atomic_function_skeleton.rs
+++ b/src/parsers/atomic_function_skeleton.rs
@@ -40,8 +40,7 @@ impl crate::parsers::Parser for AtomicFunctionSkeleton {
     ///
     /// ## Example
     /// ```
-    /// # use pddl::parsers::{parse_atomic_function_skeleton, Span, UnwrapValue};
-    /// # use pddl::{Variable, AtomicFunctionSkeleton, Predicate, FunctionSymbol, Parser};
+    /// # use pddl::{Variable, AtomicFunctionSkeleton, FunctionSymbol, Parser};
     /// # use pddl::{ToTyped, TypedList};
     /// let (_, value) = AtomicFunctionSkeleton::parse("(battery-amount ?r - rover)").unwrap();
     ///
@@ -58,5 +57,23 @@ impl crate::parsers::Parser for AtomicFunctionSkeleton {
     /// See [`parse_atomic_function_skeleton`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_atomic_function_skeleton(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{AtomicFunctionSkeleton, FunctionSymbol, Parser, Variable};
+    use crate::{ToTyped, TypedList};
+
+    #[test]
+    fn test_parse() {
+        let (_, value) = AtomicFunctionSkeleton::parse("(battery-amount ?r - rover)").unwrap();
+        assert_eq!(
+            value,
+            AtomicFunctionSkeleton::new(
+                FunctionSymbol::from("battery-amount"),
+                TypedList::from_iter([Variable::from("r").to_typed("rover")])
+            )
+        );
     }
 }

--- a/src/parsers/basic_function_term.rs
+++ b/src/parsers/basic_function_term.rs
@@ -66,3 +66,23 @@ impl crate::parsers::Parser for BasicFunctionTerm {
         parse_basic_function_term(input)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{BasicFunctionTerm, Parser};
+
+    #[test]
+    fn test_parse() {
+        let (_, value) = BasicFunctionTerm::parse("abcde").unwrap();
+        assert_eq!(value, BasicFunctionTerm::new("abcde".into(), []));
+
+        let (_, value) = BasicFunctionTerm::parse("(abcde)").unwrap();
+        assert_eq!(value, BasicFunctionTerm::new("abcde".into(), []));
+
+        let (_, value) = BasicFunctionTerm::parse("(abcde x y z)").unwrap();
+        assert_eq!(
+            value,
+            BasicFunctionTerm::new("abcde".into(), ["x".into(), "y".into(), "z".into()])
+        );
+    }
+}

--- a/src/parsers/binary_comp.rs
+++ b/src/parsers/binary_comp.rs
@@ -1,10 +1,11 @@
 //! Provides parsers for binary comparison operations.
 
-use crate::parsers::{ParseResult, Span};
-use crate::types::{binary_comp::names, BinaryComp};
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::combinator::map;
+
+use crate::parsers::{ParseResult, Span};
+use crate::types::{binary_comp::names, BinaryComp};
 
 /// Parses a binary comparison operation.
 ///
@@ -47,5 +48,28 @@ impl crate::parsers::Parser for BinaryComp {
     /// See [`parse_binary_comp`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_binary_comp(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{BinaryComp, Parser};
+
+    #[test]
+    fn test_parse() {
+        let (_, value) = BinaryComp::parse(">=").unwrap();
+        assert_eq!(value, BinaryComp::GreaterOrEqual);
+
+        let (_, value) = BinaryComp::parse(">").unwrap();
+        assert_eq!(value, BinaryComp::GreaterThan);
+
+        let (_, value) = BinaryComp::parse("<=").unwrap();
+        assert_eq!(value, BinaryComp::LessThanOrEqual);
+
+        let (_, value) = BinaryComp::parse("<").unwrap();
+        assert_eq!(value, BinaryComp::LessThan);
+
+        let (_, value) = BinaryComp::parse("=").unwrap();
+        assert_eq!(value, BinaryComp::Equal);
     }
 }

--- a/src/parsers/binary_op.rs
+++ b/src/parsers/binary_op.rs
@@ -1,10 +1,11 @@
 //! Provides parsers for binary-operand operations.
 
-use crate::parsers::{ParseResult, Span};
-use crate::types::{binary_op::names, BinaryOp};
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::combinator::map;
+
+use crate::parsers::{ParseResult, Span};
+use crate::types::{binary_op::names, BinaryOp};
 
 /// Parses a two-operand operation, i.e. `* | + | - | /`.
 ///
@@ -45,5 +46,25 @@ impl crate::parsers::Parser for BinaryOp {
     /// See [`parse_binary_op`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_binary_op(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{BinaryOp, Parser};
+
+    #[test]
+    fn test_parse() {
+        let (_, value) = BinaryOp::parse("*").unwrap();
+        assert_eq!(value, BinaryOp::Multiplication);
+
+        let (_, value) = BinaryOp::parse("/").unwrap();
+        assert_eq!(value, BinaryOp::Division);
+
+        let (_, value) = BinaryOp::parse("+").unwrap();
+        assert_eq!(value, BinaryOp::Addition);
+
+        let (_, value) = BinaryOp::parse("-").unwrap();
+        assert_eq!(value, BinaryOp::Subtraction);
     }
 }

--- a/src/parsers/con_gd.rs
+++ b/src/parsers/con_gd.rs
@@ -282,3 +282,23 @@ impl crate::parsers::Parser for Con2GD {
         parse_con2_gd(input)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::preamble::*;
+    use crate::{AtomicFormula, Con2GD, ConGD, GoalDefinition, Number, Term};
+
+    #[test]
+    fn test_parse() {
+        let gd = GoalDefinition::new_atomic_formula(AtomicFormula::new_equality(
+            Term::Name("x".into()),
+            Term::Name("y".into()),
+        ));
+
+        let input = "(within 10 (at-most-once (= x y)))";
+        assert!(ConGD::parse(input).is_value(ConGD::new_within(
+            Number::from(10),
+            Con2GD::new_nested(ConGD::new_at_most_once(Con2GD::new_goal(gd)))
+        )));
+    }
+}

--- a/src/parsers/con_gd.rs
+++ b/src/parsers/con_gd.rs
@@ -298,7 +298,15 @@ mod tests {
         let input = "(within 10 (at-most-once (= x y)))";
         assert!(ConGD::parse(input).is_value(ConGD::new_within(
             Number::from(10),
-            Con2GD::new_nested(ConGD::new_at_most_once(Con2GD::new_goal(gd)))
+            Con2GD::new_nested(ConGD::new_at_most_once(Con2GD::new_goal(gd.clone())))
         )));
+
+        let input = "(within 10 (at-most-once (= x y)))";
+        assert!(
+            Con2GD::parse(input).is_value(Con2GD::Nested(Box::new(ConGD::new_within(
+                Number::from(10),
+                Con2GD::new_nested(ConGD::new_at_most_once(Con2GD::new_goal(gd)))
+            ))))
+        );
     }
 }

--- a/src/parsers/cond_effect.rs
+++ b/src/parsers/cond_effect.rs
@@ -1,10 +1,11 @@
 //! Provides parsers for conditional effects.
 
+use nom::branch::alt;
+use nom::combinator::map;
+
 use crate::parsers::{parse_p_effect, ParseResult, Span};
 use crate::parsers::{prefix_expr, space_separated_list0};
 use crate::types::ConditionalEffect;
-use nom::branch::alt;
-use nom::combinator::map;
 
 /// Parses conditional effects.
 ///
@@ -56,5 +57,38 @@ impl crate::parsers::Parser for ConditionalEffect {
     /// See [`parse_cond_effect`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_cond_effect(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::UnwrapValue;
+    use crate::{AtomicFormula, ConditionalEffect, EqualityAtomicFormula, PEffect, Parser, Term};
+
+    #[test]
+    fn test_parse() {
+        assert!(
+            ConditionalEffect::parse("(= x y)").is_value(ConditionalEffect::Single(
+                PEffect::AtomicFormula(AtomicFormula::Equality(EqualityAtomicFormula::new(
+                    Term::Name("x".into()),
+                    Term::Name("y".into())
+                )))
+            ))
+        );
+
+        assert!(
+            ConditionalEffect::parse("(and (= x y) (not (= ?a B)))").is_value(
+                ConditionalEffect::All(vec![
+                    PEffect::AtomicFormula(AtomicFormula::Equality(EqualityAtomicFormula::new(
+                        Term::Name("x".into()),
+                        Term::Name("y".into())
+                    ))),
+                    PEffect::NotAtomicFormula(AtomicFormula::Equality(EqualityAtomicFormula::new(
+                        Term::Variable("a".into()),
+                        Term::Name("B".into())
+                    )))
+                ])
+            )
+        );
     }
 }

--- a/src/parsers/constants_def.rs
+++ b/src/parsers/constants_def.rs
@@ -1,8 +1,9 @@
 //! Provides parsers for constant definitions.
 
+use nom::combinator::map;
+
 use crate::parsers::{parse_name, prefix_expr, typed_list, ParseResult, Span};
 use crate::types::Constants;
-use nom::combinator::map;
 
 /// Parses constant definitions, i.e. `(:constants <typed list (name)>)`.
 ///
@@ -31,5 +32,23 @@ impl crate::parsers::Parser for Constants {
     /// See [`parse_constants_def`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_constants_def(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::UnwrapValue;
+    use crate::{Constants, Name, Parser, ToTyped, TypedList};
+
+    #[test]
+    fn test_parse() {
+        let input = "(:constants B P D - physob)";
+        assert!(
+            Constants::parse(input).is_value(Constants::new(TypedList::from_iter([
+                Name::from("B").to_typed("physob"),
+                Name::from("P").to_typed("physob"),
+                Name::from("D").to_typed("physob"),
+            ])))
+        );
     }
 }

--- a/src/parsers/d_op.rs
+++ b/src/parsers/d_op.rs
@@ -1,10 +1,11 @@
 //! Provides parsers for durative operations.
 
-use crate::parsers::{ParseResult, Span};
-use crate::types::{d_op::names, DOp};
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::combinator::map;
+
+use crate::parsers::{ParseResult, Span};
+use crate::types::{d_op::names, DOp};
 
 /// Parses a durative operation, i.e. `<= | >= | =`.
 ///
@@ -47,5 +48,18 @@ impl crate::parsers::Parser for DOp {
     /// See [`parse_d_op`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_d_op(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::UnwrapValue;
+    use crate::{DOp, Parser};
+
+    #[test]
+    fn test_parse() {
+        assert!(DOp::parse("<=").is_value(DOp::LessThanOrEqual));
+        assert!(DOp::parse(">=").is_value(DOp::GreaterOrEqual));
+        assert!(DOp::parse("=").is_value(DOp::Equal));
     }
 }

--- a/src/parsers/d_value.rs
+++ b/src/parsers/d_value.rs
@@ -1,10 +1,11 @@
 //! Provides parsers for d-values.
 
+use nom::branch::alt;
+use nom::combinator::map;
+
 use crate::parsers::parse_number;
 use crate::parsers::{parse_f_exp, ParseResult, Span};
 use crate::types::DurationValue;
-use nom::branch::alt;
-use nom::combinator::map;
 
 /// Parses a d-value.
 ///
@@ -37,5 +38,22 @@ impl crate::parsers::Parser for DurationValue {
     /// See [`parse_d_value`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_d_value(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::UnwrapValue;
+    use crate::{DurationValue, FExp, FHead, Parser};
+
+    #[test]
+    fn test_parse() {
+        assert!(DurationValue::parse("1.23").is_value(DurationValue::new_number(1.23)));
+
+        assert!(
+            DurationValue::parse("fun-sym").is_value(DurationValue::new_f_exp(FExp::new_function(
+                FHead::Simple("fun-sym".into())
+            )))
+        );
     }
 }

--- a/src/parsers/da_def.rs
+++ b/src/parsers/da_def.rs
@@ -103,6 +103,7 @@ impl crate::parsers::Parser for DurativeActionDefinition {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Parser;
 
     #[test]
     fn it_works() {
@@ -134,6 +135,6 @@ mod tests {
                         (at end (increase (distance-travelled) 5))
                         )
             )"#;
-        let (_, _gd) = parse_da_def(Span::new(input)).unwrap();
+        let (_, _gd) = DurativeActionDefinition::parse(Span::new(input)).unwrap();
     }
 }

--- a/src/parsers/da_symbol.rs
+++ b/src/parsers/da_symbol.rs
@@ -33,3 +33,14 @@ impl crate::parsers::Parser for DurativeActionSymbol {
         parse_da_symbol(input)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{DurativeActionSymbol, Parser};
+
+    #[test]
+    fn test_parse() {
+        let (_, value) = DurativeActionSymbol::parse("abcde").unwrap();
+        assert_eq!(value, "abcde".into());
+    }
+}

--- a/src/parsers/derived_predicate.rs
+++ b/src/parsers/derived_predicate.rs
@@ -1,11 +1,12 @@
 //! Provides parsers for derived predicates.
 
-use crate::parsers::{parse_atomic_formula_skeleton, parse_gd};
-use crate::parsers::{prefix_expr, ParseResult, Span};
-use crate::types::DerivedPredicate;
 use nom::character::complete::multispace1;
 use nom::combinator::map;
 use nom::sequence::{preceded, tuple};
+
+use crate::parsers::{parse_atomic_formula_skeleton, parse_gd};
+use crate::parsers::{prefix_expr, ParseResult, Span};
+use crate::types::DerivedPredicate;
 
 /// Parses a derived predicate, i.e. `(:derived <atomic formula skeleton> <GD>)`.
 ///
@@ -45,5 +46,24 @@ impl crate::parsers::Parser for DerivedPredicate {
     /// See [`parse_derived_predicate`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_derived_predicate(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{DerivedPredicate, GoalDefinition, Parser};
+
+    #[test]
+    fn test_parse() {
+        let input = r#"(:derived (train-usable ?t - train)
+                            (and
+                                (train-has-guard ?t)
+                                (train-has-driver ?t)
+                            )
+                        )"#;
+
+        let (_, predicate) = DerivedPredicate::parse(input).unwrap();
+        assert_eq!(predicate.predicate().name(), "train-usable");
+        assert!(matches!(predicate.expression(), &GoalDefinition::And(..)));
     }
 }

--- a/src/parsers/domain.rs
+++ b/src/parsers/domain.rs
@@ -1,5 +1,9 @@
 //! Provides parsers for domain definitions.
 
+use nom::character::complete::multispace1;
+use nom::combinator::{map, opt};
+use nom::sequence::{preceded, tuple};
+
 use crate::parsers::{
     parse_constants_def, parse_domain_constraints_def, parse_functions_def, parse_predicates_def,
     parse_require_def, parse_structure_def, ParseResult, Span,
@@ -9,9 +13,6 @@ use crate::types::{
     Constants, Domain, Functions, PredicateDefinitions, Requirements, StructureDefs,
 };
 use crate::types::{DomainConstraintsDef, Types};
-use nom::character::complete::multispace1;
-use nom::combinator::{map, opt};
-use nom::sequence::{preceded, tuple};
 
 /// Parses a domain definition.
 ///
@@ -166,5 +167,57 @@ impl crate::parsers::Parser for Domain {
     /// See [`parse_domain`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_domain(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Domain, Name, Parser};
+
+    #[test]
+    fn test_parse() {
+        let input = r#"
+         ; A toy domain.
+         (define (domain briefcase-world)
+              ; If no requirements are provided, :strips is implied.
+              (:requirements :strips :equality :typing :conditional-effects)
+              (:types location physob) ; type definitions could also be represented as predicates
+              (:constants B P D - physob)
+              (:predicates (at ?x - physob ?y - location)
+                           (in ?x ?y - physob))
+              (:constraints (and))
+
+              ; Move briefcase from one location to another.
+              (:action mov-B
+                   :parameters (?m ?l - location)
+                   :precondition (and (at B ?m) (not (= ?m ?l)))
+                   :effect (and (at B ?l) (not (at B ?m))
+                                (forall (?z)
+                                    (when (and (in ?z) (not (= ?z B)))
+                                          (and (at ?z ?l) (not (at ?z ?m)))))) )
+
+              ; Put the item in the briefcase if it is not already in there.
+              (:action put-in
+                   :parameters (?x - physob ?l - location)
+                   :precondition (not (= ?x B))
+                   :effect (when (and (at ?x ?l) (at B ?l))
+                         (in ?x)) )
+
+              ; Take the item out of the briefcase if it is in there.
+              (:action take-out
+                   :parameters (?x - physob)
+                   :precondition (not (= ?x B))
+                   :effect (not (in ?x)) )
+            )"#;
+
+        let (_, domain) = Domain::parse(input).unwrap();
+
+        assert_eq!(domain.name(), &Name::new("briefcase-world"));
+        assert_eq!(domain.requirements().len(), 4);
+        assert_eq!(domain.types().len(), 2);
+        assert_eq!(domain.constants().len(), 3);
+        assert_eq!(domain.predicates().len(), 2);
+        assert!(domain.constraints().is_empty());
+        assert_eq!(domain.structure().len(), 3);
     }
 }

--- a/src/parsers/domain_constraints_def.rs
+++ b/src/parsers/domain_constraints_def.rs
@@ -1,8 +1,9 @@
 //! Provides parsers for domain constraint definitions.
 
+use nom::combinator::map;
+
 use crate::parsers::{parse_con_gd, prefix_expr, ParseResult, Span};
 use crate::types::DomainConstraintsDef;
-use nom::combinator::map;
 
 /// Parses domain constraint definitions, i.e. `(:constraints <con-gd>)`.
 ///
@@ -32,5 +33,18 @@ impl crate::parsers::Parser for DomainConstraintsDef {
     /// See [`parse_domain_constraints_def`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_domain_constraints_def(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::UnwrapValue;
+    use crate::{ConGD, DomainConstraintsDef, Parser};
+
+    #[test]
+    fn test_parse() {
+        let input = "(:constraints (and))";
+        assert!(DomainConstraintsDef::parse(input)
+            .is_value(DomainConstraintsDef::new(ConGD::new_and([]))));
     }
 }

--- a/src/parsers/duration_constraint.rs
+++ b/src/parsers/duration_constraint.rs
@@ -1,11 +1,12 @@
 //! Provides parsers for duration constraints.
 
-use crate::parsers::{parse_simple_duration_constraint, ParseResult, Span};
-use crate::parsers::{prefix_expr, space_separated_list1};
-use crate::types::DurationConstraint;
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::combinator::map;
+
+use crate::parsers::{parse_simple_duration_constraint, ParseResult, Span};
+use crate::parsers::{prefix_expr, space_separated_list1};
+use crate::types::DurationConstraint;
 
 /// Parses a duration constraint.
 ///
@@ -82,5 +83,56 @@ impl crate::parsers::Parser for DurationConstraint {
     /// See [`parse_duration_constraint`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_duration_constraint(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::UnwrapValue;
+    use crate::{
+        DOp, DurationConstraint, DurationValue, Parser, SimpleDurationConstraint, TimeSpecifier,
+    };
+
+    #[test]
+    fn test_parse() {
+        let input = "()";
+        assert!(DurationConstraint::parse(input).is_value(None));
+
+        let input = "(= ?duration 5)";
+        assert!(
+            DurationConstraint::parse(input).is_value(Some(DurationConstraint::new(
+                SimpleDurationConstraint::Op(DOp::Equal, DurationValue::Number(5.into()))
+            )))
+        );
+
+        let input = "(at end (<= ?duration 1.23))";
+        assert!(
+            DurationConstraint::parse(input).is_value(Some(DurationConstraint::new(
+                SimpleDurationConstraint::new_at(
+                    TimeSpecifier::End,
+                    SimpleDurationConstraint::Op(
+                        DOp::LessThanOrEqual,
+                        DurationValue::Number(1.23.into())
+                    )
+                )
+            )))
+        );
+
+        let input = "(and (at end (<= ?duration 1.23)) (>= ?duration 1.0))";
+        assert!(
+            DurationConstraint::parse(input).is_value(Some(DurationConstraint::new_all([
+                SimpleDurationConstraint::new_at(
+                    TimeSpecifier::End,
+                    SimpleDurationConstraint::Op(
+                        DOp::LessThanOrEqual,
+                        DurationValue::Number(1.23.into())
+                    )
+                ),
+                SimpleDurationConstraint::new_op(
+                    DOp::GreaterOrEqual,
+                    DurationValue::Number(1.0.into())
+                )
+            ])))
+        );
     }
 }

--- a/src/parsers/effects.rs
+++ b/src/parsers/effects.rs
@@ -1,10 +1,11 @@
 //! Provides parsers for effects.
 
+use nom::branch::alt;
+use nom::combinator::map;
+
 use crate::parsers::{parse_c_effect, ParseResult, Span};
 use crate::parsers::{prefix_expr, space_separated_list0};
 use crate::types::Effects;
-use nom::branch::alt;
-use nom::combinator::map;
 
 /// Parser for effects.
 ///
@@ -61,5 +62,33 @@ impl crate::parsers::Parser for Effects {
     /// See [`parse_effect`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_effect(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::UnwrapValue;
+    use crate::{AtomicFormula, CEffect, Effects, EqualityAtomicFormula, PEffect, Parser, Term};
+
+    #[test]
+    fn test_parse() {
+        assert!(
+            Effects::parse("(= x y)").is_value(Effects::new(CEffect::Effect(
+                PEffect::AtomicFormula(AtomicFormula::Equality(EqualityAtomicFormula::new(
+                    Term::Name("x".into()),
+                    Term::Name("y".into())
+                )))
+            )))
+        );
+        assert!(
+            Effects::parse("(and (= x y) (not (= ?a B)))").is_value(Effects::from_iter([
+                CEffect::Effect(PEffect::AtomicFormula(AtomicFormula::Equality(
+                    EqualityAtomicFormula::new(Term::Name("x".into()), Term::Name("y".into()))
+                ))),
+                CEffect::Effect(PEffect::NotAtomicFormula(AtomicFormula::Equality(
+                    EqualityAtomicFormula::new(Term::Variable("a".into()), Term::Name("B".into()))
+                )))
+            ]))
+        );
     }
 }

--- a/src/parsers/empty_or.rs
+++ b/src/parsers/empty_or.rs
@@ -1,10 +1,11 @@
 //! Provides the [`empty_or`] parser combinator.
 
-use crate::parsers::{ParseResult, Span};
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::combinator::map;
 use nom::error::ParseError;
+
+use crate::parsers::{ParseResult, Span};
 
 /// Parser combinator that takes a parser `inner` and produces a parser that
 /// consumes `()` and returns [`None`] or the result of `inner` and produces [`Some(O)`](Some).
@@ -33,9 +34,11 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::parsers::Match;
     use nom::character::complete::alpha1;
+
+    use crate::parsers::Match;
+
+    use super::*;
 
     #[test]
     fn empty_or_works() {

--- a/src/parsers/f_assign_da.rs
+++ b/src/parsers/f_assign_da.rs
@@ -37,10 +37,11 @@ impl crate::parsers::Parser for FAssignDa {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Parser;
 
     #[test]
     fn it_works() {
         let input = "(increase (distance-travelled) 5)";
-        let (_, _effect) = parse_f_assign_da(Span::new(input)).unwrap();
+        let (_, _effect) = FAssignDa::parse(Span::new(input)).unwrap();
     }
 }

--- a/src/parsers/f_comp.rs
+++ b/src/parsers/f_comp.rs
@@ -1,11 +1,12 @@
 //! Provides parsers for f-comps.
 
-use crate::parsers::{parens, ParseResult, Span};
-use crate::parsers::{parse_binary_comp, parse_f_exp};
-use crate::types::FComp;
 use nom::character::complete::multispace1;
 use nom::combinator::map;
 use nom::sequence::{preceded, tuple};
+
+use crate::parsers::{parens, ParseResult, Span};
+use crate::parsers::{parse_binary_comp, parse_f_exp};
+use crate::types::FComp;
 
 /// Parses an f-comp.
 ///
@@ -46,5 +47,30 @@ impl crate::parsers::Parser for FComp {
     /// See [`parse_f_comp`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_f_comp(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::UnwrapValue;
+    use crate::{BinaryComp, BinaryOp, FComp, FExp, Parser};
+
+    #[test]
+    fn test_parse() {
+        assert!(
+            FComp::parse("(= (+ 1.23 2.34) (+ 1.23 2.34))").is_value(FComp::new(
+                BinaryComp::Equal,
+                FExp::new_binary_op(
+                    BinaryOp::Addition,
+                    FExp::new_number(1.23),
+                    FExp::new_number(2.34),
+                ),
+                FExp::new_binary_op(
+                    BinaryOp::Addition,
+                    FExp::new_number(1.23),
+                    FExp::new_number(2.34),
+                )
+            ))
+        );
     }
 }

--- a/src/parsers/f_exp_da.rs
+++ b/src/parsers/f_exp_da.rs
@@ -1,13 +1,14 @@
 //! Provides parsers for f-exp-da values..
 
-use crate::parsers::{parens, space_separated_list1, ParseResult, Span};
-use crate::parsers::{parse_binary_op, parse_f_exp, parse_multi_op};
-use crate::types::FExpDa;
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::character::complete::{char, multispace0, multispace1};
 use nom::combinator::map;
 use nom::sequence::{preceded, tuple};
+
+use crate::parsers::{parens, space_separated_list1, ParseResult, Span};
+use crate::parsers::{parse_binary_op, parse_f_exp, parse_multi_op};
+use crate::types::FExpDa;
 
 /// Parses an f-exp-da.
 ///
@@ -73,5 +74,32 @@ impl crate::parsers::Parser for FExpDa {
     /// See [`parse_f_exp_da`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_f_exp_da(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::UnwrapValue;
+    use crate::{BinaryOp, FExp, FExpDa, MultiOp, Parser};
+
+    #[test]
+    fn test_parse() {
+        assert!(FExpDa::parse("?duration").is_value(FExpDa::Duration));
+
+        assert!(
+            FExpDa::parse("(+ 1.23 2.34)").is_value(FExpDa::new_binary_op(
+                BinaryOp::Addition,
+                FExpDa::new_f_exp(FExp::new_number(1.23)),
+                FExpDa::new_f_exp(FExp::new_number(2.34))
+            ))
+        );
+
+        assert!(
+            FExpDa::parse("(+ 1.23 2.34 3.45)").is_value(FExpDa::new_multi_op(
+                MultiOp::Addition,
+                FExpDa::new_f_exp(FExp::new_number(1.23)),
+                [FExp::new_number(2.34).into(), FExp::new_number(3.45).into()]
+            ))
+        );
     }
 }

--- a/src/parsers/f_exp_t.rs
+++ b/src/parsers/f_exp_t.rs
@@ -1,13 +1,14 @@
 //! Provides parsers for f-exps.
 
-use crate::parsers::prefix_expr;
-use crate::parsers::{parse_f_exp, ParseResult, Span};
-use crate::types::FExpT;
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::character::complete::multispace1;
 use nom::combinator::map;
 use nom::sequence::{preceded, terminated, tuple};
+
+use crate::parsers::prefix_expr;
+use crate::parsers::{parse_f_exp, ParseResult, Span};
+use crate::types::FExpT;
 
 /// Parses an f-exp-t.
 ///
@@ -61,5 +62,34 @@ impl crate::parsers::Parser for FExpT {
     /// See [`parse_f_exp_t`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_f_exp_t(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::UnwrapValue;
+    use crate::{FExp, FExpT, FHead, FunctionSymbol, Parser, Term, Variable};
+
+    #[test]
+    fn test_parse() {
+        assert!(FExpT::parse("#t").is_value(FExpT::Now));
+
+        assert!(
+            FExpT::parse("(* (fuel ?tank) #t)").is_value(FExpT::new_scaled(FExp::new_function(
+                FHead::new_with_terms(
+                    FunctionSymbol::from_str("fuel"),
+                    [Term::Variable(Variable::from_str("tank"))]
+                )
+            )))
+        );
+
+        assert!(
+            FExpT::parse("(* #t (fuel ?tank))").is_value(FExpT::new_scaled(FExp::new_function(
+                FHead::new_with_terms(
+                    FunctionSymbol::from_str("fuel"),
+                    [Term::Variable(Variable::from_str("tank"))]
+                )
+            )))
+        );
     }
 }

--- a/src/parsers/f_head.rs
+++ b/src/parsers/f_head.rs
@@ -1,12 +1,13 @@
 //! Provides parsers for f-heads.
 
-use crate::parsers::{parens, space_separated_list0, ParseResult, Span};
-use crate::parsers::{parse_function_symbol, parse_term};
-use crate::types::FHead;
 use nom::branch::alt;
 use nom::character::complete::multispace1;
 use nom::combinator::map;
 use nom::sequence::{preceded, tuple};
+
+use crate::parsers::{parens, space_separated_list0, ParseResult, Span};
+use crate::parsers::{parse_function_symbol, parse_term};
+use crate::types::FHead;
 
 /// Parses an f-head.
 ///
@@ -48,5 +49,25 @@ impl crate::parsers::Parser for FHead {
     /// See [`parse_f_head`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_f_head(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::UnwrapValue;
+    use crate::{FHead, FunctionSymbol, Parser, Term};
+
+    #[test]
+    fn test_parse() {
+        assert!(FHead::parse("fun-sym").is_value(FHead::new(FunctionSymbol::from_str("fun-sym"))));
+
+        assert!(FHead::parse("(fun-sym)").is_value(FHead::new(FunctionSymbol::from_str("fun-sym"))));
+
+        assert!(
+            FHead::parse("(fun-sym term)").is_value(FHead::new_with_terms(
+                FunctionSymbol::from_str("fun-sym"),
+                [Term::Name("term".into())]
+            ))
+        );
     }
 }

--- a/src/parsers/function_symbol.rs
+++ b/src/parsers/function_symbol.rs
@@ -45,11 +45,20 @@ impl crate::parsers::Parser for FunctionSymbol {
 
 #[cfg(test)]
 mod tests {
+    use crate::parsers::UnwrapValue;
     use crate::{FunctionSymbol, Parser};
 
     #[test]
     fn test_parse() {
-        let (_, value) = FunctionSymbol::parse("abcde").unwrap();
-        assert_eq!(value, "abcde".into());
+        assert!(FunctionSymbol::parse("abcde").is_value("abcde".into()));
+        assert!(FunctionSymbol::parse("a-1_2").is_value("a-1_2".into()));
+        assert!(FunctionSymbol::parse("Z01").is_value("Z01".into()));
+        assert!(FunctionSymbol::parse("x-_-_").is_value("x-_-_".into()));
+
+        assert!(FunctionSymbol::parse("").is_err());
+        assert!(FunctionSymbol::parse(".").is_err());
+        assert!(FunctionSymbol::parse("-abc").is_err());
+        assert!(FunctionSymbol::parse("0124").is_err());
+        assert!(FunctionSymbol::parse("-1").is_err());
     }
 }

--- a/src/parsers/function_symbol.rs
+++ b/src/parsers/function_symbol.rs
@@ -42,3 +42,14 @@ impl crate::parsers::Parser for FunctionSymbol {
         parse_function_symbol(input)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{FunctionSymbol, Parser};
+
+    #[test]
+    fn test_parse() {
+        let (_, value) = FunctionSymbol::parse("abcde").unwrap();
+        assert_eq!(value, "abcde".into());
+    }
+}

--- a/src/parsers/function_term.rs
+++ b/src/parsers/function_term.rs
@@ -47,3 +47,32 @@ impl crate::parsers::Parser for FunctionTerm {
         parse_function_term(input)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::UnwrapValue;
+    use crate::{FunctionSymbol, FunctionTerm, Parser, Term};
+
+    #[test]
+    fn test_parse() {
+        assert!(
+            FunctionTerm::parse("(fun-sym)").is_value(FunctionTerm::new("fun-sym".into(), vec![]))
+        );
+
+        let x = Term::Name("x".into());
+        assert!(FunctionTerm::parse("(fun-sym x)")
+            .is_value(FunctionTerm::new("fun-sym".into(), vec![x])));
+
+        let x = Term::Name("x".into());
+        let y = Term::Variable("y".into());
+        assert!(FunctionTerm::parse("(fun-sym ?y x)")
+            .is_value(FunctionTerm::new("fun-sym".into(), vec![y, x])));
+
+        let x = Term::Name("x".into());
+        let y = Term::Variable("y".into());
+        let a = Term::Name("a".into());
+        let ft = Term::Function(FunctionTerm::new(FunctionSymbol::from("fn"), vec![a]));
+        assert!(FunctionTerm::parse("(fun-sym ?y x (fn a))")
+            .is_value(FunctionTerm::new("fun-sym".into(), vec![y, x, ft])));
+    }
+}

--- a/src/parsers/function_type.rs
+++ b/src/parsers/function_type.rs
@@ -26,3 +26,17 @@ impl crate::parsers::Parser for FunctionType {
         parse_function_type(input)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::UnwrapValue;
+    use crate::{FunctionType, Parser, Type};
+
+    #[test]
+    fn test_parse() {
+        assert!(FunctionType::parse("number")
+            .is_value(FunctionType::new(Type::Exactly("number".into()))));
+        assert!(FunctionType::parse("(either object number)")
+            .is_value(FunctionType::new(Type::from_iter(["object", "number"]))));
+    }
+}

--- a/src/parsers/function_typed_list.rs
+++ b/src/parsers/function_typed_list.rs
@@ -91,5 +91,18 @@ mod tests {
                 )])
             )
         )])));
+
+        assert!(function_typed_list(parse_atomic_function_skeleton)(
+            "(move ?from ?to - location)".into()
+        )
+        .is_value(FunctionTypedList::from_iter([FunctionTyped::new_number(
+            AtomicFunctionSkeleton::new(
+                FunctionSymbol::from_str("move"),
+                TypedList::from_iter([
+                    Typed::new(Variable::from("from"), Type::Exactly("location".into())),
+                    Typed::new(Variable::from("to"), Type::Exactly("location".into()))
+                ])
+            )
+        )])));
     }
 }

--- a/src/parsers/function_typed_list.rs
+++ b/src/parsers/function_typed_list.rs
@@ -62,10 +62,10 @@ where
         implicitly_typed_list,
     ));
 
-    let repeated_lists = map(typed_list_choice, |(mut explicit, mut implicit)| {
+    
+
+    map(typed_list_choice, |(mut explicit, mut implicit)| {
         explicit.append(&mut implicit);
         FunctionTypedList::new(explicit)
-    });
-
-    repeated_lists
+    })
 }

--- a/src/parsers/function_typed_list.rs
+++ b/src/parsers/function_typed_list.rs
@@ -1,11 +1,12 @@
-use crate::parsers::{
-    parse_type, space_separated_list0, space_separated_list1, ws, ParseResult, Span,
-};
-use crate::types::{FunctionType, FunctionTyped, FunctionTypedList};
 use nom::character::complete::char;
 use nom::combinator::map;
 use nom::multi::many0;
 use nom::sequence::{preceded, tuple};
+
+use crate::parsers::{
+    parse_type, space_separated_list0, space_separated_list1, ws, ParseResult, Span,
+};
+use crate::types::{FunctionType, FunctionTyped, FunctionTypedList};
 
 /// Parses a typed list, i.e. `x* | x⁺ - <type> <typed-list (x)>.
 ///
@@ -62,10 +63,33 @@ where
         implicitly_typed_list,
     ));
 
-    
-
     map(typed_list_choice, |(mut explicit, mut implicit)| {
         explicit.append(&mut implicit);
         FunctionTypedList::new(explicit)
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::{function_typed_list, parse_atomic_function_skeleton, UnwrapValue};
+    use crate::{
+        AtomicFunctionSkeleton, FunctionSymbol, FunctionTyped, FunctionTypedList, Type, Typed,
+        TypedList, Variable,
+    };
+
+    #[test]
+    fn test_parse() {
+        assert!(function_typed_list(parse_atomic_function_skeleton)(
+            "(battery-amount ?r - rover)".into()
+        )
+        .is_value(FunctionTypedList::from_iter([FunctionTyped::new_number(
+            AtomicFunctionSkeleton::new(
+                FunctionSymbol::from_str("battery-amount"),
+                TypedList::from_iter([Typed::new(
+                    Variable::from("r"),
+                    Type::Exactly("rover".into())
+                )])
+            )
+        )])));
+    }
 }

--- a/src/parsers/functions_def.rs
+++ b/src/parsers/functions_def.rs
@@ -1,9 +1,10 @@
 //! Provides parsers for constant definitions.
 
+use nom::combinator::map;
+
 use crate::parsers::{function_typed_list, parse_atomic_function_skeleton};
 use crate::parsers::{prefix_expr, ParseResult, Span};
 use crate::types::Functions;
-use nom::combinator::map;
 
 /// Parses constant definitions, i.e. `(:constants <typed list (name)>)`.
 ///
@@ -42,5 +43,28 @@ impl crate::parsers::Parser for Functions {
     /// See [`parse_functions_def`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_functions_def(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::UnwrapValue;
+    use crate::{
+        AtomicFunctionSkeleton, FunctionSymbol, FunctionTyped, Functions, Parser, Type, Typed,
+        TypedList, Variable,
+    };
+
+    #[test]
+    fn test_parse() {
+        let input = "(:functions (battery-amount ?r - rover))";
+        assert!(Functions::parse(input).is_value(Functions::from_iter([
+            FunctionTyped::new_number(AtomicFunctionSkeleton::new(
+                FunctionSymbol::from_str("battery-amount"),
+                TypedList::from_iter([Typed::new(
+                    Variable::from("r"),
+                    Type::Exactly("rover".into())
+                )])
+            ))
+        ])));
     }
 }

--- a/src/parsers/functions_def.rs
+++ b/src/parsers/functions_def.rs
@@ -32,7 +32,7 @@ pub fn parse_functions_def<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, F
             ":functions",
             function_typed_list(parse_atomic_function_skeleton),
         ),
-        |vec| Functions::new(vec),
+        Functions::new,
     )(input.into())
 }
 

--- a/src/parsers/gd.rs
+++ b/src/parsers/gd.rs
@@ -1,14 +1,15 @@
 //! Provides parsers for goal definitions.
 
+use nom::branch::alt;
+use nom::character::complete::multispace1;
+use nom::combinator::map;
+use nom::sequence::{preceded, tuple};
+
 use crate::parsers::{
     atomic_formula, literal, parse_f_comp, parse_term, parse_variable, ParseResult, Span,
 };
 use crate::parsers::{parens, prefix_expr, space_separated_list0, typed_list};
 use crate::types::GoalDefinition;
-use nom::branch::alt;
-use nom::character::complete::multispace1;
-use nom::combinator::map;
-use nom::sequence::{preceded, tuple};
 
 /// Parser for goal definitions.
 ///
@@ -196,5 +197,130 @@ impl crate::parsers::Parser for GoalDefinition {
     /// See [`parse_gd`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_gd(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::UnwrapValue;
+    use crate::{
+        AtomicFormula, BinaryComp, BinaryOp, FComp, FExp, GoalDefinition, Parser, Term, TypedList,
+        Variable,
+    };
+
+    #[test]
+    fn test_parse() {
+        assert!(
+            GoalDefinition::parse("(= x y)").is_value(GoalDefinition::AtomicFormula(
+                AtomicFormula::new_equality(Term::Name("x".into()), Term::Name("y".into()))
+            ))
+        );
+
+        // Literal
+        assert!(
+            GoalDefinition::parse("(not (= x y))").is_value(GoalDefinition::new_not(
+                GoalDefinition::new_atomic_formula(AtomicFormula::new_equality(
+                    Term::Name("x".into()),
+                    Term::Name("y".into())
+                ))
+            ))
+        );
+
+        // Conjunction (and)
+        assert!(
+            GoalDefinition::parse("(and (not (= x y)) (= x z))").is_value(GoalDefinition::new_and(
+                [
+                    GoalDefinition::new_not(GoalDefinition::new_atomic_formula(
+                        AtomicFormula::new_equality(Term::Name("x".into()), Term::Name("y".into()))
+                    )),
+                    GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
+                        Term::Name("x".into()),
+                        Term::Name("z".into())
+                    ))
+                ]
+            ))
+        );
+
+        // Disjunction (or)
+        assert!(
+            GoalDefinition::parse("(or (not (= x y)) (= x z))").is_value(GoalDefinition::new_or([
+                GoalDefinition::new_not(GoalDefinition::new_atomic_formula(
+                    AtomicFormula::new_equality(Term::Name("x".into()), Term::Name("y".into()))
+                )),
+                GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
+                    Term::Name("x".into()),
+                    Term::Name("z".into())
+                ))
+            ]))
+        );
+
+        // Implication
+        assert!(
+            GoalDefinition::parse("(imply (not (= x y)) (= x z))").is_value(
+                GoalDefinition::new_imply(
+                    GoalDefinition::new_not(GoalDefinition::new_atomic_formula(
+                        AtomicFormula::new_equality(Term::Name("x".into()), Term::Name("y".into()))
+                    )),
+                    GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
+                        Term::Name("x".into()),
+                        Term::Name("z".into())
+                    ))
+                )
+            )
+        );
+
+        // Existential preconditions
+        assert!(
+            GoalDefinition::parse("(exists (?x ?y) (not (= ?x ?y)))").is_value(
+                GoalDefinition::new_exists(
+                    TypedList::from_iter([
+                        Variable::from_str("x").into(),
+                        Variable::from_str("y").into()
+                    ]),
+                    GoalDefinition::new_not(GoalDefinition::new_atomic_formula(
+                        AtomicFormula::new_equality(
+                            Term::Variable("x".into()),
+                            Term::Variable("y".into())
+                        )
+                    ))
+                )
+            )
+        );
+
+        // Universal preconditions
+        assert!(
+            GoalDefinition::parse("(forall (?x ?y) (not (= ?x ?y)))").is_value(
+                GoalDefinition::new_forall(
+                    TypedList::from_iter([
+                        Variable::from_str("x").into(),
+                        Variable::from_str("y").into()
+                    ]),
+                    GoalDefinition::new_not(GoalDefinition::new_atomic_formula(
+                        AtomicFormula::new_equality(
+                            Term::Variable("x".into()),
+                            Term::Variable("y".into())
+                        )
+                    ))
+                )
+            )
+        );
+
+        assert!(
+            GoalDefinition::parse("(= (+ 1.23 2.34) (+ 1.23 2.34))").is_value(
+                GoalDefinition::new_f_comp(FComp::new(
+                    BinaryComp::Equal,
+                    FExp::new_binary_op(
+                        BinaryOp::Addition,
+                        FExp::new_number(1.23),
+                        FExp::new_number(2.34),
+                    ),
+                    FExp::new_binary_op(
+                        BinaryOp::Addition,
+                        FExp::new_number(1.23),
+                        FExp::new_number(2.34),
+                    )
+                ))
+            )
+        );
     }
 }

--- a/src/parsers/goal_def.rs
+++ b/src/parsers/goal_def.rs
@@ -38,3 +38,25 @@ impl crate::parsers::Parser for GoalDef {
         parse_problem_goal_def(input)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::UnwrapValue;
+    use crate::{
+        AtomicFormula, GoalDef, GoalDefinition, Parser, PreconditionGoalDefinition, PreferenceGD,
+        Term,
+    };
+
+    #[test]
+    fn test_parse() {
+        let input = "(:goal (= x y))";
+        assert!(GoalDef::parse(input).is_value(GoalDef::from(
+            PreconditionGoalDefinition::Preference(PreferenceGD::Goal(
+                GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
+                    Term::Name("x".into()),
+                    Term::Name("y".into())
+                ))
+            ))
+        )));
+    }
+}

--- a/src/parsers/init_def.rs
+++ b/src/parsers/init_def.rs
@@ -1,8 +1,9 @@
 //! Provides parsers for goal initial state definitions.
 
+use nom::combinator::map;
+
 use crate::parsers::{parse_init_el, prefix_expr, space_separated_list0, ParseResult, Span};
 use crate::types::InitElements;
-use nom::combinator::map;
 
 /// Parser for goal initial state definitions.
 ///
@@ -45,5 +46,31 @@ impl crate::parsers::Parser for InitElements {
     /// See [`parse_problem_init_def`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_problem_init_def(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::UnwrapValue;
+    use crate::{AtomicFormula, InitElement, InitElements, NameLiteral, Number, Parser};
+
+    #[test]
+    fn test_parse() {
+        let input = "(:init (train-not-in-use train1) (at 10 (train-not-in-use train2)))";
+        assert!(
+            InitElements::parse(input).is_value(InitElements::from_iter([
+                InitElement::new_literal(NameLiteral::new(AtomicFormula::new_predicate(
+                    "train-not-in-use".into(),
+                    ["train1".into()]
+                ))),
+                InitElement::new_at(
+                    Number::from(10),
+                    NameLiteral::new(AtomicFormula::new_predicate(
+                        "train-not-in-use".into(),
+                        ["train2".into()]
+                    ))
+                )
+            ]))
+        );
     }
 }

--- a/src/parsers/interval.rs
+++ b/src/parsers/interval.rs
@@ -1,10 +1,11 @@
 //! Provides parsers for assignment operations.
 
+use nom::bytes::complete::tag;
+use nom::combinator::map;
+
 use crate::parsers::{ParseResult, Span};
 use crate::types::interval::names;
 use crate::types::Interval;
-use nom::bytes::complete::tag;
-use nom::combinator::map;
 
 /// Parses an intervals, i.e. `all`.
 ///
@@ -26,5 +27,16 @@ impl crate::parsers::Parser for Interval {
     /// See [`parse_interval`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_interval(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::UnwrapValue;
+    use crate::{Interval, Parser};
+
+    #[test]
+    fn test_parse() {
+        assert!(Interval::parse("all").is_value(Interval::All));
     }
 }

--- a/src/parsers/length_spec.rs
+++ b/src/parsers/length_spec.rs
@@ -1,10 +1,11 @@
 //! Provides parsers for length specification.
 
-use crate::parsers::{prefix_expr, ParseResult, Span};
-use crate::types::LengthSpec;
 use nom::character::complete::multispace0;
 use nom::combinator::{map, opt};
 use nom::sequence::{preceded, tuple};
+
+use crate::parsers::{prefix_expr, ParseResult, Span};
+use crate::types::LengthSpec;
 
 /// Parses a length specification. Deprecated since PDDL 2.1.
 ///
@@ -36,5 +37,22 @@ impl crate::parsers::Parser for LengthSpec {
     /// See [`parse_problem_length_spec`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_problem_length_spec(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::UnwrapValue;
+    use crate::{LengthSpec, Parser};
+
+    #[test]
+    fn test_parse() {
+        assert!(LengthSpec::parse("(:length)").is_value(LengthSpec::default()));
+        assert!(LengthSpec::parse("(:length (:serial 123))").is_value(LengthSpec::new_serial(123)));
+        assert!(
+            LengthSpec::parse("(:length (:parallel 42))").is_value(LengthSpec::new_parallel(42))
+        );
+        assert!(LengthSpec::parse("(:length (:serial 123) (:parallel 42))")
+            .is_value(LengthSpec::new(Some(123), Some(42))));
     }
 }

--- a/src/parsers/literal.rs
+++ b/src/parsers/literal.rs
@@ -1,10 +1,11 @@
 //! Provides parsers for literals.
 
+use nom::branch::alt;
+use nom::combinator::map;
+
 use crate::parsers::prefix_expr;
 use crate::parsers::{atomic_formula, ParseResult, Span};
 use crate::types::Literal;
-use nom::branch::alt;
-use nom::combinator::map;
 
 /// Parser combinator that parses a literal, i.e. `<atomic formula(t)> | (not <atomic formula(t)>)`.
 ///
@@ -44,4 +45,25 @@ where
     });
 
     alt((is_not, is))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::{literal, parse_name, Span, UnwrapValue};
+    use crate::{AtomicFormula, EqualityAtomicFormula, Literal};
+
+    #[test]
+    fn test_parse() {
+        assert!(
+            literal(parse_name)(Span::new("(= x y)")).is_value(Literal::AtomicFormula(
+                AtomicFormula::Equality(EqualityAtomicFormula::new("x".into(), "y".into()))
+            ))
+        );
+        assert!(literal(parse_name)(Span::new("(not (= x y))")).is_value(
+            Literal::NotAtomicFormula(AtomicFormula::Equality(EqualityAtomicFormula::new(
+                "x".into(),
+                "y".into()
+            )))
+        ));
+    }
 }

--- a/src/parsers/metric_f_exp.rs
+++ b/src/parsers/metric_f_exp.rs
@@ -143,3 +143,58 @@ impl crate::parsers::Parser for MetricFExp {
         parse_metric_f_exp(input)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::preamble::*;
+    use crate::{BinaryOp, FunctionSymbol, MetricFExp, MultiOp, Name, PreferenceName};
+
+    #[test]
+    fn test_parse() {
+        assert!(MetricFExp::parse("1.23").is_value(MetricFExp::new_number(1.23)));
+
+        assert!(MetricFExp::parse("(- total-time)")
+            .is_value(MetricFExp::new_negative(MetricFExp::TotalTime)));
+
+        assert!(
+            MetricFExp::parse("(+ 1.23 2.34)").is_value(MetricFExp::new_binary_op(
+                BinaryOp::Addition,
+                MetricFExp::new_number(1.23),
+                MetricFExp::new_number(2.34)
+            ))
+        );
+
+        assert!(
+            MetricFExp::parse("(+ 1.23 2.34 3.45)").is_value(MetricFExp::new_multi_op(
+                MultiOp::Addition,
+                MetricFExp::new_number(1.23),
+                [MetricFExp::new_number(2.34), MetricFExp::new_number(3.45)]
+            ))
+        );
+
+        assert!(MetricFExp::parse("(is-violated preference)").is_value(
+            MetricFExp::new_is_violated(PreferenceName::from("preference"))
+        ));
+
+        assert!(
+            MetricFExp::parse("fun-sym").is_value(MetricFExp::new_function(
+                FunctionSymbol::from_str("fun-sym"),
+                []
+            ))
+        );
+
+        assert!(
+            MetricFExp::parse("(fun-sym)").is_value(MetricFExp::new_function(
+                FunctionSymbol::from_str("fun-sym"),
+                []
+            ))
+        );
+
+        assert!(
+            MetricFExp::parse("(fun-sym a b c)").is_value(MetricFExp::new_function(
+                FunctionSymbol::from_str("fun-sym"),
+                [Name::new("a"), Name::new("b"), Name::new("c")]
+            ))
+        );
+    }
+}

--- a/src/parsers/metric_spec.rs
+++ b/src/parsers/metric_spec.rs
@@ -1,10 +1,11 @@
 //! Provides parsers for metric specification.
 
-use crate::parsers::{parse_metric_f_exp, parse_optimization, prefix_expr, ParseResult, Span};
-use crate::types::MetricSpec;
 use nom::character::complete::multispace1;
 use nom::combinator::map;
 use nom::sequence::{preceded, tuple};
+
+use crate::parsers::{parse_metric_f_exp, parse_optimization, prefix_expr, ParseResult, Span};
+use crate::types::MetricSpec;
 
 /// Parses a metric specification.
 ///
@@ -39,5 +40,21 @@ impl crate::parsers::Parser for MetricSpec {
     /// See [`parse_problem_metric_spec`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_problem_metric_spec(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::UnwrapValue;
+    use crate::{MetricFExp, MetricSpec, Optimization, Parser};
+
+    #[test]
+    fn test_parse() {
+        assert!(
+            MetricSpec::parse("(:metric minimize total-time)").is_value(MetricSpec::new(
+                Optimization::Minimize,
+                MetricFExp::TotalTime
+            ))
+        );
     }
 }

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -202,3 +202,26 @@ pub use typed_list::typed_list;
 pub(crate) use utilities::{
     parens, prefix_expr, space_separated_list0, space_separated_list1, ws, ws2,
 };
+
+#[cfg(test)]
+mod tests {
+    use crate::{BasicFunctionTerm, Parser};
+
+    #[test]
+    fn test_parse() {
+        let (_, value) = BasicFunctionTerm::parse("abcde").unwrap();
+        assert_eq!(value, BasicFunctionTerm::new("abcde".into(), []));
+    }
+
+    #[test]
+    fn test_parse_span() {
+        let (_, value) = BasicFunctionTerm::parse_span("abcde".into()).unwrap();
+        assert_eq!(value, BasicFunctionTerm::new("abcde".into(), []));
+    }
+
+    #[test]
+    fn test_from_str() {
+        let value = BasicFunctionTerm::from_str("abcde").unwrap();
+        assert_eq!(value, BasicFunctionTerm::new("abcde".into(), []));
+    }
+}

--- a/src/parsers/multi_op.rs
+++ b/src/parsers/multi_op.rs
@@ -1,10 +1,11 @@
 //! Provides parsers for multi-operand operations.
 
-use crate::parsers::{ParseResult, Span};
-use crate::types::{multi_op::names, MultiOp};
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::combinator::map;
+
+use crate::parsers::{ParseResult, Span};
+use crate::types::{multi_op::names, MultiOp};
 
 /// Parses a multi-operand operation, i.e. `* | +`.
 ///
@@ -28,5 +29,17 @@ impl crate::parsers::Parser for MultiOp {
     /// See [`parse_multi_op`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_multi_op(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::UnwrapValue;
+    use crate::{MultiOp, Parser};
+
+    #[test]
+    fn test_parse() {
+        assert!(MultiOp::parse("*").is_value(MultiOp::Multiplication));
+        assert!(MultiOp::parse("+").is_value(MultiOp::Addition));
     }
 }

--- a/src/parsers/name.rs
+++ b/src/parsers/name.rs
@@ -50,10 +50,11 @@ impl crate::parsers::Parser for Name {
 mod test {
     use super::*;
     use crate::parsers::Match;
+    use crate::Parser;
 
     #[test]
     fn parse_name_works() {
-        assert!(parse_name(Span::new("abcde")).is_exactly("abcde"));
+        assert!(Name::parse(Span::new("abcde")).is_exactly("abcde"));
     }
 
     #[test]

--- a/src/parsers/number.rs
+++ b/src/parsers/number.rs
@@ -48,6 +48,7 @@ impl crate::parsers::Parser for Number {
 mod tests {
     use crate::parsers::number::parse_decimal;
     use crate::parsers::{Match, Span};
+    use crate::{Number, Parser};
 
     #[test]
     fn parse_decimal_works() {
@@ -55,5 +56,11 @@ mod tests {
         assert!(parse_decimal(Span::new(".012")).is_exactly(".012"));
         assert!(parse_decimal(Span::new(".")).is_err());
         assert!(parse_decimal(Span::new("012")).is_err());
+    }
+
+    #[test]
+    fn test_parse() {
+        let (_, value) = Number::parse("1.20").unwrap();
+        assert_eq!(value, Number::from(1.2));
     }
 }

--- a/src/parsers/number.rs
+++ b/src/parsers/number.rs
@@ -1,13 +1,14 @@
 //! Provides parsers for numbers, decimals and digits.
 
-use crate::parsers::{ParseResult, Span};
-use crate::types::Number;
 use nom::character::complete::{char, digit1};
 use nom::combinator::{map, recognize};
 use nom::multi::many_m_n;
 use nom::number::complete::float;
 use nom::sequence::tuple;
 use nom::Parser;
+
+use crate::parsers::{ParseResult, Span};
+use crate::types::Number;
 
 /// Parses a number, i.e. `<digit>⁺[<decimal>]`.
 ///
@@ -45,8 +46,8 @@ impl crate::parsers::Parser for Number {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::parsers::Match;
+    use crate::parsers::number::parse_decimal;
+    use crate::parsers::{Match, Span};
 
     #[test]
     fn parse_decimal_works() {

--- a/src/parsers/objects_def.rs
+++ b/src/parsers/objects_def.rs
@@ -1,8 +1,9 @@
 //! Provides parsers for goal object declarations.
 
+use nom::combinator::map;
+
 use crate::parsers::{parse_name, prefix_expr, typed_list, ParseResult, Span};
 use crate::types::Objects;
-use nom::combinator::map;
 
 /// Parser for goal object declarations.
 ///
@@ -33,5 +34,24 @@ impl crate::parsers::Parser for Objects {
     /// See [`parse_problem_objects_declaration`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_problem_objects_declaration(input)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::parsers::UnwrapValue;
+    use crate::{Name, ToTyped, Type};
+
+    use super::*;
+
+    #[test]
+    fn test_parse() {
+        let input = "(:objects train1 train2)";
+        assert!(
+            parse_problem_objects_declaration(input).is_value(Objects::new([
+                Name::new("train1").to_typed(Type::OBJECT),
+                Name::new("train2").to_typed(Type::OBJECT),
+            ]))
+        );
     }
 }

--- a/src/parsers/objects_def.rs
+++ b/src/parsers/objects_def.rs
@@ -40,18 +40,16 @@ impl crate::parsers::Parser for Objects {
 #[cfg(test)]
 mod test {
     use crate::parsers::UnwrapValue;
-    use crate::{Name, ToTyped, Type};
+    use crate::{Name, Parser, ToTyped, Type};
 
     use super::*;
 
     #[test]
     fn test_parse() {
         let input = "(:objects train1 train2)";
-        assert!(
-            parse_problem_objects_declaration(input).is_value(Objects::new([
-                Name::new("train1").to_typed(Type::OBJECT),
-                Name::new("train2").to_typed(Type::OBJECT),
-            ]))
-        );
+        assert!(Objects::parse(input).is_value(Objects::new([
+            Name::new("train1").to_typed(Type::OBJECT),
+            Name::new("train2").to_typed(Type::OBJECT),
+        ])));
     }
 }

--- a/src/parsers/optimization.rs
+++ b/src/parsers/optimization.rs
@@ -30,3 +30,15 @@ impl crate::parsers::Parser for Optimization {
         parse_optimization(input)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::preamble::*;
+    use crate::Optimization;
+
+    #[test]
+    fn test_parse() {
+        assert!(Optimization::parse("minimize").is_value(Optimization::Minimize));
+        assert!(Optimization::parse("maximize").is_value(Optimization::Maximize));
+    }
+}

--- a/src/parsers/p_effect.rs
+++ b/src/parsers/p_effect.rs
@@ -67,7 +67,7 @@ use nom::sequence::{preceded, terminated, tuple};
 /// ));
 /// ```
 pub fn parse_p_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, PEffect> {
-    let is = map(atomic_formula(parse_term), |af| PEffect::new(af));
+    let is = map(atomic_formula(parse_term), PEffect::new);
     let is_not = map(prefix_expr("not", atomic_formula(parse_term)), |af| {
         PEffect::new_not(af)
     });

--- a/src/parsers/pre_gd.rs
+++ b/src/parsers/pre_gd.rs
@@ -1,13 +1,14 @@
 //! Provides parsers for goal definitions.
 
-use crate::parsers::{parens, prefix_expr, space_separated_list0, typed_list, ParseResult, Span};
-use crate::parsers::{parse_pref_gd, parse_variable};
-use crate::types::PreconditionGoalDefinition;
-use crate::PreconditionGoalDefinitions;
 use nom::branch::alt;
 use nom::character::complete::multispace1;
 use nom::combinator::map;
 use nom::sequence::{preceded, tuple};
+
+use crate::parsers::{parens, prefix_expr, space_separated_list0, typed_list, ParseResult, Span};
+use crate::parsers::{parse_pref_gd, parse_variable};
+use crate::types::PreconditionGoalDefinition;
+use crate::PreconditionGoalDefinitions;
 
 /// Parser for goal definitions.
 ///
@@ -100,5 +101,66 @@ impl crate::parsers::Parser for PreconditionGoalDefinitions {
     /// See [`parse_pre_gd`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_pre_gd(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::preamble::*;
+    use crate::{
+        AtomicFormula, GoalDefinition, PreconditionGoalDefinition, PreconditionGoalDefinitions,
+        PreferenceGD, Term, Type, Typed, TypedList, Variable,
+    };
+
+    #[test]
+    fn test_parse() {
+        assert!(
+            PreconditionGoalDefinitions::parse(Span::new("(= x y)")).is_value(
+                PreconditionGoalDefinitions::new_preference(PreferenceGD::Goal(
+                    GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
+                        Term::Name("x".into()),
+                        Term::Name("y".into())
+                    ))
+                ))
+            )
+        );
+
+        assert!(
+            PreconditionGoalDefinitions::parse(Span::new("(and (= x y) (= a b))")).is_value(
+                PreconditionGoalDefinitions::from_iter([
+                    PreconditionGoalDefinition::Preference(PreferenceGD::Goal(
+                        GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
+                            Term::Name("x".into()),
+                            Term::Name("y".into())
+                        ))
+                    )),
+                    PreconditionGoalDefinition::Preference(PreferenceGD::Goal(
+                        GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
+                            Term::Name("a".into()),
+                            Term::Name("b".into())
+                        ))
+                    ))
+                ])
+            )
+        );
+
+        assert!(
+            PreconditionGoalDefinitions::parse(Span::new("(forall (?a ?b) (= a b))")).is_value(
+                PreconditionGoalDefinition::new_forall(
+                    TypedList::from_iter([
+                        Typed::new(Variable::from_str("a"), Type::OBJECT),
+                        Typed::new(Variable::from_str("b"), Type::OBJECT),
+                    ]),
+                    PreconditionGoalDefinition::new_preference(PreferenceGD::Goal(
+                        GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
+                            Term::Name("a".into()),
+                            Term::Name("b".into())
+                        ))
+                    ))
+                    .into()
+                )
+                .into()
+            )
+        );
     }
 }

--- a/src/parsers/predicate.rs
+++ b/src/parsers/predicate.rs
@@ -41,3 +41,14 @@ impl crate::parsers::Parser for Predicate {
         parse_predicate(input)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{Parser, Predicate};
+
+    #[test]
+    fn test_parse() {
+        let (_, value) = Predicate::parse("abcde").unwrap();
+        assert_eq!(value, "abcde".into());
+    }
+}

--- a/src/parsers/predicates_def.rs
+++ b/src/parsers/predicates_def.rs
@@ -42,7 +42,7 @@ pub fn parse_predicates_def<'a, T: Into<Span<'a>>>(
             ":predicates",
             space_separated_list1(parse_atomic_formula_skeleton),
         ),
-        |vec| PredicateDefinitions::new(vec),
+        PredicateDefinitions::new,
     )(input.into())
 }
 

--- a/src/parsers/predicates_def.rs
+++ b/src/parsers/predicates_def.rs
@@ -1,9 +1,10 @@
 //! Provides parsers for predicate definitions.
 
+use nom::combinator::map;
+
 use crate::parsers::{parse_atomic_formula_skeleton, ParseResult, Span};
 use crate::parsers::{prefix_expr, space_separated_list1};
 use crate::types::PredicateDefinitions;
-use nom::combinator::map;
 
 /// Parses predicate definitions, i.e. `(:predicates <atomic formula skeleton>⁺)`.
 ///
@@ -52,5 +53,40 @@ impl crate::parsers::Parser for PredicateDefinitions {
     /// See [`parse_predicates_def`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_predicates_def(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::preamble::*;
+    use crate::{
+        AtomicFormulaSkeleton, Predicate, PredicateDefinitions, ToTyped, TypedList, Variable,
+    };
+
+    #[test]
+    fn test_parse() {
+        let input = r#"(:predicates
+                             (at ?x - physob ?y - location)
+                             (in ?x ?y - physob)
+                        )"#;
+
+        assert!(
+            PredicateDefinitions::parse(input).is_value(PredicateDefinitions::new(vec![
+                AtomicFormulaSkeleton::new(
+                    Predicate::from("at"),
+                    TypedList::from_iter([
+                        Variable::from("x").to_typed("physob"),
+                        Variable::from("y").to_typed("location"),
+                    ])
+                ),
+                AtomicFormulaSkeleton::new(
+                    Predicate::from("in"),
+                    TypedList::from_iter([
+                        Variable::from("x").to_typed("physob"),
+                        Variable::from("y").to_typed("physob"),
+                    ])
+                )
+            ]))
+        );
     }
 }

--- a/src/parsers/pref_con_gd.rs
+++ b/src/parsers/pref_con_gd.rs
@@ -141,7 +141,7 @@ mod tests {
             Term::Name("x".into()),
             Term::Name("y".into()),
         ));
-        ///
+
         // (not (= x z))
         let gd_b = GoalDefinition::new_not(GoalDefinition::new_atomic_formula(
             AtomicFormula::new_equality(Term::Name("x".into()), Term::Name("z".into())),

--- a/src/parsers/pref_name.rs
+++ b/src/parsers/pref_name.rs
@@ -22,3 +22,14 @@ impl crate::parsers::Parser for PreferenceName {
         parse_pref_name(input)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::preamble::*;
+    use crate::PreferenceName;
+
+    #[test]
+    fn test_parse() {
+        assert!(PreferenceName::parse("abcde").is_value("abcde".into()));
+    }
+}

--- a/src/parsers/primitive_type.rs
+++ b/src/parsers/primitive_type.rs
@@ -1,10 +1,11 @@
 //! Provides parsers for primitive types.
 
-use crate::parsers::{parse_name, ParseResult, Span};
-use crate::types::{Name, PrimitiveType};
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::combinator::map;
+
+use crate::parsers::{parse_name, ParseResult, Span};
+use crate::types::{Name, PrimitiveType};
 
 /// Parses a primitive type, i.e. `object | <name>`.
 ///
@@ -30,5 +31,19 @@ impl crate::parsers::Parser for PrimitiveType {
     /// See [`parse_primitive_type`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_primitive_type(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::{Span, UnwrapValue};
+    use crate::{Parser, PrimitiveType};
+
+    #[test]
+    fn test_parse() {
+        assert!(PrimitiveType::parse(Span::new("object")).is_value("object".into()));
+        assert!(PrimitiveType::parse(Span::new("number")).is_value("number".into()));
+        assert!(PrimitiveType::parse(Span::new("a-1_2")).is_value("a-1_2".into()));
+        assert!(PrimitiveType::parse(Span::new("obj!ect")).is_value("obj".into()));
     }
 }

--- a/src/parsers/problem_constraints_def.rs
+++ b/src/parsers/problem_constraints_def.rs
@@ -1,8 +1,9 @@
 //! Provides parsers for problem constraint definitions.
 
+use nom::combinator::map;
+
 use crate::parsers::{parse_pref_con_gd, prefix_expr, ParseResult, Span};
 use crate::types::ProblemConstraintsDef;
-use nom::combinator::map;
 
 /// Parses problem constraint definitions, i.e. `(:constraints <pref-con-GD>)`.
 ///
@@ -33,5 +34,21 @@ impl crate::parsers::Parser for ProblemConstraintsDef {
     /// See [`parse_problem_constraints_def`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_problem_constraints_def(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::preamble::*;
+    use crate::{ConGD, PrefConGDs, ProblemConstraintsDef};
+
+    #[test]
+    fn test_parse() {
+        let input = "(:constraints (preference test (and)))";
+        assert!(
+            ProblemConstraintsDef::parse(input).is_value(ProblemConstraintsDef::new(
+                PrefConGDs::new_preference(Some("test".into()), ConGD::new_and([]))
+            ))
+        );
     }
 }

--- a/src/parsers/requirements.rs
+++ b/src/parsers/requirements.rs
@@ -1,11 +1,12 @@
 //! Provides parsers for requirements.
 
-use crate::parsers::{prefix_expr, space_separated_list1, ParseResult, Span};
-use crate::types::requirement::{names, Requirement};
-use crate::types::Requirements;
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::combinator::map;
+
+use crate::parsers::{prefix_expr, space_separated_list1, ParseResult, Span};
+use crate::types::requirement::{names, Requirement};
+use crate::types::Requirements;
 
 /// Parses a requirement definition, i.e. `(:requirements <require-key>)⁺`.
 ///
@@ -97,5 +98,47 @@ impl crate::parsers::Parser for Requirement {
     /// See [`parse_require_key`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_require_key(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::preamble::*;
+    use crate::Requirement;
+
+    #[test]
+    fn test_parse() {
+        assert!(Requirement::parse(":strips").is_value(Requirement::Strips));
+        assert!(Requirement::parse(":typing").is_value(Requirement::Typing));
+        assert!(Requirement::parse(":negative-preconditions")
+            .is_value(Requirement::NegativePreconditions));
+        assert!(Requirement::parse(":disjunctive-preconditions")
+            .is_value(Requirement::DisjunctivePreconditions));
+        assert!(Requirement::parse(":equality").is_value(Requirement::Equality));
+        assert!(Requirement::parse(":existential-preconditions")
+            .is_value(Requirement::ExistentialPreconditions));
+        assert!(Requirement::parse(":universal-preconditions")
+            .is_value(Requirement::UniversalPreconditions));
+        assert!(Requirement::parse(":quantified-preconditions")
+            .is_value(Requirement::QuantifiedPreconditions));
+        assert!(
+            Requirement::parse(":conditional-effects").is_value(Requirement::ConditionalEffects)
+        );
+        assert!(Requirement::parse(":fluents").is_value(Requirement::Fluents));
+        assert!(Requirement::parse(":numeric-fluents").is_value(Requirement::NumericFluents));
+        assert!(Requirement::parse(":adl").is_value(Requirement::Adl));
+        assert!(Requirement::parse(":durative-actions").is_value(Requirement::DurativeActions));
+        assert!(Requirement::parse(":duration-inequalities")
+            .is_value(Requirement::DurationInequalities));
+        assert!(Requirement::parse(":continuous-effects").is_value(Requirement::ContinuousEffects));
+        assert!(Requirement::parse(":derived-predicates").is_value(Requirement::DerivedPredicates));
+        assert!(Requirement::parse(":timed-initial-literals")
+            .is_value(Requirement::TimedInitialLiterals));
+        assert!(Requirement::parse(":preferences").is_value(Requirement::Preferences));
+        assert!(Requirement::parse(":constraints").is_value(Requirement::Constraints));
+        assert!(Requirement::parse(":action-costs").is_value(Requirement::ActionCosts));
+
+        assert!(Requirement::parse(":unknown").is_err());
+        assert!(Requirement::parse("invalid").is_err());
     }
 }

--- a/src/parsers/requirements.rs
+++ b/src/parsers/requirements.rs
@@ -104,10 +104,10 @@ impl crate::parsers::Parser for Requirement {
 #[cfg(test)]
 mod tests {
     use crate::parsers::preamble::*;
-    use crate::Requirement;
+    use crate::{Requirement, Requirements};
 
     #[test]
-    fn test_parse() {
+    fn test_parse_requirement() {
         assert!(Requirement::parse(":strips").is_value(Requirement::Strips));
         assert!(Requirement::parse(":typing").is_value(Requirement::Typing));
         assert!(Requirement::parse(":negative-preconditions")
@@ -140,5 +140,22 @@ mod tests {
 
         assert!(Requirement::parse(":unknown").is_err());
         assert!(Requirement::parse("invalid").is_err());
+    }
+
+    #[test]
+    fn test_parse_requirements() {
+        assert!(Requirements::parse("(:requirements :adl)")
+            .is_value(Requirements::new([Requirement::Adl])));
+        assert!(
+            Requirements::parse("(:requirements :strips :typing)").is_value(Requirements::new([
+                Requirement::Strips,
+                Requirement::Typing
+            ]))
+        );
+        assert!(
+            Requirements::parse("(:requirements\n:strips   :typing  )").is_value(
+                Requirements::new([Requirement::Strips, Requirement::Typing])
+            )
+        );
     }
 }

--- a/src/parsers/simple_duration_constraint.rs
+++ b/src/parsers/simple_duration_constraint.rs
@@ -1,13 +1,14 @@
 //! Provides parsers for simple duration constraints.
 
-use crate::parsers::{parens, prefix_expr, ParseResult, Span};
-use crate::parsers::{parse_d_op, parse_d_value, parse_time_specifier};
-use crate::types::SimpleDurationConstraint;
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::character::complete::multispace1;
 use nom::combinator::map;
 use nom::sequence::{preceded, tuple};
+
+use crate::parsers::{parens, prefix_expr, ParseResult, Span};
+use crate::parsers::{parse_d_op, parse_d_value, parse_time_specifier};
+use crate::types::SimpleDurationConstraint;
 
 /// Parses a simple duration constraint.
 ///
@@ -68,5 +69,30 @@ impl crate::parsers::Parser for SimpleDurationConstraint {
     /// See [`parse_simple_duration_constraint`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_simple_duration_constraint(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::preamble::*;
+    use crate::{DOp, DurationValue, SimpleDurationConstraint, TimeSpecifier};
+
+    #[test]
+    fn test_parse() {
+        let input = "(>= ?duration 1.23)";
+        assert!(
+            SimpleDurationConstraint::parse(input).is_value(SimpleDurationConstraint::new_op(
+                DOp::GreaterOrEqual,
+                DurationValue::new_number(1.23)
+            ))
+        );
+
+        let input = "(at end (<= ?duration 1.23))";
+        assert!(
+            SimpleDurationConstraint::parse(input).is_value(SimpleDurationConstraint::new_at(
+                TimeSpecifier::End,
+                SimpleDurationConstraint::Op(DOp::LessThanOrEqual, DurationValue::new_number(1.23))
+            ))
+        );
     }
 }

--- a/src/parsers/term.rs
+++ b/src/parsers/term.rs
@@ -57,3 +57,17 @@ impl crate::parsers::Parser for Term {
         parse_term(input)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{Parser, Term};
+
+    #[test]
+    fn test_parse() {
+        let (_, value) = Term::parse("some-name").unwrap();
+        assert_eq!(value, Term::Name("some-name".into()));
+
+        let (_, value) = Term::parse("?some-var").unwrap();
+        assert_eq!(value, Term::Variable("some-var".into()));
+    }
+}

--- a/src/parsers/term.rs
+++ b/src/parsers/term.rs
@@ -30,10 +30,7 @@ pub fn parse_term<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Term> {
         return Ok((remaining, Term::Function(ft)));
     }
 
-    Err(nom::Err::Error(error_position!(
-        input,
-        ErrorKind::Alt
-    )))
+    Err(nom::Err::Error(error_position!(input, ErrorKind::Alt)))
 }
 
 impl crate::parsers::Parser for Term {

--- a/src/parsers/term.rs
+++ b/src/parsers/term.rs
@@ -30,10 +30,10 @@ pub fn parse_term<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Term> {
         return Ok((remaining, Term::Function(ft)));
     }
 
-    return Err(nom::Err::Error(error_position!(
-        input.into(),
+    Err(nom::Err::Error(error_position!(
+        input,
         ErrorKind::Alt
-    )));
+    )))
 }
 
 impl crate::parsers::Parser for Term {

--- a/src/parsers/test_helpers.rs
+++ b/src/parsers/test_helpers.rs
@@ -32,11 +32,13 @@ where
 pub trait Match<V> {
     /// Ensures the parser produced the specified value
     /// and leaves no remaining value to be parsed.
+    #[allow(unused)]
     fn is_exactly(&self, value: V) -> bool {
         self.is_result("", value)
     }
 
     /// Ensures the remainder value are as specified.
+    #[allow(unused)]
     fn is_result(&self, remainder: &str, value: V) -> bool;
 }
 

--- a/src/parsers/test_helpers.rs
+++ b/src/parsers/test_helpers.rs
@@ -107,3 +107,37 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::parsers::name::parse_any_char;
+    use crate::parsers::Match;
+    use crate::{Name, Parser};
+
+    #[test]
+    fn test_is_value() {
+        assert!(Name::parse("abcde").is_value("abcde".into()));
+    }
+
+    #[test]
+    fn test_is_value_fails() {
+        assert!(!Name::parse("abcde").is_value("xyz".into()));
+        assert!(!Name::parse("-").is_value("abcde".into()));
+    }
+
+    #[test]
+    fn test_unwrap_value() {
+        assert_eq!(Name::parse("abcde").unwrap_value(), "abcde");
+    }
+
+    #[test]
+    fn test_is_exactly() {
+        assert!(Name::parse(Span::new("abcde")).is_exactly("abcde"));
+    }
+
+    #[test]
+    fn test_is_er() {
+        assert!(parse_any_char(Span::new(".")).is_err());
+    }
+}

--- a/src/parsers/time_specifier.rs
+++ b/src/parsers/time_specifier.rs
@@ -1,11 +1,12 @@
 //! Provides parsers for assignment operations.
 
-use crate::parsers::{ParseResult, Span};
-use crate::types::time_specifier::names;
-use crate::types::TimeSpecifier;
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::combinator::map;
+
+use crate::parsers::{ParseResult, Span};
+use crate::types::time_specifier::names;
+use crate::types::TimeSpecifier;
 
 /// Parses an assignment operation, i.e. `increase | decrease`.
 ///
@@ -28,5 +29,17 @@ impl crate::parsers::Parser for TimeSpecifier {
     /// See [`parse_time_specifier`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_time_specifier(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::{parse_time_specifier, UnwrapValue};
+    use crate::TimeSpecifier;
+
+    #[test]
+    fn test_parse() {
+        assert!(parse_time_specifier("start").is_value(TimeSpecifier::Start));
+        assert!(parse_time_specifier("end").is_value(TimeSpecifier::End));
     }
 }

--- a/src/parsers/time_specifier.rs
+++ b/src/parsers/time_specifier.rs
@@ -34,12 +34,12 @@ impl crate::parsers::Parser for TimeSpecifier {
 
 #[cfg(test)]
 mod tests {
-    use crate::parsers::{parse_time_specifier, UnwrapValue};
-    use crate::TimeSpecifier;
+    use crate::parsers::UnwrapValue;
+    use crate::{Parser, TimeSpecifier};
 
     #[test]
     fn test_parse() {
-        assert!(parse_time_specifier("start").is_value(TimeSpecifier::Start));
-        assert!(parse_time_specifier("end").is_value(TimeSpecifier::End));
+        assert!(TimeSpecifier::parse("start").is_value(TimeSpecifier::Start));
+        assert!(TimeSpecifier::parse("end").is_value(TimeSpecifier::End));
     }
 }

--- a/src/parsers/timed_effect.rs
+++ b/src/parsers/timed_effect.rs
@@ -100,10 +100,48 @@ impl crate::parsers::Parser for TimedEffect {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parsers::UnwrapValue;
+    use crate::{
+        AssignOp, AssignOpT, AtomicFormula, ConditionalEffect, EqualityAtomicFormula, FAssignDa,
+        FExpDa, FExpT, FHead, PEffect, Parser, Term, TimeSpecifier,
+    };
 
     #[test]
     fn it_works() {
         let input = "(at end (increase (distance-travelled) 5))";
         let (_, _effect) = parse_timed_effect(Span::new(input)).unwrap();
+    }
+
+    #[test]
+    fn test_parse() {
+        assert!(
+            TimedEffect::parse("(at start (= x y))").is_value(TimedEffect::new_conditional(
+                TimeSpecifier::Start,
+                ConditionalEffect::new(PEffect::AtomicFormula(AtomicFormula::Equality(
+                    EqualityAtomicFormula::new(Term::Name("x".into()), Term::Name("y".into()))
+                )))
+            ))
+        );
+
+        assert!(
+            TimedEffect::parse("(at end (assign fun-sym ?duration))").is_value(
+                TimedEffect::new_fluent(
+                    TimeSpecifier::End,
+                    FAssignDa::new(
+                        AssignOp::Assign,
+                        FHead::Simple("fun-sym".into()),
+                        FExpDa::Duration
+                    )
+                )
+            )
+        );
+
+        assert!(
+            TimedEffect::parse("(increase fun-sym #t)").is_value(TimedEffect::new_continuous(
+                AssignOpT::Increase,
+                FHead::Simple("fun-sym".into()),
+                FExpT::Now
+            ))
+        );
     }
 }

--- a/src/parsers/timed_gd.rs
+++ b/src/parsers/timed_gd.rs
@@ -70,10 +70,35 @@ impl crate::parsers::Parser for TimedGD {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parsers::UnwrapValue;
+    use crate::{AtomicFormula, GoalDefinition, Interval, Parser, Term, TimeSpecifier};
 
     #[test]
     fn it_works() {
         let input = "(over all (can-move ?from-waypoint ?to-waypoint))";
         let (_, _gd) = parse_timed_gd(Span::new(input)).unwrap();
+    }
+
+    #[test]
+    fn test_parse() {
+        assert!(
+            TimedGD::parse("(at start (= x y))").is_value(TimedGD::new_at(
+                TimeSpecifier::Start,
+                GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
+                    Term::Name("x".into()),
+                    Term::Name("y".into())
+                ))
+            ))
+        );
+
+        assert!(
+            parse_timed_gd("(over all (= x y))").is_value(TimedGD::new_over(
+                Interval::All,
+                GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
+                    Term::Name("x".into()),
+                    Term::Name("y".into())
+                ))
+            ))
+        );
     }
 }

--- a/src/parsers/timeless_def.rs
+++ b/src/parsers/timeless_def.rs
@@ -49,3 +49,24 @@ impl crate::parsers::Parser for Timeless {
         parse_timeless_def(input)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::preamble::*;
+    use crate::{AtomicFormula, EqualityAtomicFormula, Literal, Timeless};
+
+    #[test]
+    fn test_parse() {
+        let input = "(:timeless (= x y) (= a b))";
+        assert!(Timeless::parse(input).is_value(Timeless::from_iter([
+            Literal::AtomicFormula(AtomicFormula::Equality(EqualityAtomicFormula::new(
+                "x".into(),
+                "y".into()
+            ))),
+            Literal::AtomicFormula(AtomicFormula::Equality(EqualityAtomicFormula::new(
+                "a".into(),
+                "b".into()
+            )))
+        ])));
+    }
+}

--- a/src/parsers/type.rs
+++ b/src/parsers/type.rs
@@ -26,10 +26,7 @@ pub fn parse_type<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Type> {
         return Ok((remaining, Type::EitherOf(types)));
     }
 
-    Err(nom::Err::Failure(error_position!(
-        input,
-        ErrorKind::Alt
-    )))
+    Err(nom::Err::Failure(error_position!(input, ErrorKind::Alt)))
 }
 
 /// Parses a either type, i.e. `(either a b c)`.

--- a/src/parsers/type.rs
+++ b/src/parsers/type.rs
@@ -27,7 +27,7 @@ pub fn parse_type<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Type> {
     }
 
     Err(nom::Err::Failure(error_position!(
-        input.into(),
+        input,
         ErrorKind::Alt
     )))
 }

--- a/src/parsers/type.rs
+++ b/src/parsers/type.rs
@@ -68,4 +68,9 @@ mod tests {
             ])
         );
     }
+
+    #[test]
+    fn test_invalid() {
+        assert!(parse_type(Span::new("()")).is_err());
+    }
 }

--- a/src/parsers/typed_list.rs
+++ b/src/parsers/typed_list.rs
@@ -72,10 +72,10 @@ where
         implicitly_typed_list,
     ));
 
-    let repeated_lists = map(typed_list_choice, |(mut explicit, mut implicit)| {
+    
+
+    map(typed_list_choice, |(mut explicit, mut implicit)| {
         explicit.append(&mut implicit);
         TypedList::new(explicit)
-    });
-
-    repeated_lists
+    })
 }

--- a/src/parsers/typed_list.rs
+++ b/src/parsers/typed_list.rs
@@ -1,13 +1,14 @@
 //! Provides the [`typed_list`] parser combinator.
 
-use crate::parsers::{
-    parse_type, space_separated_list0, space_separated_list1, ws, ParseResult, Span,
-};
-use crate::types::{Typed, TypedList};
 use nom::character::complete::char;
 use nom::combinator::map;
 use nom::multi::many0;
 use nom::sequence::{preceded, tuple};
+
+use crate::parsers::{
+    parse_type, space_separated_list0, space_separated_list1, ws, ParseResult, Span,
+};
+use crate::types::{Typed, TypedList};
 
 /// Parser combinator that parses a typed list, i.e. `x* | x⁺ - <type> <typed-list (x)>.
 ///
@@ -72,10 +73,58 @@ where
         implicitly_typed_list,
     ));
 
-    
-
     map(typed_list_choice, |(mut explicit, mut implicit)| {
         explicit.append(&mut implicit);
         TypedList::new(explicit)
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::preamble::*;
+    use crate::parsers::{parse_name, typed_list};
+    use crate::{Name, ToTyped, Type, TypedList};
+
+    #[test]
+    fn test_parse() {
+        // Single implicitly typed element.
+        assert!(
+            typed_list(parse_name)(Span::new("abc"))
+                .is_value(TypedList::from_iter([
+                    Name::new("abc").to_typed(Type::OBJECT)
+                ]))
+        );
+
+        // Multiple implicitly typed elements.
+        assert!(
+            typed_list(parse_name)(Span::new("abc def\nghi")).is_value(TypedList::from_iter([
+                Name::new("abc").to_typed(Type::OBJECT),
+                Name::new("def").to_typed(Type::OBJECT),
+                Name::new("ghi").to_typed(Type::OBJECT)
+            ]))
+        );
+
+        // Multiple explicitly typed elements.
+        assert!(
+            typed_list(parse_name)(Span::new("abc def - word kitchen - room")).is_value(
+                TypedList::from_iter([
+                    Name::new("abc").to_typed("word"),
+                    Name::new("def").to_typed("word"),
+                    Name::new("kitchen").to_typed("room"),
+                ])
+            )
+        );
+
+        // Mixed
+        assert!(typed_list(parse_name)(Span::new(
+            "abc def - word\ngeorgia - (either state country)\nuvw xyz"
+        ))
+        .is_value(TypedList::from_iter([
+            Name::new("abc").to_typed("word"),
+            Name::new("def").to_typed("word"),
+            Name::new("georgia").to_typed_either(["state", "country"]),
+            Name::new("uvw").to_typed(Type::OBJECT),
+            Name::new("xyz").to_typed(Type::OBJECT)
+        ])));
+    }
 }

--- a/src/parsers/types_def.rs
+++ b/src/parsers/types_def.rs
@@ -1,8 +1,9 @@
 //! Provides parsers for constant definitions.
 
+use nom::combinator::map;
+
 use crate::parsers::{parse_name, prefix_expr, typed_list, ParseResult, Span};
 use crate::types::Types;
-use nom::combinator::map;
 
 /// Parses constant definitions, i.e. `(:constants <typed list (name)>)`.
 ///
@@ -31,5 +32,22 @@ impl crate::parsers::Parser for Types {
     /// See [`parse_types_def`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_types_def(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parsers::UnwrapValue;
+    use crate::{Name, Parser, Type, Typed, TypedList, Types};
+
+    #[test]
+    fn test_parse() {
+        let input = "(:types location physob)";
+        assert!(
+            Types::parse(input).is_value(Types::new(TypedList::from_iter([
+                Typed::new(Name::from("location"), Type::OBJECT),
+                Typed::new(Name::from("physob"), Type::OBJECT),
+            ])))
+        );
     }
 }

--- a/src/parsers/variable.rs
+++ b/src/parsers/variable.rs
@@ -1,10 +1,11 @@
 //! Provides parsers for variables.
 
-use crate::parsers::{parse_name, ParseResult, Span};
-use crate::types::Variable;
 use nom::bytes::complete::tag;
 use nom::combinator::map;
 use nom::sequence::preceded;
+
+use crate::parsers::{parse_name, ParseResult, Span};
+use crate::types::Variable;
 
 /// Parses a variable, i.e. `?<name>` and returns its name.
 ///
@@ -40,5 +41,16 @@ impl crate::parsers::Parser for Variable {
     /// See [`parse_variable`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_variable(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Parser, Variable};
+
+    #[test]
+    fn test_parse() {
+        let (_, value) = Variable::parse("?abcde").unwrap();
+        assert_eq!(value, "abcde".into());
     }
 }

--- a/src/types/assign_op.rs
+++ b/src/types/assign_op.rs
@@ -72,12 +72,12 @@ pub enum AssignOp {
 
 pub mod names {
     /// [`CHANGE`] is a deprecated name for [`ASSIGN`].
-    pub const CHANGE: &'static str = "change";
-    pub const ASSIGN: &'static str = "assign";
-    pub const SCALE_UP: &'static str = "scale-up";
-    pub const SCALE_DOWN: &'static str = "scale-down";
-    pub const INCREASE: &'static str = "increase";
-    pub const DECREASE: &'static str = "decrease";
+    pub const CHANGE: &str = "change";
+    pub const ASSIGN: &str = "assign";
+    pub const SCALE_UP: &str = "scale-up";
+    pub const SCALE_DOWN: &str = "scale-down";
+    pub const INCREASE: &str = "increase";
+    pub const DECREASE: &str = "decrease";
 }
 
 impl AssignOp {

--- a/src/types/assign_op_t.rs
+++ b/src/types/assign_op_t.rs
@@ -13,8 +13,8 @@ pub enum AssignOpT {
 }
 
 pub mod names {
-    pub const INCREASE: &'static str = "increase";
-    pub const DECREASE: &'static str = "decrease";
+    pub const INCREASE: &str = "increase";
+    pub const DECREASE: &str = "decrease";
 }
 
 impl Display for AssignOpT {

--- a/src/types/binary_comp.rs
+++ b/src/types/binary_comp.rs
@@ -16,11 +16,11 @@ pub enum BinaryComp {
 }
 
 pub mod names {
-    pub const GREATER_THAN: &'static str = ">";
-    pub const LESS_THAN: &'static str = "<";
-    pub const EQUAL: &'static str = "=";
-    pub const GREATER_THAN_OR_EQUAL: &'static str = ">=";
-    pub const LESS_THAN_OR_EQUAL: &'static str = "<=";
+    pub const GREATER_THAN: &str = ">";
+    pub const LESS_THAN: &str = "<";
+    pub const EQUAL: &str = "=";
+    pub const GREATER_THAN_OR_EQUAL: &str = ">=";
+    pub const LESS_THAN_OR_EQUAL: &str = "<=";
 }
 
 impl Display for BinaryComp {

--- a/src/types/binary_op.rs
+++ b/src/types/binary_op.rs
@@ -16,10 +16,10 @@ pub enum BinaryOp {
 }
 
 pub mod names {
-    pub const MULTIPLICATION: &'static str = "*";
-    pub const ADDITION: &'static str = "+";
-    pub const SUBTRACTION: &'static str = "-";
-    pub const DIVISION: &'static str = "/";
+    pub const MULTIPLICATION: &str = "*";
+    pub const ADDITION: &str = "+";
+    pub const SUBTRACTION: &str = "-";
+    pub const DIVISION: &str = "/";
 }
 
 impl Display for BinaryOp {

--- a/src/types/d_op.rs
+++ b/src/types/d_op.rs
@@ -16,9 +16,9 @@ pub enum DOp {
 }
 
 pub mod names {
-    pub const EQUAL: &'static str = "=";
-    pub const GREATER_OR_EQUAL: &'static str = ">=";
-    pub const LESS_THAN_OR_EQUAL: &'static str = "<=";
+    pub const EQUAL: &str = "=";
+    pub const GREATER_OR_EQUAL: &str = ">=";
+    pub const LESS_THAN_OR_EQUAL: &str = "<=";
 }
 
 impl Display for DOp {

--- a/src/types/domain.rs
+++ b/src/types/domain.rs
@@ -170,7 +170,7 @@ impl Domain {
     /// Gets the names of the domains this definition extends.
     /// This is a PDDL 1.2 construct.
     pub fn extends(&self) -> &[Name] {
-        &self.extends.as_slice()
+        self.extends.as_slice()
     }
 
     /// Returns the optional domain requirements.
@@ -205,7 +205,7 @@ impl Domain {
 
     /// Returns the optional constraint declaration.
     pub const fn constraints(&self) -> &ConGD {
-        &self.constraints.value()
+        self.constraints.value()
     }
 
     /// Returns the domain structure definitions.

--- a/src/types/domain_constraints_def.rs
+++ b/src/types/domain_constraints_def.rs
@@ -44,8 +44,8 @@ impl Deref for DomainConstraintsDef {
     }
 }
 
-impl Into<ConGD> for DomainConstraintsDef {
-    fn into(self) -> ConGD {
-        self.0
+impl From<DomainConstraintsDef> for ConGD {
+    fn from(val: DomainConstraintsDef) -> Self {
+        val.0
     }
 }

--- a/src/types/goal_def.rs
+++ b/src/types/goal_def.rs
@@ -54,8 +54,8 @@ impl Deref for GoalDef {
     }
 }
 
-impl Into<PreconditionGoalDefinitions> for GoalDef {
-    fn into(self) -> PreconditionGoalDefinitions {
-        self.0
+impl From<GoalDef> for PreconditionGoalDefinitions {
+    fn from(val: GoalDef) -> Self {
+        val.0
     }
 }

--- a/src/types/interval.rs
+++ b/src/types/interval.rs
@@ -13,7 +13,7 @@ pub enum Interval {
 }
 
 pub mod names {
-    pub const ALL: &'static str = "all";
+    pub const ALL: &str = "all";
 }
 
 impl Display for Interval {

--- a/src/types/multi_op.rs
+++ b/src/types/multi_op.rs
@@ -14,8 +14,8 @@ pub enum MultiOp {
 }
 
 pub mod names {
-    pub const MULTIPLICATION: &'static str = "*";
-    pub const ADDITION: &'static str = "+";
+    pub const MULTIPLICATION: &str = "*";
+    pub const ADDITION: &str = "+";
 }
 
 impl Display for MultiOp {

--- a/src/types/name.rs
+++ b/src/types/name.rs
@@ -121,7 +121,7 @@ impl Name {
     }
 
     /// Maps the provided to a well-known `'static` string if possible.
-    fn map_to_static<'a>(value: &'a str) -> Option<&'static str> {
+    fn map_to_static(value: &str) -> Option<&'static str> {
         match value {
             "object" => Some(well_known::OBJECT),
             "number" => Some(well_known::NUMBER),
@@ -132,8 +132,8 @@ impl Name {
 
 /// Provides well-known names for string interning.
 mod well_known {
-    pub static OBJECT: &'static str = "object";
-    pub static NUMBER: &'static str = "number";
+    pub static OBJECT: &str = "object";
+    pub static NUMBER: &str = "number";
 }
 
 impl<T> From<T> for Name
@@ -217,7 +217,7 @@ impl Deref for NameVariant {
     fn deref(&self) -> &Self::Target {
         match self {
             NameVariant::String(str) => str.as_str(),
-            NameVariant::Static(str) => *str,
+            NameVariant::Static(str) => str,
         }
     }
 }

--- a/src/types/number.rs
+++ b/src/types/number.rs
@@ -126,13 +126,13 @@ impl Ord for Number {
             unreachable!("Proper construction of this type prevents NaN");
         }
 
-        return lhs.partial_cmp(&rhs).expect("Values cannot be ambiguous");
+        lhs.partial_cmp(&rhs).expect("Values cannot be ambiguous")
     }
 }
 
 impl PartialOrd for Number {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.total_cmp(&other))
+        Some(self.total_cmp(other))
     }
 }
 

--- a/src/types/optimization.rs
+++ b/src/types/optimization.rs
@@ -18,8 +18,8 @@ pub enum Optimization {
 }
 
 pub mod names {
-    pub const MINIMIZE: &'static str = "minimize";
-    pub const MAXIMIZE: &'static str = "maximize";
+    pub const MINIMIZE: &str = "minimize";
+    pub const MAXIMIZE: &str = "maximize";
 }
 
 impl Display for Optimization {

--- a/src/types/problem.rs
+++ b/src/types/problem.rs
@@ -163,14 +163,14 @@ impl Problem {
 
     /// Returns the goal statement of the problem.
     pub const fn goals(&self) -> &PreconditionGoalDefinitions {
-        &self.goal.value()
+        self.goal.value()
     }
 
     /// Returns the optional constraints of the problem.
     /// ## Requirements
     /// Requires [Constraints](crate::Requirement::Constraints).
     pub const fn constraints(&self) -> &PrefConGDs {
-        &self.constraints.value()
+        self.constraints.value()
     }
 
     /// Returns the optional metric specification of the problem.

--- a/src/types/problem_constraints_def.rs
+++ b/src/types/problem_constraints_def.rs
@@ -41,8 +41,8 @@ impl Deref for ProblemConstraintsDef {
     }
 }
 
-impl Into<PrefConGDs> for ProblemConstraintsDef {
-    fn into(self) -> PrefConGDs {
-        self.0
+impl From<ProblemConstraintsDef> for PrefConGDs {
+    fn from(val: ProblemConstraintsDef) -> Self {
+        val.0
     }
 }

--- a/src/types/requirement.rs
+++ b/src/types/requirement.rs
@@ -16,8 +16,10 @@ use std::fmt::{Display, Formatter};
 /// ## References
 /// - "Complete BNF description of PDDL 3.1 (completely corrected)", Daniel L. Kovacs (`dkovacs@mit.bme.hu`).
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Default)]
 pub enum Requirement {
     /// Basic STRIPS-style adds and deletes.
+    #[default]
     Strips,
     /// Allow type names in declarations of variables.
     Typing,
@@ -104,27 +106,27 @@ pub enum Requirement {
 }
 
 pub mod names {
-    pub const STRIPS: &'static str = ":strips";
-    pub const TYPING: &'static str = ":typing";
-    pub const NEGATIVE_PRECONDITIONS: &'static str = ":negative-preconditions";
-    pub const DISJUNCTIVE_PRECONDITIONS: &'static str = ":disjunctive-preconditions";
-    pub const EQUALITY: &'static str = ":equality";
-    pub const EXISTENTIAL_PRECONDITIONS: &'static str = ":existential-preconditions";
-    pub const UNIVERSAL_PRECONDITIONS: &'static str = ":universal-preconditions";
-    pub const QUANTIFIED_PRECONDITIONS: &'static str = ":quantified-preconditions";
-    pub const CONDITIONAL_EFFECTS: &'static str = ":conditional-effects";
-    pub const FLUENTS: &'static str = ":fluents";
-    pub const NUMERIC_FLUENTS: &'static str = ":numeric-fluents";
-    pub const OBJECT_FLUENTS: &'static str = ":object-fluents";
-    pub const ADL: &'static str = ":adl";
-    pub const DURATIVE_ACTIONS: &'static str = ":durative-actions";
-    pub const DURATION_INEQUALITIES: &'static str = ":duration-inequalities";
-    pub const CONTINUOUS_EFFECTS: &'static str = ":continuous-effects";
-    pub const DERIVED_PREDICATES: &'static str = ":derived-predicates";
-    pub const TIMED_INITIAL_LITERALS: &'static str = ":timed-initial-literals";
-    pub const PREFERENCES: &'static str = ":preferences";
-    pub const CONSTRAINTS: &'static str = ":constraints";
-    pub const ACTION_COSTS: &'static str = ":action-costs";
+    pub const STRIPS: &str = ":strips";
+    pub const TYPING: &str = ":typing";
+    pub const NEGATIVE_PRECONDITIONS: &str = ":negative-preconditions";
+    pub const DISJUNCTIVE_PRECONDITIONS: &str = ":disjunctive-preconditions";
+    pub const EQUALITY: &str = ":equality";
+    pub const EXISTENTIAL_PRECONDITIONS: &str = ":existential-preconditions";
+    pub const UNIVERSAL_PRECONDITIONS: &str = ":universal-preconditions";
+    pub const QUANTIFIED_PRECONDITIONS: &str = ":quantified-preconditions";
+    pub const CONDITIONAL_EFFECTS: &str = ":conditional-effects";
+    pub const FLUENTS: &str = ":fluents";
+    pub const NUMERIC_FLUENTS: &str = ":numeric-fluents";
+    pub const OBJECT_FLUENTS: &str = ":object-fluents";
+    pub const ADL: &str = ":adl";
+    pub const DURATIVE_ACTIONS: &str = ":durative-actions";
+    pub const DURATION_INEQUALITIES: &str = ":duration-inequalities";
+    pub const CONTINUOUS_EFFECTS: &str = ":continuous-effects";
+    pub const DERIVED_PREDICATES: &str = ":derived-predicates";
+    pub const TIMED_INITIAL_LITERALS: &str = ":timed-initial-literals";
+    pub const PREFERENCES: &str = ":preferences";
+    pub const CONSTRAINTS: &str = ":constraints";
+    pub const ACTION_COSTS: &str = ":action-costs";
 }
 
 impl Requirement {
@@ -247,11 +249,6 @@ pub enum ParseError {
     InvalidRequirement,
 }
 
-impl Default for Requirement {
-    fn default() -> Self {
-        Requirement::Strips
-    }
-}
 
 impl Borrow<str> for Requirement {
     fn borrow(&self) -> &str {

--- a/src/types/requirement.rs
+++ b/src/types/requirement.rs
@@ -15,8 +15,7 @@ use std::fmt::{Display, Formatter};
 ///
 /// ## References
 /// - "Complete BNF description of PDDL 3.1 (completely corrected)", Daniel L. Kovacs (`dkovacs@mit.bme.hu`).
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-#[derive(Default)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
 pub enum Requirement {
     /// Basic STRIPS-style adds and deletes.
     #[default]
@@ -248,7 +247,6 @@ pub enum ParseError {
     #[error("Invalid requirement")]
     InvalidRequirement,
 }
-
 
 impl Borrow<str> for Requirement {
     fn borrow(&self) -> &str {

--- a/src/types/time_specifier.rs
+++ b/src/types/time_specifier.rs
@@ -15,8 +15,8 @@ pub enum TimeSpecifier {
 }
 
 pub mod names {
-    pub const START: &'static str = "start";
-    pub const END: &'static str = "end";
+    pub const START: &str = "start";
+    pub const END: &str = "end";
 }
 
 impl Display for TimeSpecifier {

--- a/src/types/timeless.rs
+++ b/src/types/timeless.rs
@@ -24,7 +24,7 @@ impl Timeless {
 
     /// Gets the literals.
     pub fn values(&self) -> &[NameLiteral] {
-        &self.0.as_slice()
+        self.0.as_slice()
     }
 }
 

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -48,7 +48,7 @@ mod tests {
     struct Item(i32);
 
     impl VisitorMut<Item, ()> for Visi {
-        fn visit_mut(&mut self, value: &Item) -> () {
+        fn visit_mut(&mut self, value: &Item) {
             self.0 += value.0 as isize;
         }
     }

--- a/tests/briefcase_world.rs
+++ b/tests/briefcase_world.rs
@@ -3,7 +3,7 @@ use pddl::{
     Problem, TermLiteral,
 };
 
-pub const BRIEFCASE_WORLD: &'static str = r#"
+pub const BRIEFCASE_WORLD: &str = r#"
     (define (domain briefcase-world)
       (:requirements :strips :equality :typing :conditional-effects)
       (:types location physob)
@@ -40,7 +40,7 @@ pub const BRIEFCASE_WORLD: &'static str = r#"
     )
     "#;
 
-pub const BRIEFCASE_WORLD_PROBLEM: &'static str = r#"
+pub const BRIEFCASE_WORLD_PROBLEM: &str = r#"
     (define (problem get-paid)
         (:domain briefcase-world)
         (:init


### PR DESCRIPTION
The parsers and functions are already covered by doctests, however codecov doesn't pick that up due to the runner configuration. This PR adds some of these tests as explicit test functions.