### PR TITLE
Fix rustdoc broken links and move type system guide to crate docs

### DIFF
--- a/Taskfile.dist.yaml
+++ b/Taskfile.dist.yaml
@@ -152,14 +152,14 @@ tasks:
     aliases:
       - docs
     cmds:
-      - "{{.CARGO}} doc --no-deps"
+      - "{{.CARGO}} doc --no-deps --all-features"
 
   doc:open:
     desc: Build and open Rust documentation
     aliases:
       - docs:open
     cmds:
-      - "{{.CARGO}} doc --no-deps --open"
+      - "{{.CARGO}} doc --no-deps --all-features --open"
 
   clean:
     desc: Remove Cargo build artifacts

--- a/Taskfile.dist.yaml
+++ b/Taskfile.dist.yaml
@@ -147,6 +147,20 @@ tasks:
       - test:all-features
       - test:no-features
 
+  doc:
+    desc: Build Rust documentation
+    aliases:
+      - docs
+    cmds:
+      - "{{.CARGO}} doc --no-deps"
+
+  doc:open:
+    desc: Build and open Rust documentation
+    aliases:
+      - docs:open
+    cmds:
+      - "{{.CARGO}} doc --no-deps --open"
+
   clean:
     desc: Remove Cargo build artifacts
     cmds:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! * `parser` - Enables parsing of PDDL types through the [`Parser`] trait.
 //! * `interning` - Enables string interning for [`Name`] types to reduce memory footprint.
 //! * `pretty` - Enables pretty-printing of PDDL types via the
-//!   [`Pretty`] extension trait. The feature provides round-trip-safe
+//!   `Pretty` extension trait. The feature provides round-trip-safe
 //!   rendering: `parse → pretty() → parse` preserves AST equality.
 //!
 //! ## Example

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,198 @@
 //! # #[cfg(not(feature = "parser"))]
 //! # fn main() {}
 //! ```
+//!
+//! ## PDDL Type System Guide
+//!
+//! This crate provides a comprehensive type system that models the PDDL 3.1 specification.
+//! The type names may look unwieldy at first glance, but they follow a deliberate design principle:
+//!
+//! **Every type name maps directly to a BNF non-terminal from the PDDL 3.1 spec.**
+//!
+//! For example, the BNF rule `<c-effect>` becomes [`CEffect`], `<da-gd>` becomes
+//! [`DurativeActionGoalDefinition`], and `<con-GD>` becomes [`ConGD`]. This 1:1 mapping
+//! makes it trivial to cross-reference the spec while reading or writing code.
+//!
+//! ### BNF Naming Convention
+//!
+//! The PDDL 3.1 specification defines its grammar using BNF (Backus-Naur Form). Each
+//! non-terminal in the BNF is written as `<something>`. This crate uses those names
+//! directly, with minor transformations:
+//!
+//! | BNF Non-Terminal | Rust Type | Notes |
+//! |------------------|-----------|-------|
+//! | `<gd>` | [`GoalDefinition`] | Goal definition (the core logical formula type) |
+//! | `<pre-GD>` | [`PreconditionGoalDefinition`] | Precondition-specific wrapper |
+//! | `<precondition>` | [`PreconditionGoalDefinitions`] | Collection of preconditions |
+//! | `<da-gd>` | [`DurativeActionGoalDefinition`] | Durative action goals (timed) |
+//! | `<con-GD>` | [`ConGD`] | Constraint goals (temporal constraints) |
+//! | `<con2-GD>` | [`Con2GD`] | Inner constraint goal (goal or nested con-GD) |
+//! | `<pref-con-GD>` | [`PrefConGD`] | Preference constraint goals |
+//! | `<c-effect>` | [`CEffect`] | Conditional effect |
+//! | `<p-effect>` | [`PEffect`] | Primitive effect |
+//! | `<effect>` | [`Effects`] | Collection of effects (the `(and ...)` block) |
+//! | `<da-effect>` | [`DurativeActionEffect`] | Durative action effect |
+//! | `<f-exp>` | [`FExp`] | Fluent/numeric expression |
+//! | `<f-comp>` | [`FComp`] | Fluent comparison |
+//! | `<f-head>` | [`FHead`] | Fluent head (function reference) |
+//! | `<atomic formula (skeleton)>` | [`AtomicFormulaSkeleton`] | Predicate declaration with typed variables |
+//!
+//! When you see a type with an abbreviated name, look for the corresponding BNF rule
+//! in the spec — it will almost certainly match.
+//!
+//! ### Type Groups
+//!
+//! #### Atoms & Formulas
+//!
+//! The building blocks of PDDL logical expressions:
+//!
+//! - [`AtomicFormula<T>`] — An atomic formula parameterized by its term type `T`.
+//!   Can be either an equality (`(= x y)`) or a predicate application (`(on a b)`).
+//!   See [`EqualityAtomicFormula`] and [`PredicateAtomicFormula`].
+//! - [`AtomicFormulaSkeleton`] — A predicate declaration with typed variables, used
+//!   in `(:predicates ...)` blocks. Think of it as a "template" for [`AtomicFormula`].
+//! - [`Literal<T>`] — A possibly-negated [`AtomicFormula<T>`]. Represents `(not (on a b))`.
+//! - [`Predicate`] — A named predicate (wraps a [`Name`]).
+//!
+//! **Generic parameter `T`**: [`AtomicFormula<T>`] and [`Literal<T>`] are generic.
+//! - `AtomicFormula<Name>` — Used in problem initial states (concrete objects only).
+//! - `AtomicFormula<Term>` — Used in action goals/preconditions (may contain [`Variable`]s).
+//!
+//! #### Goals & Preconditions
+//!
+//! This is where the naming proliferation is most apparent. Each variant serves a
+//! distinct purpose in the PDDL spec:
+//!
+//! - [`GoalDefinition`] (`<gd>`) — The core logical formula type. Supports `and`, `or`,
+//!   `not`, `imply`, `exists`, `forall`, atomic formulas, literals, and fluent comparisons.
+//!   Used in action preconditions, goal definitions, and effect conditions.
+//!
+//! - [`PreconditionGoalDefinition`] (`<pre-GD>`) — A simplified variant used specifically
+//!   for action preconditions. Contains either a [`PreferenceGD`] or a `forall` quantifier.
+//!   Multiple are collected in [`PreconditionGoalDefinitions`].
+//!
+//! - [`GoalDef`] — A thin wrapper around [`PreconditionGoalDefinitions`] used by
+//!   [`Problem`] for the `(:goal ...)` section.
+//!
+//! - [`DurativeActionGoalDefinition`] (`<da-gd>`) — Goals for durative actions. Uses
+//!   [`TimedGD`] (time-qualified goals like `(at start (on a b))`) instead of plain
+//!   [`GoalDefinition`].
+//!
+//! - [`ConGD`] (`<con-GD>`) — Temporal constraint goals for problem-level constraints.
+//!   Supports `always`, `sometime`, `within`, `at-most-once`, `sometime-after`,
+//!   `sometime-before`, `always-within`, `hold-during`, `hold-after`. Used by
+//!   [`ProblemConstraintsDef`].
+//!
+//! - [`Con2GD`] (`<con2-GD>`) — An inner component of [`ConGD`], representing either
+//!   a plain [`GoalDefinition`] or a nested [`ConGD`].
+//!
+//! - [`PrefConGD`] (`<pref-con-GD>`) — Constraint goals with optional preference names.
+//!   Used in [`ProblemConstraintsDef`].
+//!
+//! - [`PreferenceGD`] — Either a plain [`GoalDefinition`] or a named [`Preference`].
+//!   Used in [`PreconditionGoalDefinition`].
+//!
+//! #### Effects
+//!
+//! The effects hierarchy mirrors the BNF structure:
+//!
+//! ```text
+//! Effects (Vec<CEffect>)        ← the (and ...) block
+//! └── CEffect                   ← one effect element
+//!       ├── Effect(PEffect)     ← primitive effect
+//!       ├── Forall(ForallCEffect)  ← universal quantification over effects
+//!       └── When(WhenCEffect)   ← conditional effect (when <cond> <effect>)
+//!             └── ConditionalEffect
+//!                   ├── PEffect ← primitive effect (same as above)
+//!                   ├── Forall...
+//!                   └── When...
+//! ```
+//!
+//! - [`PEffect`] (`<p-effect>`) — A primitive effect: setting/negating an atomic formula,
+//!   or assigning a numeric/object fluent.
+//! - [`CEffect`] (`<c-effect>`) — A potentially conditional effect. Wraps [`PEffect`],
+//!   [`ForallCEffect`], or [`WhenCEffect`].
+//! - [`Effects`] (`<effect>`) — A collection of [`CEffect`] values, representing the
+//!   `(and ...)` block in PDDL.
+//! - [`DurativeActionEffect`] (`<da-effect>`) — Effects for durative actions, using
+//!   [`TimedEffect`] (time-qualified effects like `(at end (on a b))`).
+//!
+//! #### Numeric & Fluents
+//!
+//! Types for numeric reasoning in PDDL:
+//!
+//! - [`FExp`] (`<f-exp>`) — A fluent expression: a number, function call, negation,
+//!   binary operation (`+`, `-`, `*`, `/`), or multi-operand operation.
+//! - [`FHead`] (`<f-head>`) — A function head: either a bare function symbol or a
+//!   [`FunctionTerm`] (function applied to arguments).
+//! - [`FComp`] (`<f-comp>`) — A fluent comparison: `<`, `<=`, `>`, `>=`, `=` applied
+//!   to two [`FExp`] values.
+//! - [`FExpT`] (`<f-exp-t>`) — Time-qualified fluent expression (for durative actions).
+//! - [`FExpDa`] (`<f-exp-da>`) — Durative-action-specific fluent expression.
+//! - [`FHead`] variants: [`BasicFunctionTerm`], [`FunctionTerm`].
+//! - [`AssignOp`] / [`AssignOpT`] — Assignment operators (`assign`, `scale-up`, etc.).
+//!
+//! #### Terms
+//!
+//! The fundamental building blocks that appear in formulas:
+//!
+//! - [`Term`] — A term: either a [`Name`] (concrete object), [`Variable`], or
+//!   [`FunctionTerm`] (fluent application).
+//! - [`Name`] — A named constant/object.
+//! - [`Variable`] — A logical variable (e.g., `?x`).
+//! - [`TypedList<T>`] — A list of items with shared type annotations, e.g.,
+//!   `(?x ?y - robot obj1 obj2 - package)`.
+//!
+//! ### Common Confusion Points
+//!
+//! | Confused Pair | Difference |
+//! |---------------|------------|
+//! | [`AtomicFormulaSkeleton`] vs [`AtomicFormula`] | Skeleton declares a predicate's signature (used in `:predicates`); Formula applies it to concrete terms (used in goals/init). |
+//! | [`PEffect`] vs [`CEffect`] vs [`Effects`] | `PEffect` is a single primitive effect; `CEffect` may add conditions/quantifiers; `Effects` is the `(and ...)` collection. |
+//! | [`GoalDefinition`] vs [`PreconditionGoalDefinition`] | `GoalDefinition` is the full logical formula; `PreconditionGoalDefinition` is a simplified wrapper used only in action preconditions. |
+//! | [`GoalDefinition`] vs [`DurativeActionGoalDefinition`] | `GoalDefinition` is timeless; `DurativeActionGoalDefinition` uses [`TimedGD`] for time-qualified goals `(at start ...)`. |
+//! | [`ConGD`] vs [`GoalDefinition`] | `ConGD` is for problem-level temporal constraints (`always`, `sometime`); `GoalDefinition` is the standard logical formula. |
+//! | [`GoalDef`] vs [`GoalDefinition`] | `GoalDef` wraps [`PreconditionGoalDefinitions`] for the problem's `(:goal ...)`; `GoalDefinition` is the individual formula. |
+//! | [`PreferenceGD`] vs [`PrefConGD`] | `PreferenceGD` is for action-level preferences; `PrefConGD` is for problem-level constraint preferences. |
+//! | [`Effects`] vs [`ConditionalEffect`] | `Effects` is a flat collection of [`CEffect`]; `ConditionalEffect` is recursive (used inside `when` clauses). |
+//! | [`FExp`] vs [`FHead`] | `FExp` is any numeric expression; `FHead` is specifically a function reference (with or without args). |
+//! | [`Literal<T>`] vs [`AtomicFormula<T>`] | `Literal` can be negated; `AtomicFormula` is always positive. |
+//!
+//! ### PDDL Snippet → Rust Type Mapping
+//!
+//! ```text
+//! ;; PDDL domain definition
+//! (define (domain blocksworld)
+//!   (:predicates (on ?x ?y)      ← AtomicFormulaSkeleton
+//!                (clear ?x))      ← AtomicFormulaSkeleton
+//!
+//!   (:action pick-up
+//!     :parameters (?x)            ← TypedList<Variable>
+//!     :precondition (and          ← PreconditionGoalDefinitions
+//!       (clear ?x)                ← GoalDefinition::AtomicFormula
+//!       (handempty))              ← GoalDefinition::AtomicFormula
+//!     :effect (and                ← Effects
+//!       (not (clear ?x))          ← CEffect::Effect(PEffect::NotAtomicFormula)
+//!       (holding ?x)))            ← CEffect::Effect(PEffect::AtomicFormula)
+//!
+//!   (:goal (and                   ← GoalDef → PreconditionGoalDefinitions
+//!     (on a b)                    ← GoalDefinition::AtomicFormula
+//!     (on b c)))                  ← GoalDefinition::AtomicFormula
+//! )
+//!
+//! ;; PDDL problem initial state
+//! (define (problem bw-1)
+//!   (:init
+//!     (on a b)                    ← InitElement::AtomicFormula (Literal<Name>)
+//!     (clear a)                   ← InitElement::AtomicFormula
+//!     (= (total-cost) 0))         ← InitElement::FAssign (numeric fluent)
+//! )
+//! ```
+//!
+//! ### Navigating Further
+//!
+//! Each type has its own documentation with detailed examples and PDDL requirement annotations.
+//! Use your IDE's "Go to Definition" or hover documentation to explore individual types.
 
 // only enables the `doc_cfg` feature when
 // the `docsrs` configuration attribute is defined

--- a/src/parsers/con_gd.rs
+++ b/src/parsers/con_gd.rs
@@ -279,7 +279,7 @@ impl crate::parsers::Parser for ConGD {
 impl crate::parsers::Parser for Con2GD {
     type Item = Con2GD;
 
-    /// See [`parse_con2_gd`].
+    /// Parses a constraint goal definition.
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
         parse_con2_gd(input)
     }

--- a/src/parsers/d_op.rs
+++ b/src/parsers/d_op.rs
@@ -43,9 +43,6 @@ impl crate::parsers::Parser for DOp {
     /// assert_eq!(value, DOp::LessThanOrEqual);
     ///```
     ///
-    /// ## See also.
-    /// See [`parse_binary_op`].
-    ///
     /// ## See also
     /// See [`parse_d_op`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {

--- a/src/parsers/typed_list.rs
+++ b/src/parsers/typed_list.rs
@@ -11,7 +11,7 @@ use crate::parsers::{
 };
 use crate::types::{Typed, TypedList};
 
-/// Parser combinator that parses a typed list, i.e. `x* | x⁺ - <type> <typed-list (x)>.
+/// Parser combinator that parses a typed list, i.e. `x* | x⁺ - <type> <typed-list (x)>`.
 ///
 /// ## Example
 /// ```

--- a/src/types/binary_op.rs
+++ b/src/types/binary_op.rs
@@ -6,7 +6,7 @@ use std::fmt::{Display, Formatter};
 /// A binary operation.
 ///
 /// ## Usage
-/// Used by [`FExp`](crate::Fexp), [`FExpDa`](crate::FExpDa) and [`Optimization`](crate::Optimization).
+/// Used by [`FExp`](crate::FExp), [`FExpDa`](crate::FExpDa) and [`Optimization`](crate::Optimization).
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum BinaryOp {
     Multiplication,

--- a/src/types/domain.rs
+++ b/src/types/domain.rs
@@ -203,7 +203,7 @@ impl Domain {
 
     /// Returns the optional function definitions.
     /// ## Requirements
-    /// Requires [Fluents](Requirement::Fluents).
+    /// Requires [Fluents](crate::Requirement::Fluents).
     pub const fn functions(&self) -> &Functions {
         &self.functions
     }

--- a/src/types/gd.rs
+++ b/src/types/gd.rs
@@ -6,7 +6,7 @@ use crate::types::{AtomicFormula, FComp, Term, TypedVariables};
 /// A goal definition.
 ///
 /// ## Usage
-/// Used by [`GD`] itself, as well as [`PreferenceGD`](crate::PreferenceGD), [`CEffect`](crate::CEffect),
+/// Used by [`GoalDefinition`] itself, as well as [`PreferenceGD`](crate::PreferenceGD), [`CEffect`](crate::CEffect),
 /// [`TimedGD`](crate::TimedGD), [`DerivedPredicate`](crate::DerivedPredicate) and
 /// [`Con2GD`](crate::Con2GD).
 #[derive(Debug, Clone, PartialEq)]

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,5 +1,4 @@
 //! Type definitions.
-
 mod action_definition;
 mod action_symbols;
 pub(crate) mod assign_op;

--- a/src/types/name.rs
+++ b/src/types/name.rs
@@ -55,7 +55,7 @@ impl Name {
         }
     }
 
-    /// Like [`new`] but makes use of the fact that if the string provided
+    /// Like [`Self::new`] but makes use of the fact that if the string provided
     /// is `'static`, the method can be `const`.
     ///
     /// ## Interning

--- a/src/types/number.rs
+++ b/src/types/number.rs
@@ -54,7 +54,7 @@ impl Number {
     /// * `value` - A finite value to construct the instance from.
     ///
     /// ## Returns
-    /// A new [`Number`] instance if successful or [`NumberError::NotFinite`] if the
+    /// A new [`Number`] instance if successful or an error if the
     /// input was not a finite number.
     pub fn try_new(value: UnderlyingType) -> Result<Self, NumberError> {
         if !value.is_finite() {

--- a/src/types/problem_constraints_def.rs
+++ b/src/types/problem_constraints_def.rs
@@ -3,7 +3,7 @@
 use crate::PrefConGDs;
 use std::ops::Deref;
 
-/// A problem constraints definition; wraps a [`PrefConGD`].
+/// A problem constraints definition; wraps a [`PrefConGDs`].
 ///
 /// ## Requirements
 /// Requires [Constraints](crate::Requirement::Constraints).


### PR DESCRIPTION
## Summary

- Fix all rustdoc broken intra-doc links and warnings (9→0 warnings)
- Move type system guide from `types` module to crate-level docs for better discoverability
- Update Taskfile `doc` tasks to use `--all-features`

## Before

Docs build produced warnings like:
- `unresolved link to crate::Fexp` (wrong casing)
- `unresolved link to Requirement::Fluents` (missing `crate::` prefix)
- `unresolved link to GD` (renamed type)
- Links to private items (`NumberError::NotFinite`, `parse_con2_gd`)
- Link to non-existent `parse_binary_op`
- Unclosed HTML tag `<type>`

## After

`cargo doc --no-deps` and `cargo doc --all-features --no-deps` both build with zero warnings.

## Outcome

Clean docs build locally and on docs.rs (`all-features = true` was already set in `Cargo.toml`).

## Review Instructions

- Spot-check a few of the fixed doc links render correctly in `cargo doc --all-features --open`
- Verify the type system guide in crate-level docs is readable