### PR TITLE
Rename abbreviated type names to full descriptive names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **pddl-rs** (2375 symbols, 4690 relationships, 116 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **pddl-rs** (2428 symbols, 4816 relationships, 116 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **pddl-rs** (2284 symbols, 4535 relationships, 114 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **pddl-rs** (2375 symbols, 4690 relationships, 116 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **pddl-rs** (2375 symbols, 4690 relationships, 116 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **pddl-rs** (2428 symbols, 4816 relationships, 116 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **pddl-rs** (2284 symbols, 4535 relationships, 114 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **pddl-rs** (2375 symbols, 4690 relationships, 116 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pddl"
-version = "0.1.0"
+version = "0.2.0"
 description = "A PDDL 3.1 parser, strongly typed"
 license = "EUPL-1.2"
 documentation = "https://docs.rs/pddl"

--- a/Taskfile.dist.yaml
+++ b/Taskfile.dist.yaml
@@ -165,3 +165,23 @@ tasks:
     desc: Remove Cargo build artifacts
     cmds:
       - "{{.CARGO}} clean"
+
+  coverage:
+    desc: Generate code coverage report (HTML)
+    cmds:
+      - cargo llvm-cov nextest --all-features --workspace --html
+
+  coverage:text:
+    desc: Generate code coverage report (text)
+    cmds:
+      - cargo llvm-cov nextest --all-features --workspace
+
+  coverage:lcov:
+    desc: Generate LCOV coverage file for upload
+    cmds:
+      - cargo llvm-cov nextest --all-features --workspace --lcov --output-path lcov.info
+
+  coverage:lib:
+    desc: Generate code coverage for lib tests only
+    cmds:
+      - cargo llvm-cov nextest --all-features --workspace --lib

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,7 @@
 //! | `<con2-GD>` | [`Con2GD`] | Inner constraint goal (goal or nested con-GD) |
 //! | `<pref-con-GD>` | [`PrefConGD`] | Preference constraint goals |
 //! | `<c-effect>` | [`CEffect`] | Conditional effect |
-//! | `<p-effect>` | [`PEffect`] | Primitive effect |
+//! | `<p-effect>` | [`PrimitiveEffect`] | Primitive effect |
 //! | `<effect>` | [`Effects`] | Collection of effects (the `(and ...)` block) |
 //! | `<da-effect>` | [`DurativeActionEffect`] | Durative action effect |
 //! | `<f-exp>` | [`FExp`] | Fluent/numeric expression |
@@ -207,18 +207,18 @@
 //! ```text
 //! Effects (Vec<CEffect>)        ← the (and ...) block
 //! └── CEffect                   ← one effect element
-//!       ├── Effect(PEffect)     ← primitive effect
+//!       ├── Effect(PrimitiveEffect)     ← primitive effect
 //!       ├── Forall(ForallCEffect)  ← universal quantification over effects
 //!       └── When(WhenCEffect)   ← conditional effect (when <cond> <effect>)
 //!             └── ConditionalEffect
-//!                   ├── PEffect ← primitive effect (same as above)
+//!                   ├── PrimitiveEffect ← primitive effect (same as above)
 //!                   ├── Forall...
 //!                   └── When...
 //! ```
 //!
-//! - [`PEffect`] (`<p-effect>`) — A primitive effect: setting/negating an atomic formula,
+//! - [`PrimitiveEffect`] (`<p-effect>`) — A primitive effect: setting/negating an atomic formula,
 //!   or assigning a numeric/object fluent.
-//! - [`CEffect`] (`<c-effect>`) — A potentially conditional effect. Wraps [`PEffect`],
+//! - [`CEffect`] (`<c-effect>`) — A potentially conditional effect. Wraps [`PrimitiveEffect`],
 //!   [`ForallCEffect`], or [`WhenCEffect`].
 //! - [`Effects`] (`<effect>`) — A collection of [`CEffect`] values, representing the
 //!   `(and ...)` block in PDDL.
@@ -256,7 +256,7 @@
 //! | Confused Pair | Difference |
 //! |---------------|------------|
 //! | [`AtomicFormulaSkeleton`] vs [`AtomicFormula`] | Skeleton declares a predicate's signature (used in `:predicates`); Formula applies it to concrete terms (used in goals/init). |
-//! | [`PEffect`] vs [`CEffect`] vs [`Effects`] | `PEffect` is a single primitive effect; `CEffect` may add conditions/quantifiers; `Effects` is the `(and ...)` collection. |
+//! | [`PrimitiveEffect`] vs [`CEffect`] vs [`Effects`] | `PrimitiveEffect` is a single primitive effect; `CEffect` may add conditions/quantifiers; `Effects` is the `(and ...)` collection. |
 //! | [`GoalDefinition`] vs [`PreconditionGoalDefinition`] | `GoalDefinition` is the full logical formula; `PreconditionGoalDefinition` is a simplified wrapper used only in action preconditions. |
 //! | [`GoalDefinition`] vs [`DurativeActionGoalDefinition`] | `GoalDefinition` is timeless; `DurativeActionGoalDefinition` uses [`TimedGD`] for time-qualified goals `(at start ...)`. |
 //! | [`ConGD`] vs [`GoalDefinition`] | `ConGD` is for problem-level temporal constraints (`always`, `sometime`); `GoalDefinition` is the standard logical formula. |
@@ -280,8 +280,8 @@
 //!       (clear ?x)                ← GoalDefinition::AtomicFormula
 //!       (handempty))              ← GoalDefinition::AtomicFormula
 //!     :effect (and                ← Effects
-//!       (not (clear ?x))          ← CEffect::Effect(PEffect::NotAtomicFormula)
-//!       (holding ?x)))            ← CEffect::Effect(PEffect::AtomicFormula)
+//!       (not (clear ?x))          ← CEffect::Effect(PrimitiveEffect::NotAtomicFormula)
+//!       (holding ?x)))            ← CEffect::Effect(PrimitiveEffect::AtomicFormula)
 //!
 //!   (:goal (and                   ← GoalDef → PreconditionGoalDefinitions
 //!     (on a b)                    ← GoalDefinition::AtomicFormula

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,8 +281,8 @@
 //!       (clear ?x)                ← GoalDefinition::AtomicFormula
 //!       (handempty))              ← GoalDefinition::AtomicFormula
 //!     :effect (and                ← Effects
-//!       (not (clear ?x))          ← ConditionalEffect::PrimitiveEffect(PrimitiveEffect::NotAtomicFormula)
-//!       (holding ?x)))            ← ConditionalEffect::PrimitiveEffect(PrimitiveEffect::AtomicFormula)
+//!       (not (clear ?x))          ← ConditionalEffect::Effect(PrimitiveEffect::NotAtomicFormula)
+//!       (holding ?x)))            ← ConditionalEffect::Effect(PrimitiveEffect::AtomicFormula)
 //!
 //!   (:goal (and                   ← ProblemGoalDefinition → PreconditionGoalDefinitions
 //!     (on a b)                    ← GoalDefinition::AtomicFormula

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,8 +117,8 @@
 //!
 //! **Every type name maps directly to a BNF non-terminal from the PDDL 3.1 spec.**
 //!
-//! For example, the BNF rule `<c-effect>` becomes [`CEffect`], `<da-gd>` becomes
-//! [`DurativeActionGoalDefinition`], and `<con-GD>` becomes [`ConGD`]. This 1:1 mapping
+//! For example, the BNF rule `<c-effect>` becomes [`ConditionalEffect`], `<da-gd>` becomes
+//! [`DurativeActionGoalDefinition`], and `<con-GD>` becomes [`ConstraintGoalDefinition`]. This 1:1 mapping
 //! makes it trivial to cross-reference the spec while reading or writing code.
 //!
 //! ### BNF Naming Convention
@@ -133,16 +133,17 @@
 //! | `<pre-GD>` | [`PreconditionGoalDefinition`] | Precondition-specific wrapper |
 //! | `<precondition>` | [`PreconditionGoalDefinitions`] | Collection of preconditions |
 //! | `<da-gd>` | [`DurativeActionGoalDefinition`] | Durative action goals (timed) |
-//! | `<con-GD>` | [`ConGD`] | Constraint goals (temporal constraints) |
-//! | `<con2-GD>` | [`Con2GD`] | Inner constraint goal (goal or nested con-GD) |
-//! | `<pref-con-GD>` | [`PrefConGD`] | Preference constraint goals |
-//! | `<c-effect>` | [`CEffect`] | Conditional effect |
+//! | `<con-GD>` | [`ConstraintGoalDefinition`] | Constraint goals (temporal constraints) |
+//! | `<con2-GD>` | [`ConstraintGoalDefinitionInner`] | Inner constraint goal (goal or nested con-GD) |
+//! | `<pref-con-GD>` | [`PreferenceConstraintGoalDefinition`] | Preference constraint goals |
+//! | `<pref-GD>` | [`PreferenceGoalDefinition`] | Preferred goal (goal or named preference) |
+//! | `<c-effect>` | [`ConditionalEffect`] | Conditional effect |
 //! | `<p-effect>` | [`PrimitiveEffect`] | Primitive effect |
 //! | `<effect>` | [`Effects`] | Collection of effects (the `(and ...)` block) |
 //! | `<da-effect>` | [`DurativeActionEffect`] | Durative action effect |
-//! | `<f-exp>` | [`FExp`] | Fluent/numeric expression |
-//! | `<f-comp>` | [`FComp`] | Fluent comparison |
-//! | `<f-head>` | [`FHead`] | Fluent head (function reference) |
+//! | `<f-exp>` | [`FluentExpression`] | Fluent/numeric expression |
+//! | `<f-comp>` | [`FluentComparison`] | Fluent comparison |
+//! | `<f-head>` | [`FunctionHead`] | Fluent head (function reference) |
 //! | `<atomic formula (skeleton)>` | [`AtomicFormulaSkeleton`] | Predicate declaration with typed variables |
 //!
 //! When you see a type with an abbreviated name, look for the corresponding BNF rule
@@ -176,28 +177,28 @@
 //!   Used in action preconditions, goal definitions, and effect conditions.
 //!
 //! - [`PreconditionGoalDefinition`] (`<pre-GD>`) — A simplified variant used specifically
-//!   for action preconditions. Contains either a [`PreferenceGD`] or a `forall` quantifier.
+//!   for action preconditions. Contains either a [`PreferenceGoalDefinition`] or a `forall` quantifier.
 //!   Multiple are collected in [`PreconditionGoalDefinitions`].
 //!
-//! - [`GoalDef`] — A thin wrapper around [`PreconditionGoalDefinitions`] used by
+//! - [`ProblemGoalDefinition`] (`<goal>` in problem context) — A thin wrapper around [`PreconditionGoalDefinitions`] used by
 //!   [`Problem`] for the `(:goal ...)` section.
 //!
 //! - [`DurativeActionGoalDefinition`] (`<da-gd>`) — Goals for durative actions. Uses
-//!   [`TimedGD`] (time-qualified goals like `(at start (on a b))`) instead of plain
+//!   [`TimedGoalDefinition`] (time-qualified goals like `(at start (on a b))`) instead of plain
 //!   [`GoalDefinition`].
 //!
-//! - [`ConGD`] (`<con-GD>`) — Temporal constraint goals for problem-level constraints.
+//! - [`ConstraintGoalDefinition`] (`<con-GD>`) — Temporal constraint goals for problem-level constraints.
 //!   Supports `always`, `sometime`, `within`, `at-most-once`, `sometime-after`,
 //!   `sometime-before`, `always-within`, `hold-during`, `hold-after`. Used by
 //!   [`ProblemConstraintsDef`].
 //!
-//! - [`Con2GD`] (`<con2-GD>`) — An inner component of [`ConGD`], representing either
-//!   a plain [`GoalDefinition`] or a nested [`ConGD`].
+//! - [`ConstraintGoalDefinitionInner`] (`<con2-GD>`) — An inner component of [`ConstraintGoalDefinition`], representing either
+//!   a plain [`GoalDefinition`] or a nested [`ConstraintGoalDefinition`].
 //!
-//! - [`PrefConGD`] (`<pref-con-GD>`) — Constraint goals with optional preference names.
+//! - [`PreferenceConstraintGoalDefinition`] (`<pref-con-GD>`) — Constraint goals with optional preference names.
 //!   Used in [`ProblemConstraintsDef`].
 //!
-//! - [`PreferenceGD`] — Either a plain [`GoalDefinition`] or a named [`Preference`].
+//! - [`PreferenceGoalDefinition`] — Either a plain [`GoalDefinition`] or a named [`Preference`].
 //!   Used in [`PreconditionGoalDefinition`].
 //!
 //! #### Effects
@@ -205,22 +206,22 @@
 //! The effects hierarchy mirrors the BNF structure:
 //!
 //! ```text
-//! Effects (Vec<CEffect>)        ← the (and ...) block
-//! └── CEffect                   ← one effect element
-//!       ├── Effect(PrimitiveEffect)     ← primitive effect
-//!       ├── Forall(ForallCEffect)  ← universal quantification over effects
-//!       └── When(WhenCEffect)   ← conditional effect (when <cond> <effect>)
-//!             └── ConditionalEffect
-//!                   ├── PrimitiveEffect ← primitive effect (same as above)
+//! Effects (Vec<ConditionalEffect>)        ← the (and ...) block
+//! └── ConditionalEffect                   ← one effect element
+//!       ├── PrimitiveEffect               ← primitive effect
+//!       ├── Forall(ForallConditionalEffect)  ← universal quantification over effects
+//!       └── When(WhenConditionalEffect)   ← conditional effect (when <cond> <effect>)
+//!             └── EffectCondition
+//!                   ├── PrimitiveEffect   ← primitive effect (same as above)
 //!                   ├── Forall...
 //!                   └── When...
 //! ```
 //!
 //! - [`PrimitiveEffect`] (`<p-effect>`) — A primitive effect: setting/negating an atomic formula,
 //!   or assigning a numeric/object fluent.
-//! - [`CEffect`] (`<c-effect>`) — A potentially conditional effect. Wraps [`PrimitiveEffect`],
-//!   [`ForallCEffect`], or [`WhenCEffect`].
-//! - [`Effects`] (`<effect>`) — A collection of [`CEffect`] values, representing the
+//! - [`ConditionalEffect`] (`<c-effect>`) — A potentially conditional effect. Wraps [`PrimitiveEffect`],
+//!   [`ForallConditionalEffect`], or [`WhenConditionalEffect`].
+//! - [`Effects`] (`<effect>`) — A collection of [`ConditionalEffect`] values, representing the
 //!   `(and ...)` block in PDDL.
 //! - [`DurativeActionEffect`] (`<da-effect>`) — Effects for durative actions, using
 //!   [`TimedEffect`] (time-qualified effects like `(at end (on a b))`).
@@ -229,16 +230,16 @@
 //!
 //! Types for numeric reasoning in PDDL:
 //!
-//! - [`FExp`] (`<f-exp>`) — A fluent expression: a number, function call, negation,
+//! - [`FluentExpression`] (`<f-exp>`) — A fluent expression: a number, function call, negation,
 //!   binary operation (`+`, `-`, `*`, `/`), or multi-operand operation.
-//! - [`FHead`] (`<f-head>`) — A function head: either a bare function symbol or a
+//! - [`FunctionHead`] (`<f-head>`) — A function head: either a bare function symbol or a
 //!   [`FunctionTerm`] (function applied to arguments).
-//! - [`FComp`] (`<f-comp>`) — A fluent comparison: `<`, `<=`, `>`, `>=`, `=` applied
-//!   to two [`FExp`] values.
-//! - [`FExpT`] (`<f-exp-t>`) — Time-qualified fluent expression (for durative actions).
-//! - [`FExpDa`] (`<f-exp-da>`) — Durative-action-specific fluent expression.
-//! - [`FHead`] variants: [`BasicFunctionTerm`], [`FunctionTerm`].
-//! - [`AssignOp`] / [`AssignOpT`] — Assignment operators (`assign`, `scale-up`, etc.).
+//! - [`FluentComparison`] (`<f-comp>`) — A fluent comparison: `<`, `<=`, `>`, `>=`, `=` applied
+//!   to two [`FluentExpression`] values.
+//! - [`TimedFluentExpression`] (`<f-exp-t>`) — Time-qualified fluent expression (for durative actions).
+//! - [`DurativeActionFluentExpression`] (`<f-exp-da>`) — Durative-action-specific fluent expression.
+//! - [`FunctionHead`] variants: [`BasicFunctionTerm`], [`FunctionTerm`].
+//! - [`AssignOp`] / [`TimedAssignOperator`] — Assignment operators (`assign`, `scale-up`, etc.).
 //!
 //! #### Terms
 //!
@@ -256,14 +257,14 @@
 //! | Confused Pair | Difference |
 //! |---------------|------------|
 //! | [`AtomicFormulaSkeleton`] vs [`AtomicFormula`] | Skeleton declares a predicate's signature (used in `:predicates`); Formula applies it to concrete terms (used in goals/init). |
-//! | [`PrimitiveEffect`] vs [`CEffect`] vs [`Effects`] | `PrimitiveEffect` is a single primitive effect; `CEffect` may add conditions/quantifiers; `Effects` is the `(and ...)` collection. |
+//! | [`PrimitiveEffect`] vs [`ConditionalEffect`] vs [`Effects`] | `PrimitiveEffect` is a single primitive effect; `ConditionalEffect` may add conditions/quantifiers; `Effects` is the `(and ...)` collection. |
 //! | [`GoalDefinition`] vs [`PreconditionGoalDefinition`] | `GoalDefinition` is the full logical formula; `PreconditionGoalDefinition` is a simplified wrapper used only in action preconditions. |
-//! | [`GoalDefinition`] vs [`DurativeActionGoalDefinition`] | `GoalDefinition` is timeless; `DurativeActionGoalDefinition` uses [`TimedGD`] for time-qualified goals `(at start ...)`. |
-//! | [`ConGD`] vs [`GoalDefinition`] | `ConGD` is for problem-level temporal constraints (`always`, `sometime`); `GoalDefinition` is the standard logical formula. |
-//! | [`GoalDef`] vs [`GoalDefinition`] | `GoalDef` wraps [`PreconditionGoalDefinitions`] for the problem's `(:goal ...)`; `GoalDefinition` is the individual formula. |
-//! | [`PreferenceGD`] vs [`PrefConGD`] | `PreferenceGD` is for action-level preferences; `PrefConGD` is for problem-level constraint preferences. |
-//! | [`Effects`] vs [`ConditionalEffect`] | `Effects` is a flat collection of [`CEffect`]; `ConditionalEffect` is recursive (used inside `when` clauses). |
-//! | [`FExp`] vs [`FHead`] | `FExp` is any numeric expression; `FHead` is specifically a function reference (with or without args). |
+//! | [`GoalDefinition`] vs [`DurativeActionGoalDefinition`] | `GoalDefinition` is timeless; `DurativeActionGoalDefinition` uses [`TimedGoalDefinition`] for time-qualified goals `(at start ...)`. |
+//! | [`ConstraintGoalDefinition`] vs [`GoalDefinition`] | `ConstraintGoalDefinition` is for problem-level temporal constraints (`always`, `sometime`); `GoalDefinition` is the standard logical formula. |
+//! | [`ProblemGoalDefinition`] vs [`GoalDefinition`] | `ProblemGoalDefinition` wraps [`PreconditionGoalDefinitions`] for the problem's `(:goal ...)`; `GoalDefinition` is the individual formula. |
+//! | [`PreferenceGoalDefinition`] vs [`PreferenceConstraintGoalDefinition`] | `PreferenceGoalDefinition` is for action-level preferences; `PreferenceConstraintGoalDefinition` is for problem-level constraint preferences. |
+//! | [`Effects`] vs [`ConditionalEffect`] vs [`EffectCondition`] | `Effects` is the top-level `(and ...)` collection of [`ConditionalEffect`]s (action `:effect` body); `ConditionalEffect` is one element that may be primitive, `forall`-quantified, or `when`-conditional; `EffectCondition` is the recursive `ConditionalEffect` tree nested inside `when` clauses. |
+//! | [`FluentExpression`] vs [`FunctionHead`] | `FluentExpression` is any numeric expression; `FunctionHead` is specifically a function reference (with or without args). |
 //! | [`Literal<T>`] vs [`AtomicFormula<T>`] | `Literal` can be negated; `AtomicFormula` is always positive. |
 //!
 //! ### PDDL Snippet → Rust Type Mapping
@@ -280,10 +281,10 @@
 //!       (clear ?x)                ← GoalDefinition::AtomicFormula
 //!       (handempty))              ← GoalDefinition::AtomicFormula
 //!     :effect (and                ← Effects
-//!       (not (clear ?x))          ← CEffect::Effect(PrimitiveEffect::NotAtomicFormula)
-//!       (holding ?x)))            ← CEffect::Effect(PrimitiveEffect::AtomicFormula)
+//!       (not (clear ?x))          ← ConditionalEffect::PrimitiveEffect(PrimitiveEffect::NotAtomicFormula)
+//!       (holding ?x)))            ← ConditionalEffect::PrimitiveEffect(PrimitiveEffect::AtomicFormula)
 //!
-//!   (:goal (and                   ← GoalDef → PreconditionGoalDefinitions
+//!   (:goal (and                   ← ProblemGoalDefinition → PreconditionGoalDefinitions
 //!     (on a b)                    ← GoalDefinition::AtomicFormula
 //!     (on b c)))                  ← GoalDefinition::AtomicFormula
 //! )
@@ -291,9 +292,9 @@
 //! ;; PDDL problem initial state
 //! (define (problem bw-1)
 //!   (:init
-//!     (on a b)                    ← InitElement::AtomicFormula (Literal<Name>)
-//!     (clear a)                   ← InitElement::AtomicFormula
-//!     (= (total-cost) 0))         ← InitElement::FAssign (numeric fluent)
+//!     (on a b)                    ← InitElement::Literal (Literal<Name>)
+//!     (clear a)                   ← InitElement::Literal
+//!     (= (total-cost) 0))         ← InitElement::IsValue (numeric fluent)
 //! )
 //! ```
 //!

--- a/src/parsers/action_def.rs
+++ b/src/parsers/action_def.rs
@@ -14,7 +14,7 @@ use crate::types::ActionDefinition;
 ///
 /// ## Example
 /// ```
-/// # use pddl::{ActionDefinition, ActionSymbol, AtomicFormula, ConditionalEffect, Effects, GoalDefinition, Name, PrimitiveEffect, Predicate, PreferenceGD, PreconditionGoalDefinitions, PreconditionGoalDefinition, Term, ToTyped, TypedList, Variable};
+/// # use pddl::{ActionDefinition, ActionSymbol, AtomicFormula, ConditionalEffect, Effects, GoalDefinition, Name, PrimitiveEffect, Predicate, PreferenceGoalDefinition, PreconditionGoalDefinitions, PreconditionGoalDefinition, Term, ToTyped, TypedList, Variable};
 /// # use pddl::parsers::{parse_action_def, Span, UnwrapValue};
 /// let input = r#"(:action take-out
 ///                     :parameters (?x - physob)
@@ -31,7 +31,7 @@ use crate::types::ActionDefinition;
 ///             Variable::new_string("x").to_typed("physob")
 ///         ]),
 ///         PreconditionGoalDefinitions::from(
-///             PreconditionGoalDefinition::Preference(PreferenceGD::from_gd(
+///             PreconditionGoalDefinition::Preference(PreferenceGoalDefinition::from_gd(
 ///                 GoalDefinition::new_not(
 ///                     GoalDefinition::AtomicFormula(
 ///                         AtomicFormula::new_equality(
@@ -94,7 +94,7 @@ impl crate::parsers::Parser for ActionDefinition {
     ///
     /// ## Example
     /// ```
-    /// # use pddl::{ActionDefinition, ActionSymbol, AtomicFormula, ConditionalEffect, Effects, GoalDefinition, Name, PrimitiveEffect, Predicate, PreferenceGD, PreconditionGoalDefinitions, PreconditionGoalDefinition, Term, ToTyped, TypedList, Variable, Parser};
+    /// # use pddl::{ActionDefinition, ActionSymbol, AtomicFormula, ConditionalEffect, Effects, GoalDefinition, Name, PrimitiveEffect, Predicate, PreferenceGoalDefinition, PreconditionGoalDefinitions, PreconditionGoalDefinition, Term, ToTyped, TypedList, Variable, Parser};
     /// # use pddl::parsers::{parse_action_def, Span, UnwrapValue};
     /// let input = r#"(:action take-out
     ///                     :parameters (?x - physob)

--- a/src/parsers/action_def.rs
+++ b/src/parsers/action_def.rs
@@ -14,7 +14,7 @@ use crate::types::ActionDefinition;
 ///
 /// ## Example
 /// ```
-/// # use pddl::{ActionDefinition, ActionSymbol, AtomicFormula, CEffect, Effects, GoalDefinition, Name, PEffect, Predicate, PreferenceGD, PreconditionGoalDefinitions, PreconditionGoalDefinition, Term, ToTyped, TypedList, Variable};
+/// # use pddl::{ActionDefinition, ActionSymbol, AtomicFormula, ConditionalEffect, Effects, GoalDefinition, Name, PrimitiveEffect, Predicate, PreferenceGD, PreconditionGoalDefinitions, PreconditionGoalDefinition, Term, ToTyped, TypedList, Variable};
 /// # use pddl::parsers::{parse_action_def, Span, UnwrapValue};
 /// let input = r#"(:action take-out
 ///                     :parameters (?x - physob)
@@ -42,8 +42,8 @@ use crate::types::ActionDefinition;
 ///                 )
 ///             )
 ///         )),
-///         Some(Effects::new(CEffect::new_p_effect(
-///             PEffect::NotAtomicFormula(
+///         Some(Effects::new(ConditionalEffect::new_primitive_effect(
+///             PrimitiveEffect::NotAtomicFormula(
 ///                 AtomicFormula::new_predicate(
 ///                     Predicate::new_string("in"),
 ///                     vec![Term::Variable(Variable::new_string("x"))]
@@ -94,7 +94,7 @@ impl crate::parsers::Parser for ActionDefinition {
     ///
     /// ## Example
     /// ```
-    /// # use pddl::{ActionDefinition, ActionSymbol, AtomicFormula, CEffect, Effects, GoalDefinition, Name, PEffect, Predicate, PreferenceGD, PreconditionGoalDefinitions, PreconditionGoalDefinition, Term, ToTyped, TypedList, Variable, Parser};
+    /// # use pddl::{ActionDefinition, ActionSymbol, AtomicFormula, ConditionalEffect, Effects, GoalDefinition, Name, PrimitiveEffect, Predicate, PreferenceGD, PreconditionGoalDefinitions, PreconditionGoalDefinition, Term, ToTyped, TypedList, Variable, Parser};
     /// # use pddl::parsers::{parse_action_def, Span, UnwrapValue};
     /// let input = r#"(:action take-out
     ///                     :parameters (?x - physob)

--- a/src/parsers/action_def.rs
+++ b/src/parsers/action_def.rs
@@ -26,7 +26,7 @@ use crate::types::ActionDefinition;
 ///
 /// assert!(action.is_value(
 ///     ActionDefinition::new(
-///         ActionSymbol::new_string("take-out"),
+///         ActionSymbol::string("take-out"),
 ///         TypedList::from_iter([
 ///             Variable::new_string("x").to_typed("physob")
 ///         ]),
@@ -106,7 +106,7 @@ impl crate::parsers::Parser for ActionDefinition {
     ///
     /// assert_eq!(action,
     ///     ActionDefinition::new(
-    ///         ActionSymbol::new_string("take-out"),
+    ///         ActionSymbol::string("take-out"),
     ///         TypedList::from_iter([
     ///             Variable::new_string("x").to_typed("physob")
     ///         ]),
@@ -143,7 +143,7 @@ mod tests {
         assert_eq!(
             action,
             ActionDefinition::new(
-                ActionSymbol::new_string("take-out"),
+                ActionSymbol::string("take-out"),
                 TypedList::from_iter([Variable::new_string("x").to_typed("physob")]),
                 PreconditionGoalDefinitions::from_str("(not (= ?x B))").unwrap(),
                 Some(Effects::from_str("(not (in ?x))").unwrap())

--- a/src/parsers/assign_op_t.rs
+++ b/src/parsers/assign_op_t.rs
@@ -7,35 +7,35 @@ use nom::Parser;
 
 use crate::parsers::{ParseResult, Span};
 use crate::types::assign_op_t::names;
-use crate::types::AssignOpT;
+use crate::types::TimedAssignOperator;
 
 /// Parses an assignment operation, i.e. `increase | decrease`.
 ///
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_assign_op_t, Span, UnwrapValue};
-/// # use pddl::{AssignOpT};
-/// assert!(parse_assign_op_t(Span::new("increase")).is_value(AssignOpT::Increase));
-/// assert!(parse_assign_op_t(Span::new("decrease")).is_value(AssignOpT::Decrease));
+/// # use pddl::{TimedAssignOperator};
+/// assert!(parse_assign_op_t(Span::new("increase")).is_value(TimedAssignOperator::Increase));
+/// assert!(parse_assign_op_t(Span::new("decrease")).is_value(TimedAssignOperator::Decrease));
 ///```
-pub fn parse_assign_op_t<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, AssignOpT> {
+pub fn parse_assign_op_t<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, TimedAssignOperator> {
     map(
         alt((tag(names::INCREASE), tag(names::DECREASE))),
-        |x: Span| AssignOpT::try_from(*x.fragment()).expect("unhandled variant"),
+        |x: Span| TimedAssignOperator::try_from(*x.fragment()).expect("unhandled variant"),
     )
     .parse(input.into())
 }
 
-impl crate::parsers::Parser for AssignOpT {
-    type Item = AssignOpT;
+impl crate::parsers::Parser for TimedAssignOperator {
+    type Item = TimedAssignOperator;
 
     /// Parses an assignment operation.
     ///
     /// ## Example
     /// ```
-    /// # use pddl::{AssignOpT, Parser};
-    /// let (_, value) = AssignOpT::parse("increase").unwrap();
-    /// assert_eq!(value, AssignOpT::Increase);
+    /// # use pddl::{TimedAssignOperator, Parser};
+    /// let (_, value) = TimedAssignOperator::parse("increase").unwrap();
+    /// assert_eq!(value, TimedAssignOperator::Increase);
     ///```
     ///
     /// ## See also
@@ -47,11 +47,11 @@ impl crate::parsers::Parser for AssignOpT {
 
 #[cfg(test)]
 mod tests {
-    use crate::{AssignOpT, Parser};
+    use crate::{Parser, TimedAssignOperator};
 
     #[test]
     fn test_parse() {
-        let (_, value) = AssignOpT::parse("increase").unwrap();
-        assert_eq!(value, AssignOpT::Increase);
+        let (_, value) = TimedAssignOperator::parse("increase").unwrap();
+        assert_eq!(value, TimedAssignOperator::Increase);
     }
 }

--- a/src/parsers/binary_comp.rs
+++ b/src/parsers/binary_comp.rs
@@ -6,21 +6,21 @@ use nom::combinator::map;
 use nom::Parser;
 
 use crate::parsers::{ParseResult, Span};
-use crate::types::{binary_comp::names, BinaryComp};
+use crate::types::{binary_comp::names, BinaryComparison};
 
 /// Parses a binary comparison operation.
 ///
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_binary_comp, Span, UnwrapValue};
-/// # use pddl::{AssignOp, BinaryComp};
-/// assert!(parse_binary_comp(Span::new(">")).is_value(BinaryComp::GreaterThan));
-/// assert!(parse_binary_comp(Span::new("<")).is_value(BinaryComp::LessThan));
-/// assert!(parse_binary_comp(Span::new("=")).is_value(BinaryComp::Equal));
-/// assert!(parse_binary_comp(Span::new(">=")).is_value(BinaryComp::GreaterOrEqual));
-/// assert!(parse_binary_comp(Span::new("<=")).is_value(BinaryComp::LessThanOrEqual));
+/// # use pddl::{AssignOp, BinaryComparison};
+/// assert!(parse_binary_comp(Span::new(">")).is_value(BinaryComparison::GreaterThan));
+/// assert!(parse_binary_comp(Span::new("<")).is_value(BinaryComparison::LessThan));
+/// assert!(parse_binary_comp(Span::new("=")).is_value(BinaryComparison::Equal));
+/// assert!(parse_binary_comp(Span::new(">=")).is_value(BinaryComparison::GreaterOrEqual));
+/// assert!(parse_binary_comp(Span::new("<=")).is_value(BinaryComparison::LessThanOrEqual));
 ///```
-pub fn parse_binary_comp<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, BinaryComp> {
+pub fn parse_binary_comp<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, BinaryComparison> {
     map(
         alt((
             tag(names::GREATER_THAN_OR_EQUAL),
@@ -29,21 +29,21 @@ pub fn parse_binary_comp<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Bin
             tag(names::GREATER_THAN),
             tag(names::LESS_THAN),
         )),
-        |x: Span| BinaryComp::try_from(*x.fragment()).expect("unhandled variant"),
+        |x: Span| BinaryComparison::try_from(*x.fragment()).expect("unhandled variant"),
     )
     .parse(input.into())
 }
 
-impl crate::parsers::Parser for BinaryComp {
-    type Item = BinaryComp;
+impl crate::parsers::Parser for BinaryComparison {
+    type Item = BinaryComparison;
 
     /// Parses a binary comparison operation.
     ///
     /// ## Example
     /// ```
-    /// # use pddl::{BinaryComp, Parser};
-    /// let (_, value) = BinaryComp::parse(">=").unwrap();
-    /// assert_eq!(value, BinaryComp::GreaterOrEqual);
+    /// # use pddl::{BinaryComparison, Parser};
+    /// let (_, value) = BinaryComparison::parse(">=").unwrap();
+    /// assert_eq!(value, BinaryComparison::GreaterOrEqual);
     ///```
     ///
     /// ## See also
@@ -55,23 +55,23 @@ impl crate::parsers::Parser for BinaryComp {
 
 #[cfg(test)]
 mod tests {
-    use crate::{BinaryComp, Parser};
+    use crate::{BinaryComparison, Parser};
 
     #[test]
     fn test_parse() {
-        let (_, value) = BinaryComp::parse(">=").unwrap();
-        assert_eq!(value, BinaryComp::GreaterOrEqual);
+        let (_, value) = BinaryComparison::parse(">=").unwrap();
+        assert_eq!(value, BinaryComparison::GreaterOrEqual);
 
-        let (_, value) = BinaryComp::parse(">").unwrap();
-        assert_eq!(value, BinaryComp::GreaterThan);
+        let (_, value) = BinaryComparison::parse(">").unwrap();
+        assert_eq!(value, BinaryComparison::GreaterThan);
 
-        let (_, value) = BinaryComp::parse("<=").unwrap();
-        assert_eq!(value, BinaryComp::LessThanOrEqual);
+        let (_, value) = BinaryComparison::parse("<=").unwrap();
+        assert_eq!(value, BinaryComparison::LessThanOrEqual);
 
-        let (_, value) = BinaryComp::parse("<").unwrap();
-        assert_eq!(value, BinaryComp::LessThan);
+        let (_, value) = BinaryComparison::parse("<").unwrap();
+        assert_eq!(value, BinaryComparison::LessThan);
 
-        let (_, value) = BinaryComp::parse("=").unwrap();
-        assert_eq!(value, BinaryComp::Equal);
+        let (_, value) = BinaryComparison::parse("=").unwrap();
+        assert_eq!(value, BinaryComparison::Equal);
     }
 }

--- a/src/parsers/c_effect.rs
+++ b/src/parsers/c_effect.rs
@@ -7,7 +7,9 @@ use nom::sequence::preceded;
 use nom::Parser;
 
 use crate::parsers::{parens, prefix_expr, typed_list, ParseResult, Span};
-use crate::parsers::{parse_effect_condition, parse_effect, parse_gd, parse_p_effect, parse_variable};
+use crate::parsers::{
+    parse_effect, parse_effect_condition, parse_gd, parse_p_effect, parse_variable,
+};
 use crate::types::ConditionalEffect;
 use crate::{ForallConditionalEffect, WhenConditionalEffect};
 
@@ -126,7 +128,9 @@ pub fn parse_c_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Condit
 ///     )
 /// ));
 /// ```
-pub fn parse_forall_c_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, ForallConditionalEffect> {
+pub fn parse_forall_c_effect<'a, T: Into<Span<'a>>>(
+    input: T,
+) -> ParseResult<'a, ForallConditionalEffect> {
     map(
         prefix_expr(
             "forall",
@@ -186,9 +190,14 @@ pub fn parse_forall_c_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a,
 /// ));
 /// ```
 #[allow(deprecated)]
-pub fn parse_when_c_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, WhenConditionalEffect> {
+pub fn parse_when_c_effect<'a, T: Into<Span<'a>>>(
+    input: T,
+) -> ParseResult<'a, WhenConditionalEffect> {
     map(
-        prefix_expr("when", (parse_gd, preceded(multispace1, parse_effect_condition))),
+        prefix_expr(
+            "when",
+            (parse_gd, preceded(multispace1, parse_effect_condition)),
+        ),
         WhenConditionalEffect::from,
     )
     .parse(input.into())
@@ -307,8 +316,8 @@ impl crate::parsers::Parser for WhenConditionalEffect {
 #[allow(deprecated)]
 mod tests {
     use crate::{
-        ConditionalEffect, EffectCondition, Effects, ForallConditionalEffect, GoalDefinition, PrimitiveEffect, Parser, Typed,
-        TypedList, Variable, WhenConditionalEffect,
+        ConditionalEffect, EffectCondition, Effects, ForallConditionalEffect, GoalDefinition,
+        Parser, PrimitiveEffect, Typed, TypedList, Variable, WhenConditionalEffect,
     };
 
     #[test]
@@ -322,7 +331,9 @@ mod tests {
         let (_, value) = ConditionalEffect::parse("(not (= ?a B))").unwrap();
         assert_eq!(
             value,
-            ConditionalEffect::new_primitive_effect(PrimitiveEffect::from_str("(not (= ?a B))").unwrap())
+            ConditionalEffect::new_primitive_effect(
+                PrimitiveEffect::from_str("(not (= ?a B))").unwrap()
+            )
         );
 
         let (_, value) = ConditionalEffect::parse("(forall (?a ?b) (= ?a ?b))").unwrap();

--- a/src/parsers/c_effect.rs
+++ b/src/parsers/c_effect.rs
@@ -1,4 +1,4 @@
-//! Provides parsers for c-effects.
+//! Provides parsers for conditional effects.
 
 use nom::branch::alt;
 use nom::character::complete::multispace1;
@@ -7,20 +7,20 @@ use nom::sequence::preceded;
 use nom::Parser;
 
 use crate::parsers::{parens, prefix_expr, typed_list, ParseResult, Span};
-use crate::parsers::{parse_cond_effect, parse_effect, parse_gd, parse_p_effect, parse_variable};
-use crate::types::CEffect;
-use crate::{ForallCEffect, WhenCEffect};
+use crate::parsers::{parse_effect_condition, parse_effect, parse_gd, parse_p_effect, parse_variable};
+use crate::types::ConditionalEffect;
+use crate::{ForallConditionalEffect, WhenConditionalEffect};
 
-/// Parses c-effects.
+/// Parses conditional effects.
 ///
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_c_effect, Span, UnwrapValue};
-/// # use pddl::{AtomicFormula, CEffect, ConditionalEffect, Effects, EqualityAtomicFormula, GoalDefinition, PEffect, Predicate, Term, Variable};
+/// # use pddl::{AtomicFormula, ConditionalEffect, EffectCondition, Effects, EqualityAtomicFormula, GoalDefinition, PrimitiveEffect, Predicate, Term, Variable};
 /// # use pddl::{Typed, TypedList};
 /// assert!(parse_c_effect(Span::new("(= x y)")).is_value(
-///     CEffect::Effect(
-///         PEffect::AtomicFormula(AtomicFormula::Equality(
+///     ConditionalEffect::Effect(
+///         PrimitiveEffect::AtomicFormula(AtomicFormula::Equality(
 ///             EqualityAtomicFormula::new(
 ///                 Term::Name("x".into()),
 ///                 Term::Name("y".into()))
@@ -29,8 +29,8 @@ use crate::{ForallCEffect, WhenCEffect};
 ///     )
 /// ));
 /// assert!(parse_c_effect(Span::new("(not (= ?a B))")).is_value(
-///     CEffect::Effect(
-///         PEffect::NotAtomicFormula(AtomicFormula::Equality(
+///     ConditionalEffect::Effect(
+///         PrimitiveEffect::NotAtomicFormula(AtomicFormula::Equality(
 ///             EqualityAtomicFormula::new(
 ///                 Term::Variable("a".into()),
 ///                 Term::Name("B".into()))
@@ -40,13 +40,13 @@ use crate::{ForallCEffect, WhenCEffect};
 /// ));
 ///
 /// assert!(parse_c_effect(Span::new("(forall (?a ?b) (= ?a ?b))")).is_value(
-///     CEffect::new_forall(
+///     ConditionalEffect::new_forall(
 ///         TypedList::from_iter([
 ///             Typed::new_object(Variable::new_string("a")),
 ///             Typed::new_object(Variable::new_string("b")),
 ///         ]),
-///         Effects::new(CEffect::Effect(
-///             PEffect::AtomicFormula(AtomicFormula::Equality(
+///         Effects::new(ConditionalEffect::Effect(
+///             PrimitiveEffect::AtomicFormula(AtomicFormula::Equality(
 ///                 EqualityAtomicFormula::new(
 ///                     Term::Variable("a".into()),
 ///                     Term::Variable("b".into()))
@@ -60,7 +60,7 @@ use crate::{ForallCEffect, WhenCEffect};
 ///     (and (has-hot-chocolate ?p ?c) (has-marshmallows ?c))
 ///     (and (person-is-happy ?p)))"#;
 /// assert!(parse_c_effect(Span::new(input)).is_value(
-///     CEffect::new_when(
+///     ConditionalEffect::new_when(
 ///         GoalDefinition::new_and([
 ///             GoalDefinition::new_atomic_formula(
 ///                 AtomicFormula::new_predicate(
@@ -80,8 +80,8 @@ use crate::{ForallCEffect, WhenCEffect};
 ///                 )
 ///             ),
 ///         ]),
-///         ConditionalEffect::from_iter([
-///             PEffect::new(
+///         EffectCondition::from_iter([
+///             PrimitiveEffect::new(
 ///                 AtomicFormula::new_predicate(
 ///                     Predicate::new("person-is-happy".into()),
 ///                     [
@@ -93,29 +93,30 @@ use crate::{ForallCEffect, WhenCEffect};
 ///     )
 /// ));
 /// ```
-pub fn parse_c_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, CEffect> {
-    let p_effect = map(parse_p_effect, CEffect::from);
-    let forall = map(parse_forall_c_effect, CEffect::from);
-    let when = map(parse_when_c_effect, CEffect::from);
+#[allow(deprecated)]
+pub fn parse_c_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, ConditionalEffect> {
+    let p_effect = map(parse_p_effect, ConditionalEffect::from);
+    let forall = map(parse_forall_c_effect, ConditionalEffect::from);
+    let when = map(parse_when_c_effect, ConditionalEffect::from);
 
     alt((forall, when, p_effect)).parse(input.into())
 }
 
-/// Parses [`ForallCEffect`] values.
+/// Parses [`ForallConditionalEffect`] values.
 ///
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_forall_c_effect, preamble::*};
-/// # use pddl::{AtomicFormula, CEffect, Effects, EqualityAtomicFormula, ForallCEffect, PEffect, Term, Variable};
+/// # use pddl::{AtomicFormula, ConditionalEffect, Effects, EqualityAtomicFormula, ForallConditionalEffect, PrimitiveEffect, Term, Variable};
 /// # use pddl::{Typed, TypedList};
 /// assert!(parse_forall_c_effect(Span::new("(forall (?a ?b) (= ?a ?b))")).is_value(
-///     ForallCEffect::new(
+///     ForallConditionalEffect::new(
 ///         TypedList::from_iter([
 ///             Typed::new_object(Variable::new_string("a")),
 ///             Typed::new_object(Variable::new_string("b")),
 ///         ]),
-///         Effects::new(CEffect::Effect(
-///             PEffect::AtomicFormula(AtomicFormula::Equality(
+///         Effects::new(ConditionalEffect::Effect(
+///             PrimitiveEffect::AtomicFormula(AtomicFormula::Equality(
 ///                 EqualityAtomicFormula::new(
 ///                     Term::Variable("a".into()),
 ///                     Term::Variable("b".into()))
@@ -125,7 +126,7 @@ pub fn parse_c_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, CEffec
 ///     )
 /// ));
 /// ```
-pub fn parse_forall_c_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, ForallCEffect> {
+pub fn parse_forall_c_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, ForallConditionalEffect> {
     map(
         prefix_expr(
             "forall",
@@ -134,24 +135,24 @@ pub fn parse_forall_c_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a,
                 preceded(multispace1, parse_effect),
             ),
         ),
-        ForallCEffect::from,
+        ForallConditionalEffect::from,
     )
     .parse(input.into())
 }
 
-/// Parses c-effects.
+/// Parses conditional effects.
 ///
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_when_c_effect, preamble::*};
-/// # use pddl::{AtomicFormula, CEffect, ConditionalEffect, Effects, EqualityAtomicFormula, GoalDefinition, PEffect, Predicate, Term, Variable, WhenCEffect};
+/// # use pddl::{AtomicFormula, ConditionalEffect, EffectCondition, Effects, EqualityAtomicFormula, GoalDefinition, PrimitiveEffect, Predicate, Term, Variable, WhenConditionalEffect};
 /// # use pddl::{Typed, TypedList};
 /// let input = r#"(when
 ///     (and (has-hot-chocolate ?p ?c) (has-marshmallows ?c))
 ///     (and (person-is-happy ?p)))"#;
 ///
 /// assert!(parse_when_c_effect(Span::new(input)).is_value(
-///     WhenCEffect::new(
+///     WhenConditionalEffect::new(
 ///         GoalDefinition::new_and([
 ///             GoalDefinition::new_atomic_formula(
 ///                 AtomicFormula::new_predicate(
@@ -171,8 +172,8 @@ pub fn parse_forall_c_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a,
 ///                 )
 ///             ),
 ///         ]),
-///         ConditionalEffect::from_iter([
-///             PEffect::new(
+///         EffectCondition::from_iter([
+///             PrimitiveEffect::new(
 ///                 AtomicFormula::new_predicate(
 ///                     Predicate::new("person-is-happy".into()),
 ///                     [
@@ -184,39 +185,41 @@ pub fn parse_forall_c_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a,
 ///     )
 /// ));
 /// ```
-pub fn parse_when_c_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, WhenCEffect> {
+#[allow(deprecated)]
+pub fn parse_when_c_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, WhenConditionalEffect> {
     map(
-        prefix_expr("when", (parse_gd, preceded(multispace1, parse_cond_effect))),
-        WhenCEffect::from,
+        prefix_expr("when", (parse_gd, preceded(multispace1, parse_effect_condition))),
+        WhenConditionalEffect::from,
     )
     .parse(input.into())
 }
 
-impl crate::parsers::Parser for CEffect {
-    type Item = CEffect;
+#[allow(deprecated)]
+impl crate::parsers::Parser for ConditionalEffect {
+    type Item = ConditionalEffect;
 
-    /// Parses c-effects.
+    /// Parses conditional effects.
     ///
     /// ## Example
     /// ```
-    /// # use pddl::{CEffect, ConditionalEffect, Effects, GoalDefinition, Parser, PEffect, Typed, TypedList, Variable};
-    /// let (_, value) = CEffect::parse("(= x y)").unwrap();
+    /// # use pddl::{ConditionalEffect, EffectCondition, Effects, GoalDefinition, Parser, PrimitiveEffect, Typed, TypedList, Variable};
+    /// let (_, value) = ConditionalEffect::parse("(= x y)").unwrap();
     /// assert_eq!(value,
-    ///     CEffect::new_p_effect(
-    ///         PEffect::from_str("(= x y)").unwrap()
+    ///     ConditionalEffect::new_primitive_effect(
+    ///         PrimitiveEffect::from_str("(= x y)").unwrap()
     ///     )
     /// );
     ///
-    /// let (_, value) = CEffect::parse("(not (= ?a B))").unwrap();
+    /// let (_, value) = ConditionalEffect::parse("(not (= ?a B))").unwrap();
     /// assert_eq!(value,
-    ///     CEffect::new_p_effect(
-    ///         PEffect::from_str("(not (= ?a B))").unwrap()
+    ///     ConditionalEffect::new_primitive_effect(
+    ///         PrimitiveEffect::from_str("(not (= ?a B))").unwrap()
     ///     )
     /// );
     ///
-    /// let (_, value) = CEffect::parse("(forall (?a ?b) (= ?a ?b))").unwrap();
+    /// let (_, value) = ConditionalEffect::parse("(forall (?a ?b) (= ?a ?b))").unwrap();
     /// assert_eq!(value,
-    ///     CEffect::new_forall(
+    ///     ConditionalEffect::new_forall(
     ///         TypedList::from_iter([
     ///             Typed::new_object(Variable::new_string("a")),
     ///             Typed::new_object(Variable::new_string("b")),
@@ -228,11 +231,11 @@ impl crate::parsers::Parser for CEffect {
     /// let input = r#"(when
     ///     (and (has-hot-chocolate ?p ?c) (has-marshmallows ?c))
     ///     (and (person-is-happy ?p)))"#;
-    /// let (_, value) = CEffect::parse(input).unwrap();
+    /// let (_, value) = ConditionalEffect::parse(input).unwrap();
     /// assert_eq!(value,
-    ///     CEffect::new_when(
+    ///     ConditionalEffect::new_when(
     ///         GoalDefinition::from_str("(and (has-hot-chocolate ?p ?c) (has-marshmallows ?c))").unwrap(),
-    ///         ConditionalEffect::from_str("(and (person-is-happy ?p))").unwrap()
+    ///         EffectCondition::from_str("(and (person-is-happy ?p))").unwrap()
     ///     )
     /// );
     /// ```
@@ -244,17 +247,17 @@ impl crate::parsers::Parser for CEffect {
     }
 }
 
-impl crate::parsers::Parser for ForallCEffect {
-    type Item = ForallCEffect;
+impl crate::parsers::Parser for ForallConditionalEffect {
+    type Item = ForallConditionalEffect;
 
-    /// Parses [`ForallCEffect`] values.
+    /// Parses [`ForallConditionalEffect`] values.
     ///
     /// ## Example
     /// ```
-    /// # use pddl::{Effects, ForallCEffect, Parser, Typed, TypedList, Variable};
-    /// let (_, value) = ForallCEffect::parse("(forall (?a ?b) (= ?a ?b))").unwrap();
+    /// # use pddl::{Effects, ForallConditionalEffect, Parser, Typed, TypedList, Variable};
+    /// let (_, value) = ForallConditionalEffect::parse("(forall (?a ?b) (= ?a ?b))").unwrap();
     /// assert_eq!(value,
-    ///     ForallCEffect::new(
+    ///     ForallConditionalEffect::new(
     ///         TypedList::from_iter([
     ///             Typed::new_object(Variable::new_string("a")),
     ///             Typed::new_object(Variable::new_string("b")),
@@ -271,23 +274,24 @@ impl crate::parsers::Parser for ForallCEffect {
     }
 }
 
-impl crate::parsers::Parser for WhenCEffect {
-    type Item = WhenCEffect;
+#[allow(deprecated)]
+impl crate::parsers::Parser for WhenConditionalEffect {
+    type Item = WhenConditionalEffect;
 
-    /// Parses c-effects.
+    /// Parses conditional effects.
     ///
     /// ## Example
     /// ```
-    /// # use pddl::{ConditionalEffect, GoalDefinition, Parser, WhenCEffect};
+    /// # use pddl::{EffectCondition, GoalDefinition, Parser, WhenConditionalEffect};
     /// let input = r#"(when
     ///     (and (has-hot-chocolate ?p ?c) (has-marshmallows ?c))
     ///     (and (person-is-happy ?p)))"#;
     ///
-    /// let (_, value) = WhenCEffect::parse(input).unwrap();
+    /// let (_, value) = WhenConditionalEffect::parse(input).unwrap();
     /// assert_eq!(value,
-    ///     WhenCEffect::new(
+    ///     WhenConditionalEffect::new(
     ///         GoalDefinition::from_str("(and (has-hot-chocolate ?p ?c) (has-marshmallows ?c))").unwrap(),
-    ///         ConditionalEffect::from_str("(and (person-is-happy ?p))").unwrap()
+    ///         EffectCondition::from_str("(and (person-is-happy ?p))").unwrap()
     ///     )
     /// );
     /// ```
@@ -300,30 +304,31 @@ impl crate::parsers::Parser for WhenCEffect {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use crate::{
-        CEffect, ConditionalEffect, Effects, ForallCEffect, GoalDefinition, PEffect, Parser, Typed,
-        TypedList, Variable, WhenCEffect,
+        ConditionalEffect, EffectCondition, Effects, ForallConditionalEffect, GoalDefinition, PrimitiveEffect, Parser, Typed,
+        TypedList, Variable, WhenConditionalEffect,
     };
 
     #[test]
     fn test_parse() {
-        let (_, value) = CEffect::parse("(= x y)").unwrap();
+        let (_, value) = ConditionalEffect::parse("(= x y)").unwrap();
         assert_eq!(
             value,
-            CEffect::new_p_effect(PEffect::from_str("(= x y)").unwrap())
+            ConditionalEffect::new_primitive_effect(PrimitiveEffect::from_str("(= x y)").unwrap())
         );
 
-        let (_, value) = CEffect::parse("(not (= ?a B))").unwrap();
+        let (_, value) = ConditionalEffect::parse("(not (= ?a B))").unwrap();
         assert_eq!(
             value,
-            CEffect::new_p_effect(PEffect::from_str("(not (= ?a B))").unwrap())
+            ConditionalEffect::new_primitive_effect(PrimitiveEffect::from_str("(not (= ?a B))").unwrap())
         );
 
-        let (_, value) = CEffect::parse("(forall (?a ?b) (= ?a ?b))").unwrap();
+        let (_, value) = ConditionalEffect::parse("(forall (?a ?b) (= ?a ?b))").unwrap();
         assert_eq!(
             value,
-            CEffect::new_forall(
+            ConditionalEffect::new_forall(
                 TypedList::from_iter([
                     Typed::new_object(Variable::new_string("a")),
                     Typed::new_object(Variable::new_string("b")),
@@ -335,23 +340,23 @@ mod tests {
         let input = r#"(when
             (and (has-hot-chocolate ?p ?c) (has-marshmallows ?c))
             (and (person-is-happy ?p)))"#;
-        let (_, value) = CEffect::parse(input).unwrap();
+        let (_, value) = ConditionalEffect::parse(input).unwrap();
         assert_eq!(
             value,
-            CEffect::new_when(
+            ConditionalEffect::new_when(
                 GoalDefinition::from_str("(and (has-hot-chocolate ?p ?c) (has-marshmallows ?c))")
                     .unwrap(),
-                ConditionalEffect::from_str("(and (person-is-happy ?p))").unwrap()
+                EffectCondition::from_str("(and (person-is-happy ?p))").unwrap()
             )
         );
     }
 
     #[test]
     fn test_parse_forall() {
-        let (_, value) = ForallCEffect::parse("(forall (?a ?b) (= ?a ?b))").unwrap();
+        let (_, value) = ForallConditionalEffect::parse("(forall (?a ?b) (= ?a ?b))").unwrap();
         assert_eq!(
             value,
-            ForallCEffect::new(
+            ForallConditionalEffect::new(
                 TypedList::from_iter([
                     Typed::new_object(Variable::new_string("a")),
                     Typed::new_object(Variable::new_string("b")),
@@ -367,13 +372,13 @@ mod tests {
             (and (has-hot-chocolate ?p ?c) (has-marshmallows ?c))
             (and (person-is-happy ?p)))"#;
 
-        let (_, value) = WhenCEffect::parse(input).unwrap();
+        let (_, value) = WhenConditionalEffect::parse(input).unwrap();
         assert_eq!(
             value,
-            WhenCEffect::new(
+            WhenConditionalEffect::new(
                 GoalDefinition::from_str("(and (has-hot-chocolate ?p ?c) (has-marshmallows ?c))")
                     .unwrap(),
-                ConditionalEffect::from_str("(and (person-is-happy ?p))").unwrap()
+                EffectCondition::from_str("(and (person-is-happy ?p))").unwrap()
             )
         );
     }

--- a/src/parsers/con_gd.rs
+++ b/src/parsers/con_gd.rs
@@ -19,8 +19,8 @@ use nom::Parser;
 /// # use pddl::{AtomicFormula, ConstraintGoalDefinitionInner, ConstraintGoalDefinition, GoalDefinition, Number, Term, ToTyped, Type, TypedList, Variable};
 /// // (= x y)
 /// let gd_a =
-///     GoalDefinition::new_atomic_formula(
-///         AtomicFormula::new_equality(
+///     GoalDefinition::atomic_formula(
+///         AtomicFormula::equality(
 ///             Term::Name("x".into()),
 ///             Term::Name("y".into())
 ///         )
@@ -28,9 +28,9 @@ use nom::Parser;
 ///
 /// // (not (= x z))
 /// let gd_b =
-///     GoalDefinition::new_not(
-///         GoalDefinition::new_atomic_formula(
-///             AtomicFormula::new_equality(
+///     GoalDefinition::not(
+///         GoalDefinition::atomic_formula(
+///             AtomicFormula::equality(
 ///                 Term::Name("x".into()),
 ///                 Term::Name("z".into())
 ///             )
@@ -38,27 +38,27 @@ use nom::Parser;
 ///     );
 ///
 /// assert!(parse_con_gd("(and)").is_value(
-///     ConstraintGoalDefinition::new_and([])
+///     ConstraintGoalDefinition::and([])
 /// ));
 ///
 /// assert!(parse_con_gd("(and (at end (= x y)) (at end (not (= x z))))").is_value(
-///     ConstraintGoalDefinition::new_and([
-///         ConstraintGoalDefinition::new_at_end(gd_a.clone()),
-///         ConstraintGoalDefinition::new_at_end(gd_b.clone()),
+///     ConstraintGoalDefinition::and([
+///         ConstraintGoalDefinition::at_end(gd_a.clone()),
+///         ConstraintGoalDefinition::at_end(gd_b.clone()),
 ///     ])
 /// ));
 ///
 /// assert!(parse_con_gd("(forall (?x ?z) (sometime (= ?x ?z)))").is_value(
-///     ConstraintGoalDefinition::new_forall(
+///     ConstraintGoalDefinition::forall(
 ///         TypedList::from_iter([
 ///             Variable::from("x").to_typed(Type::OBJECT),
 ///             Variable::from("z").to_typed(Type::OBJECT),
 ///         ]),
-///         ConstraintGoalDefinition::new_sometime(
+///         ConstraintGoalDefinition::sometime(
 ///             ConstraintGoalDefinitionInner::Goal(
 ///                 // gd ...
-///                 # GoalDefinition::new_atomic_formula(
-///                 #    AtomicFormula::new_equality(
+///                 # GoalDefinition::atomic_formula(
+///                 #    AtomicFormula::equality(
 ///                 #        Term::Variable("x".into()),
 ///                 #        Term::Variable("z".into())
 ///                 #    )
@@ -73,43 +73,43 @@ use nom::Parser;
 /// ));
 ///
 /// assert!(parse_con_gd("(always (= x y))").is_value(
-///     ConstraintGoalDefinition::Always(ConstraintGoalDefinitionInner::new_goal(gd_a.clone()))
+///     ConstraintGoalDefinition::Always(ConstraintGoalDefinitionInner::goal(gd_a.clone()))
 /// ));
 ///
 /// assert!(parse_con_gd("(sometime (= x y))").is_value(
-///     ConstraintGoalDefinition::Sometime(ConstraintGoalDefinitionInner::new_goal(gd_a.clone()))
+///     ConstraintGoalDefinition::Sometime(ConstraintGoalDefinitionInner::goal(gd_a.clone()))
 /// ));
 ///
 /// assert!(parse_con_gd("(within 10 (= x y))").is_value(
 ///     ConstraintGoalDefinition::Within(
 ///         Number::from(10),
-///         ConstraintGoalDefinitionInner::new_goal(gd_a.clone())
+///         ConstraintGoalDefinitionInner::goal(gd_a.clone())
 ///     )
 /// ));
 ///
 /// assert!(parse_con_gd("(at-most-once (= x y))").is_value(
-///     ConstraintGoalDefinition::AtMostOnce(ConstraintGoalDefinitionInner::new_goal(gd_a.clone()))
+///     ConstraintGoalDefinition::AtMostOnce(ConstraintGoalDefinitionInner::goal(gd_a.clone()))
 /// ));
 ///
 /// assert!(parse_con_gd("(sometime-after (= x y) (not (= x z)))").is_value(
 ///     ConstraintGoalDefinition::SometimeAfter(
-///         ConstraintGoalDefinitionInner::new_goal(gd_a.clone()),
-///         ConstraintGoalDefinitionInner::new_goal(gd_b.clone())
+///         ConstraintGoalDefinitionInner::goal(gd_a.clone()),
+///         ConstraintGoalDefinitionInner::goal(gd_b.clone())
 ///     )
 /// ));
 ///
 /// assert!(parse_con_gd("(sometime-before (= x y) (not (= x z)))").is_value(
 ///     ConstraintGoalDefinition::SometimeBefore(
-///         ConstraintGoalDefinitionInner::new_goal(gd_a.clone()),
-///         ConstraintGoalDefinitionInner::new_goal(gd_b.clone())
+///         ConstraintGoalDefinitionInner::goal(gd_a.clone()),
+///         ConstraintGoalDefinitionInner::goal(gd_b.clone())
 ///     )
 /// ));
 ///
 /// assert!(parse_con_gd("(always-within 10 (= x y) (not (= x z)))").is_value(
 ///     ConstraintGoalDefinition::AlwaysWithin(
 ///         Number::from(10),
-///         ConstraintGoalDefinitionInner::new_goal(gd_a.clone()),
-///         ConstraintGoalDefinitionInner::new_goal(gd_b.clone())
+///         ConstraintGoalDefinitionInner::goal(gd_a.clone()),
+///         ConstraintGoalDefinitionInner::goal(gd_b.clone())
 ///     )
 /// ));
 ///
@@ -117,14 +117,14 @@ use nom::Parser;
 ///     ConstraintGoalDefinition::HoldDuring(
 ///         Number::from(10),
 ///         Number::from(20),
-///         ConstraintGoalDefinitionInner::new_goal(gd_a.clone())
+///         ConstraintGoalDefinitionInner::goal(gd_a.clone())
 ///     )
 /// ));
 ///
 /// assert!(parse_con_gd("(hold-after 10 (= x y))").is_value(
 ///     ConstraintGoalDefinition::HoldAfter(
 ///         Number::from(10),
-///         ConstraintGoalDefinitionInner::new_goal(gd_a.clone())
+///         ConstraintGoalDefinitionInner::goal(gd_a.clone())
 ///     )
 /// ));
 /// ```
@@ -136,8 +136,8 @@ use nom::Parser;
 /// # use pddl::{AtomicFormula, ConstraintGoalDefinitionInner, ConstraintGoalDefinition, GoalDefinition, Number, Term};
 /// # // (= x y)
 /// # let gd =
-/// #    GoalDefinition::new_atomic_formula(
-/// #        AtomicFormula::new_equality(
+/// #    GoalDefinition::atomic_formula(
+/// #        AtomicFormula::equality(
 /// #            Term::Name("x".into()),
 /// #            Term::Name("y".into())
 /// #        )
@@ -145,11 +145,11 @@ use nom::Parser;
 ///
 /// let input = "(within 10 (at-most-once (= x y)))";
 /// assert!(parse_con_gd(input).is_value(
-///     ConstraintGoalDefinition::new_within(
+///     ConstraintGoalDefinition::within(
 ///         Number::from(10),
-///         ConstraintGoalDefinitionInner::new_nested(
-///             ConstraintGoalDefinition::new_at_most_once(
-///                 ConstraintGoalDefinitionInner::new_goal(
+///         ConstraintGoalDefinitionInner::nested(
+///             ConstraintGoalDefinition::at_most_once(
+///                 ConstraintGoalDefinitionInner::goal(
 ///                     // gd ...
 ///                     # gd
 ///                 )
@@ -172,7 +172,7 @@ pub fn parse_con_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Constrai
                 preceded(multispace1, parse_con_gd),
             ),
         ),
-        |(vars, gd)| ConstraintGoalDefinition::new_forall(vars, gd),
+        |(vars, gd)| ConstraintGoalDefinition::forall(vars, gd),
     );
 
     let at_end = map(
@@ -195,7 +195,7 @@ pub fn parse_con_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Constrai
             "within",
             (parse_number, preceded(multispace1, parse_con2_gd)),
         ),
-        |(num, gd)| ConstraintGoalDefinition::new_within(num, gd),
+        |(num, gd)| ConstraintGoalDefinition::within(num, gd),
     );
 
     let at_most_once = map(
@@ -208,7 +208,7 @@ pub fn parse_con_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Constrai
             "sometime-after",
             (parse_con2_gd, preceded(multispace1, parse_con2_gd)),
         ),
-        |(a, b)| ConstraintGoalDefinition::new_sometime_after(a, b),
+        |(a, b)| ConstraintGoalDefinition::sometime_after(a, b),
     );
 
     let sometime_before = map(
@@ -216,7 +216,7 @@ pub fn parse_con_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Constrai
             "sometime-before",
             (parse_con2_gd, preceded(multispace1, parse_con2_gd)),
         ),
-        |(a, b)| ConstraintGoalDefinition::new_sometime_before(a, b),
+        |(a, b)| ConstraintGoalDefinition::sometime_before(a, b),
     );
 
     let always_within = map(
@@ -228,7 +228,7 @@ pub fn parse_con_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Constrai
                 preceded(multispace1, parse_con2_gd),
             ),
         ),
-        |(num, a, b)| ConstraintGoalDefinition::new_always_within(num, a, b),
+        |(num, a, b)| ConstraintGoalDefinition::always_within(num, a, b),
     );
 
     let hold_during = map(
@@ -240,7 +240,7 @@ pub fn parse_con_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Constrai
                 preceded(multispace1, parse_con2_gd),
             ),
         ),
-        |(t0, t1, gd)| ConstraintGoalDefinition::new_hold_during(t0, t1, gd),
+        |(t0, t1, gd)| ConstraintGoalDefinition::hold_during(t0, t1, gd),
     );
 
     let hold_after = map(
@@ -248,7 +248,7 @@ pub fn parse_con_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Constrai
             "hold-after",
             (parse_number, preceded(multispace1, parse_con2_gd)),
         ),
-        |(time, gd)| ConstraintGoalDefinition::new_hold_after(time, gd),
+        |(time, gd)| ConstraintGoalDefinition::hold_after(time, gd),
     );
 
     alt((
@@ -306,33 +306,88 @@ mod tests {
 
     #[test]
     fn test_parse() {
-        let gd = GoalDefinition::new_atomic_formula(AtomicFormula::new_equality(
+        let gd = GoalDefinition::atomic_formula(AtomicFormula::equality(
             Term::Name("x".into()),
             Term::Name("y".into()),
         ));
 
         let input = "(within 10 (at-most-once (= x y)))";
-        assert!(ConstraintGoalDefinition::parse(input).is_value(
-            ConstraintGoalDefinition::new_within(
+        assert!(
+            ConstraintGoalDefinition::parse(input).is_value(ConstraintGoalDefinition::within(
                 Number::from(10),
-                ConstraintGoalDefinitionInner::new_nested(
-                    ConstraintGoalDefinition::new_at_most_once(
-                        ConstraintGoalDefinitionInner::new_goal(gd.clone())
-                    )
-                )
-            )
-        ));
+                ConstraintGoalDefinitionInner::nested(ConstraintGoalDefinition::at_most_once(
+                    ConstraintGoalDefinitionInner::goal(gd.clone())
+                ))
+            ))
+        );
 
         let input = "(within 10 (at-most-once (= x y)))";
         assert!(ConstraintGoalDefinitionInner::parse(input).is_value(
-            ConstraintGoalDefinitionInner::Nested(Box::new(ConstraintGoalDefinition::new_within(
+            ConstraintGoalDefinitionInner::Nested(Box::new(ConstraintGoalDefinition::within(
                 Number::from(10),
-                ConstraintGoalDefinitionInner::new_nested(
-                    ConstraintGoalDefinition::new_at_most_once(
-                        ConstraintGoalDefinitionInner::new_goal(gd)
-                    )
-                )
+                ConstraintGoalDefinitionInner::nested(ConstraintGoalDefinition::at_most_once(
+                    ConstraintGoalDefinitionInner::goal(gd)
+                ))
             )))
         ));
+    }
+
+    #[test]
+    fn test_parse_sometime() {
+        assert!(
+            ConstraintGoalDefinition::parse("(sometime (= x y))").is_value(
+                ConstraintGoalDefinition::sometime(ConstraintGoalDefinitionInner::goal(
+                    GoalDefinition::atomic_formula(AtomicFormula::equality(
+                        Term::Name("x".into()),
+                        Term::Name("y".into()),
+                    ))
+                ))
+            )
+        );
+    }
+
+    #[test]
+    fn test_parse_sometime_after() {
+        assert!(
+            ConstraintGoalDefinition::parse("(sometime-after (= x y) (= a b))").is_value(
+                ConstraintGoalDefinition::sometime_after(
+                    ConstraintGoalDefinitionInner::goal(GoalDefinition::atomic_formula(
+                        AtomicFormula::equality(Term::Name("x".into()), Term::Name("y".into()))
+                    )),
+                    ConstraintGoalDefinitionInner::goal(GoalDefinition::atomic_formula(
+                        AtomicFormula::equality(Term::Name("a".into()), Term::Name("b".into()))
+                    ))
+                )
+            )
+        );
+    }
+
+    #[test]
+    fn test_parse_hold_during() {
+        assert!(
+            ConstraintGoalDefinition::parse("(hold-during 5 10 (= x y))").is_value(
+                ConstraintGoalDefinition::hold_during(
+                    Number::from(5),
+                    Number::from(10),
+                    ConstraintGoalDefinitionInner::goal(GoalDefinition::atomic_formula(
+                        AtomicFormula::equality(Term::Name("x".into()), Term::Name("y".into()))
+                    ))
+                )
+            )
+        );
+    }
+
+    #[test]
+    fn test_parse_hold_after() {
+        assert!(
+            ConstraintGoalDefinition::parse("(hold-after 5 (= x y))").is_value(
+                ConstraintGoalDefinition::hold_after(
+                    Number::from(5),
+                    ConstraintGoalDefinitionInner::goal(GoalDefinition::atomic_formula(
+                        AtomicFormula::equality(Term::Name("x".into()), Term::Name("y".into()))
+                    ))
+                )
+            )
+        );
     }
 }

--- a/src/parsers/con_gd.rs
+++ b/src/parsers/con_gd.rs
@@ -4,7 +4,7 @@ use crate::parsers::{
     parens, parse_gd, parse_number, parse_variable, prefix_expr, space_separated_list0, typed_list,
     ParseResult, Span,
 };
-use crate::types::{ConstraintGoalDefinitionInner, ConstraintGoalDefinition};
+use crate::types::{ConstraintGoalDefinition, ConstraintGoalDefinitionInner};
 use nom::branch::alt;
 use nom::character::complete::multispace1;
 use nom::combinator::map;
@@ -175,11 +175,20 @@ pub fn parse_con_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Constrai
         |(vars, gd)| ConstraintGoalDefinition::new_forall(vars, gd),
     );
 
-    let at_end = map(prefix_expr("at end", parse_gd), ConstraintGoalDefinition::new_at_end);
+    let at_end = map(
+        prefix_expr("at end", parse_gd),
+        ConstraintGoalDefinition::new_at_end,
+    );
 
-    let always = map(prefix_expr("always", parse_con2_gd), ConstraintGoalDefinition::new_always);
+    let always = map(
+        prefix_expr("always", parse_con2_gd),
+        ConstraintGoalDefinition::new_always,
+    );
 
-    let sometime = map(prefix_expr("sometime", parse_con2_gd), ConstraintGoalDefinition::new_sometime);
+    let sometime = map(
+        prefix_expr("sometime", parse_con2_gd),
+        ConstraintGoalDefinition::new_sometime,
+    );
 
     let within = map(
         prefix_expr(
@@ -259,7 +268,9 @@ pub fn parse_con_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Constrai
     .parse(input.into())
 }
 
-fn parse_con2_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, ConstraintGoalDefinitionInner> {
+fn parse_con2_gd<'a, T: Into<Span<'a>>>(
+    input: T,
+) -> ParseResult<'a, ConstraintGoalDefinitionInner> {
     let gd = map(parse_gd, ConstraintGoalDefinitionInner::new_goal);
 
     // TODO: Add crate feature to allow this to be forbidden if unsupported by the application.
@@ -288,7 +299,10 @@ impl crate::parsers::Parser for ConstraintGoalDefinitionInner {
 #[cfg(test)]
 mod tests {
     use crate::parsers::preamble::*;
-    use crate::{AtomicFormula, ConstraintGoalDefinitionInner, ConstraintGoalDefinition, GoalDefinition, Number, Term};
+    use crate::{
+        AtomicFormula, ConstraintGoalDefinition, ConstraintGoalDefinitionInner, GoalDefinition,
+        Number, Term,
+    };
 
     #[test]
     fn test_parse() {
@@ -298,17 +312,27 @@ mod tests {
         ));
 
         let input = "(within 10 (at-most-once (= x y)))";
-        assert!(ConstraintGoalDefinition::parse(input).is_value(ConstraintGoalDefinition::new_within(
-            Number::from(10),
-            ConstraintGoalDefinitionInner::new_nested(ConstraintGoalDefinition::new_at_most_once(ConstraintGoalDefinitionInner::new_goal(gd.clone())))
-        )));
+        assert!(ConstraintGoalDefinition::parse(input).is_value(
+            ConstraintGoalDefinition::new_within(
+                Number::from(10),
+                ConstraintGoalDefinitionInner::new_nested(
+                    ConstraintGoalDefinition::new_at_most_once(
+                        ConstraintGoalDefinitionInner::new_goal(gd.clone())
+                    )
+                )
+            )
+        ));
 
         let input = "(within 10 (at-most-once (= x y)))";
-        assert!(
-            ConstraintGoalDefinitionInner::parse(input).is_value(ConstraintGoalDefinitionInner::Nested(Box::new(ConstraintGoalDefinition::new_within(
+        assert!(ConstraintGoalDefinitionInner::parse(input).is_value(
+            ConstraintGoalDefinitionInner::Nested(Box::new(ConstraintGoalDefinition::new_within(
                 Number::from(10),
-                ConstraintGoalDefinitionInner::new_nested(ConstraintGoalDefinition::new_at_most_once(ConstraintGoalDefinitionInner::new_goal(gd)))
-            ))))
-        );
+                ConstraintGoalDefinitionInner::new_nested(
+                    ConstraintGoalDefinition::new_at_most_once(
+                        ConstraintGoalDefinitionInner::new_goal(gd)
+                    )
+                )
+            )))
+        ));
     }
 }

--- a/src/parsers/con_gd.rs
+++ b/src/parsers/con_gd.rs
@@ -4,7 +4,7 @@ use crate::parsers::{
     parens, parse_gd, parse_number, parse_variable, prefix_expr, space_separated_list0, typed_list,
     ParseResult, Span,
 };
-use crate::types::{Con2GD, ConGD};
+use crate::types::{ConstraintGoalDefinitionInner, ConstraintGoalDefinition};
 use nom::branch::alt;
 use nom::character::complete::multispace1;
 use nom::combinator::map;
@@ -16,7 +16,7 @@ use nom::Parser;
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_con_gd, preamble::*};
-/// # use pddl::{AtomicFormula, Con2GD, ConGD, GoalDefinition, Number, Term, ToTyped, Type, TypedList, Variable};
+/// # use pddl::{AtomicFormula, ConstraintGoalDefinitionInner, ConstraintGoalDefinition, GoalDefinition, Number, Term, ToTyped, Type, TypedList, Variable};
 /// // (= x y)
 /// let gd_a =
 ///     GoalDefinition::new_atomic_formula(
@@ -38,24 +38,24 @@ use nom::Parser;
 ///     );
 ///
 /// assert!(parse_con_gd("(and)").is_value(
-///     ConGD::new_and([])
+///     ConstraintGoalDefinition::new_and([])
 /// ));
 ///
 /// assert!(parse_con_gd("(and (at end (= x y)) (at end (not (= x z))))").is_value(
-///     ConGD::new_and([
-///         ConGD::new_at_end(gd_a.clone()),
-///         ConGD::new_at_end(gd_b.clone()),
+///     ConstraintGoalDefinition::new_and([
+///         ConstraintGoalDefinition::new_at_end(gd_a.clone()),
+///         ConstraintGoalDefinition::new_at_end(gd_b.clone()),
 ///     ])
 /// ));
 ///
 /// assert!(parse_con_gd("(forall (?x ?z) (sometime (= ?x ?z)))").is_value(
-///     ConGD::new_forall(
+///     ConstraintGoalDefinition::new_forall(
 ///         TypedList::from_iter([
 ///             Variable::from("x").to_typed(Type::OBJECT),
 ///             Variable::from("z").to_typed(Type::OBJECT),
 ///         ]),
-///         ConGD::new_sometime(
-///             Con2GD::Goal(
+///         ConstraintGoalDefinition::new_sometime(
+///             ConstraintGoalDefinitionInner::Goal(
 ///                 // gd ...
 ///                 # GoalDefinition::new_atomic_formula(
 ///                 #    AtomicFormula::new_equality(
@@ -69,62 +69,62 @@ use nom::Parser;
 /// ));
 ///
 /// assert!(parse_con_gd("(at end (= x y))").is_value(
-///     ConGD::AtEnd(gd_a.clone())
+///     ConstraintGoalDefinition::AtEnd(gd_a.clone())
 /// ));
 ///
 /// assert!(parse_con_gd("(always (= x y))").is_value(
-///     ConGD::Always(Con2GD::new_goal(gd_a.clone()))
+///     ConstraintGoalDefinition::Always(ConstraintGoalDefinitionInner::new_goal(gd_a.clone()))
 /// ));
 ///
 /// assert!(parse_con_gd("(sometime (= x y))").is_value(
-///     ConGD::Sometime(Con2GD::new_goal(gd_a.clone()))
+///     ConstraintGoalDefinition::Sometime(ConstraintGoalDefinitionInner::new_goal(gd_a.clone()))
 /// ));
 ///
 /// assert!(parse_con_gd("(within 10 (= x y))").is_value(
-///     ConGD::Within(
+///     ConstraintGoalDefinition::Within(
 ///         Number::from(10),
-///         Con2GD::new_goal(gd_a.clone())
+///         ConstraintGoalDefinitionInner::new_goal(gd_a.clone())
 ///     )
 /// ));
 ///
 /// assert!(parse_con_gd("(at-most-once (= x y))").is_value(
-///     ConGD::AtMostOnce(Con2GD::new_goal(gd_a.clone()))
+///     ConstraintGoalDefinition::AtMostOnce(ConstraintGoalDefinitionInner::new_goal(gd_a.clone()))
 /// ));
 ///
 /// assert!(parse_con_gd("(sometime-after (= x y) (not (= x z)))").is_value(
-///     ConGD::SometimeAfter(
-///         Con2GD::new_goal(gd_a.clone()),
-///         Con2GD::new_goal(gd_b.clone())
+///     ConstraintGoalDefinition::SometimeAfter(
+///         ConstraintGoalDefinitionInner::new_goal(gd_a.clone()),
+///         ConstraintGoalDefinitionInner::new_goal(gd_b.clone())
 ///     )
 /// ));
 ///
 /// assert!(parse_con_gd("(sometime-before (= x y) (not (= x z)))").is_value(
-///     ConGD::SometimeBefore(
-///         Con2GD::new_goal(gd_a.clone()),
-///         Con2GD::new_goal(gd_b.clone())
+///     ConstraintGoalDefinition::SometimeBefore(
+///         ConstraintGoalDefinitionInner::new_goal(gd_a.clone()),
+///         ConstraintGoalDefinitionInner::new_goal(gd_b.clone())
 ///     )
 /// ));
 ///
 /// assert!(parse_con_gd("(always-within 10 (= x y) (not (= x z)))").is_value(
-///     ConGD::AlwaysWithin(
+///     ConstraintGoalDefinition::AlwaysWithin(
 ///         Number::from(10),
-///         Con2GD::new_goal(gd_a.clone()),
-///         Con2GD::new_goal(gd_b.clone())
+///         ConstraintGoalDefinitionInner::new_goal(gd_a.clone()),
+///         ConstraintGoalDefinitionInner::new_goal(gd_b.clone())
 ///     )
 /// ));
 ///
 /// assert!(parse_con_gd("(hold-during 10 20 (= x y))").is_value(
-///     ConGD::HoldDuring(
+///     ConstraintGoalDefinition::HoldDuring(
 ///         Number::from(10),
 ///         Number::from(20),
-///         Con2GD::new_goal(gd_a.clone())
+///         ConstraintGoalDefinitionInner::new_goal(gd_a.clone())
 ///     )
 /// ));
 ///
 /// assert!(parse_con_gd("(hold-after 10 (= x y))").is_value(
-///     ConGD::HoldAfter(
+///     ConstraintGoalDefinition::HoldAfter(
 ///         Number::from(10),
-///         Con2GD::new_goal(gd_a.clone())
+///         ConstraintGoalDefinitionInner::new_goal(gd_a.clone())
 ///     )
 /// ));
 /// ```
@@ -133,7 +133,7 @@ use nom::Parser;
 ///
 /// ```
 /// # use pddl::parsers::{parse_con_gd, preamble::*};
-/// # use pddl::{AtomicFormula, Con2GD, ConGD, GoalDefinition, Number, Term};
+/// # use pddl::{AtomicFormula, ConstraintGoalDefinitionInner, ConstraintGoalDefinition, GoalDefinition, Number, Term};
 /// # // (= x y)
 /// # let gd =
 /// #    GoalDefinition::new_atomic_formula(
@@ -145,11 +145,11 @@ use nom::Parser;
 ///
 /// let input = "(within 10 (at-most-once (= x y)))";
 /// assert!(parse_con_gd(input).is_value(
-///     ConGD::new_within(
+///     ConstraintGoalDefinition::new_within(
 ///         Number::from(10),
-///         Con2GD::new_nested(
-///             ConGD::new_at_most_once(
-///                 Con2GD::new_goal(
+///         ConstraintGoalDefinitionInner::new_nested(
+///             ConstraintGoalDefinition::new_at_most_once(
+///                 ConstraintGoalDefinitionInner::new_goal(
 ///                     // gd ...
 ///                     # gd
 ///                 )
@@ -158,10 +158,10 @@ use nom::Parser;
 ///     )
 /// ));
 /// ```
-pub fn parse_con_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, ConGD> {
+pub fn parse_con_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, ConstraintGoalDefinition> {
     let and = map(
         prefix_expr("and", space_separated_list0(parse_con_gd)),
-        ConGD::new_and,
+        ConstraintGoalDefinition::new_and,
     );
 
     let forall = map(
@@ -172,26 +172,26 @@ pub fn parse_con_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, ConGD> {
                 preceded(multispace1, parse_con_gd),
             ),
         ),
-        |(vars, gd)| ConGD::new_forall(vars, gd),
+        |(vars, gd)| ConstraintGoalDefinition::new_forall(vars, gd),
     );
 
-    let at_end = map(prefix_expr("at end", parse_gd), ConGD::new_at_end);
+    let at_end = map(prefix_expr("at end", parse_gd), ConstraintGoalDefinition::new_at_end);
 
-    let always = map(prefix_expr("always", parse_con2_gd), ConGD::new_always);
+    let always = map(prefix_expr("always", parse_con2_gd), ConstraintGoalDefinition::new_always);
 
-    let sometime = map(prefix_expr("sometime", parse_con2_gd), ConGD::new_sometime);
+    let sometime = map(prefix_expr("sometime", parse_con2_gd), ConstraintGoalDefinition::new_sometime);
 
     let within = map(
         prefix_expr(
             "within",
             (parse_number, preceded(multispace1, parse_con2_gd)),
         ),
-        |(num, gd)| ConGD::new_within(num, gd),
+        |(num, gd)| ConstraintGoalDefinition::new_within(num, gd),
     );
 
     let at_most_once = map(
         prefix_expr("at-most-once", parse_con2_gd),
-        ConGD::new_at_most_once,
+        ConstraintGoalDefinition::new_at_most_once,
     );
 
     let sometime_after = map(
@@ -199,7 +199,7 @@ pub fn parse_con_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, ConGD> {
             "sometime-after",
             (parse_con2_gd, preceded(multispace1, parse_con2_gd)),
         ),
-        |(a, b)| ConGD::new_sometime_after(a, b),
+        |(a, b)| ConstraintGoalDefinition::new_sometime_after(a, b),
     );
 
     let sometime_before = map(
@@ -207,7 +207,7 @@ pub fn parse_con_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, ConGD> {
             "sometime-before",
             (parse_con2_gd, preceded(multispace1, parse_con2_gd)),
         ),
-        |(a, b)| ConGD::new_sometime_before(a, b),
+        |(a, b)| ConstraintGoalDefinition::new_sometime_before(a, b),
     );
 
     let always_within = map(
@@ -219,7 +219,7 @@ pub fn parse_con_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, ConGD> {
                 preceded(multispace1, parse_con2_gd),
             ),
         ),
-        |(num, a, b)| ConGD::new_always_within(num, a, b),
+        |(num, a, b)| ConstraintGoalDefinition::new_always_within(num, a, b),
     );
 
     let hold_during = map(
@@ -231,7 +231,7 @@ pub fn parse_con_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, ConGD> {
                 preceded(multispace1, parse_con2_gd),
             ),
         ),
-        |(t0, t1, gd)| ConGD::new_hold_during(t0, t1, gd),
+        |(t0, t1, gd)| ConstraintGoalDefinition::new_hold_during(t0, t1, gd),
     );
 
     let hold_after = map(
@@ -239,7 +239,7 @@ pub fn parse_con_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, ConGD> {
             "hold-after",
             (parse_number, preceded(multispace1, parse_con2_gd)),
         ),
-        |(time, gd)| ConGD::new_hold_after(time, gd),
+        |(time, gd)| ConstraintGoalDefinition::new_hold_after(time, gd),
     );
 
     alt((
@@ -259,16 +259,16 @@ pub fn parse_con_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, ConGD> {
     .parse(input.into())
 }
 
-fn parse_con2_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Con2GD> {
-    let gd = map(parse_gd, Con2GD::new_goal);
+fn parse_con2_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, ConstraintGoalDefinitionInner> {
+    let gd = map(parse_gd, ConstraintGoalDefinitionInner::new_goal);
 
     // TODO: Add crate feature to allow this to be forbidden if unsupported by the application.
-    let con_gd = map(parse_con_gd, Con2GD::new_nested);
+    let con_gd = map(parse_con_gd, ConstraintGoalDefinitionInner::new_nested);
     alt((gd, con_gd)).parse(input.into())
 }
 
-impl crate::parsers::Parser for ConGD {
-    type Item = ConGD;
+impl crate::parsers::Parser for ConstraintGoalDefinition {
+    type Item = ConstraintGoalDefinition;
 
     /// See [`parse_con_gd`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
@@ -276,8 +276,8 @@ impl crate::parsers::Parser for ConGD {
     }
 }
 
-impl crate::parsers::Parser for Con2GD {
-    type Item = Con2GD;
+impl crate::parsers::Parser for ConstraintGoalDefinitionInner {
+    type Item = ConstraintGoalDefinitionInner;
 
     /// Parses a constraint goal definition.
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
@@ -288,7 +288,7 @@ impl crate::parsers::Parser for Con2GD {
 #[cfg(test)]
 mod tests {
     use crate::parsers::preamble::*;
-    use crate::{AtomicFormula, Con2GD, ConGD, GoalDefinition, Number, Term};
+    use crate::{AtomicFormula, ConstraintGoalDefinitionInner, ConstraintGoalDefinition, GoalDefinition, Number, Term};
 
     #[test]
     fn test_parse() {
@@ -298,16 +298,16 @@ mod tests {
         ));
 
         let input = "(within 10 (at-most-once (= x y)))";
-        assert!(ConGD::parse(input).is_value(ConGD::new_within(
+        assert!(ConstraintGoalDefinition::parse(input).is_value(ConstraintGoalDefinition::new_within(
             Number::from(10),
-            Con2GD::new_nested(ConGD::new_at_most_once(Con2GD::new_goal(gd.clone())))
+            ConstraintGoalDefinitionInner::new_nested(ConstraintGoalDefinition::new_at_most_once(ConstraintGoalDefinitionInner::new_goal(gd.clone())))
         )));
 
         let input = "(within 10 (at-most-once (= x y)))";
         assert!(
-            Con2GD::parse(input).is_value(Con2GD::Nested(Box::new(ConGD::new_within(
+            ConstraintGoalDefinitionInner::parse(input).is_value(ConstraintGoalDefinitionInner::Nested(Box::new(ConstraintGoalDefinition::new_within(
                 Number::from(10),
-                Con2GD::new_nested(ConGD::new_at_most_once(Con2GD::new_goal(gd)))
+                ConstraintGoalDefinitionInner::new_nested(ConstraintGoalDefinition::new_at_most_once(ConstraintGoalDefinitionInner::new_goal(gd)))
             ))))
         );
     }

--- a/src/parsers/cond_effect.rs
+++ b/src/parsers/cond_effect.rs
@@ -101,4 +101,9 @@ mod tests {
             ))
         );
     }
+
+    #[test]
+    fn test_parse_empty_and() {
+        assert!(EffectCondition::parse("(and)").is_value(EffectCondition::All(vec![])));
+    }
 }

--- a/src/parsers/cond_effect.rs
+++ b/src/parsers/cond_effect.rs
@@ -1,4 +1,4 @@
-//! Provides parsers for conditional effects.
+//! Provides parsers for effect conditions.
 
 use nom::branch::alt;
 use nom::combinator::map;
@@ -6,17 +6,17 @@ use nom::Parser;
 
 use crate::parsers::{parse_p_effect, ParseResult, Span};
 use crate::parsers::{prefix_expr, space_separated_list0};
-use crate::types::ConditionalEffect;
+use crate::types::EffectCondition;
 
-/// Parses conditional effects.
+/// Parses effect conditions.
 ///
 /// ## Example
 /// ```
-/// # use pddl::parsers::{parse_cond_effect, preamble::*};
-/// # use pddl::{AtomicFormula, CEffect, ConditionalEffect, EqualityAtomicFormula, PEffect, Term};
-/// assert!(parse_cond_effect("(= x y)").is_value(
-///     ConditionalEffect::Single(
-///         PEffect::AtomicFormula(AtomicFormula::Equality(
+/// # use pddl::parsers::{parse_effect_condition, preamble::*};
+/// # use pddl::{AtomicFormula, EffectCondition, EqualityAtomicFormula, PrimitiveEffect, Term};
+/// assert!(parse_effect_condition("(= x y)").is_value(
+///     EffectCondition::Single(
+///         PrimitiveEffect::AtomicFormula(AtomicFormula::Equality(
 ///             EqualityAtomicFormula::new(
 ///                 Term::Name("x".into()),
 ///                 Term::Name("y".into()))
@@ -25,15 +25,15 @@ use crate::types::ConditionalEffect;
 ///     )
 /// ));
 ///
-/// assert!(parse_cond_effect("(and (= x y) (not (= ?a B)))").is_value(
-///     ConditionalEffect::All(vec![
-///         PEffect::AtomicFormula(AtomicFormula::Equality(
+/// assert!(parse_effect_condition("(and (= x y) (not (= ?a B)))").is_value(
+///     EffectCondition::All(vec![
+///         PrimitiveEffect::AtomicFormula(AtomicFormula::Equality(
 ///             EqualityAtomicFormula::new(
 ///                 Term::Name("x".into()),
 ///                 Term::Name("y".into()))
 ///             )
 ///         ),
-///         PEffect::NotAtomicFormula(AtomicFormula::Equality(
+///         PrimitiveEffect::NotAtomicFormula(AtomicFormula::Equality(
 ///             EqualityAtomicFormula::new(
 ///                 Term::Variable("a".into()),
 ///                 Term::Name("B".into()))
@@ -42,35 +42,42 @@ use crate::types::ConditionalEffect;
 ///     ])
 /// ));
 /// ```
-pub fn parse_cond_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, ConditionalEffect> {
-    let exactly = map(parse_p_effect, ConditionalEffect::from);
+#[allow(deprecated)]
+pub fn parse_effect_condition<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, EffectCondition> {
+    let exactly = map(parse_p_effect, EffectCondition::from);
     let all = map(
         prefix_expr("and", space_separated_list0(parse_p_effect)),
-        ConditionalEffect::from,
+        EffectCondition::from,
     );
 
     alt((all, exactly)).parse(input.into())
 }
 
-impl crate::parsers::Parser for ConditionalEffect {
-    type Item = ConditionalEffect;
+/// Alias for [`parse_effect_condition`].
+#[deprecated(since = "0.2.0", note = "Use `parse_effect_condition` instead")]
+pub fn parse_cond_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, EffectCondition> {
+    parse_effect_condition(input)
+}
 
-    /// See [`parse_cond_effect`].
+impl crate::parsers::Parser for EffectCondition {
+    type Item = EffectCondition;
+
+    /// See [`parse_effect_condition`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
-        parse_cond_effect(input)
+        parse_effect_condition(input)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::parsers::UnwrapValue;
-    use crate::{AtomicFormula, ConditionalEffect, EqualityAtomicFormula, PEffect, Parser, Term};
+    use crate::{AtomicFormula, EffectCondition, EqualityAtomicFormula, PrimitiveEffect, Parser, Term};
 
     #[test]
     fn test_parse() {
         assert!(
-            ConditionalEffect::parse("(= x y)").is_value(ConditionalEffect::Single(
-                PEffect::AtomicFormula(AtomicFormula::Equality(EqualityAtomicFormula::new(
+            EffectCondition::parse("(= x y)").is_value(EffectCondition::Single(
+                PrimitiveEffect::AtomicFormula(AtomicFormula::Equality(EqualityAtomicFormula::new(
                     Term::Name("x".into()),
                     Term::Name("y".into())
                 )))
@@ -78,13 +85,13 @@ mod tests {
         );
 
         assert!(
-            ConditionalEffect::parse("(and (= x y) (not (= ?a B)))").is_value(
-                ConditionalEffect::All(vec![
-                    PEffect::AtomicFormula(AtomicFormula::Equality(EqualityAtomicFormula::new(
+            EffectCondition::parse("(and (= x y) (not (= ?a B)))").is_value(
+                EffectCondition::All(vec![
+                    PrimitiveEffect::AtomicFormula(AtomicFormula::Equality(EqualityAtomicFormula::new(
                         Term::Name("x".into()),
                         Term::Name("y".into())
                     ))),
-                    PEffect::NotAtomicFormula(AtomicFormula::Equality(EqualityAtomicFormula::new(
+                    PrimitiveEffect::NotAtomicFormula(AtomicFormula::Equality(EqualityAtomicFormula::new(
                         Term::Variable("a".into()),
                         Term::Name("B".into())
                     )))

--- a/src/parsers/cond_effect.rs
+++ b/src/parsers/cond_effect.rs
@@ -71,32 +71,34 @@ impl crate::parsers::Parser for EffectCondition {
 #[cfg(test)]
 mod tests {
     use crate::parsers::UnwrapValue;
-    use crate::{AtomicFormula, EffectCondition, EqualityAtomicFormula, PrimitiveEffect, Parser, Term};
+    use crate::{
+        AtomicFormula, EffectCondition, EqualityAtomicFormula, Parser, PrimitiveEffect, Term,
+    };
 
     #[test]
     fn test_parse() {
         assert!(
             EffectCondition::parse("(= x y)").is_value(EffectCondition::Single(
-                PrimitiveEffect::AtomicFormula(AtomicFormula::Equality(EqualityAtomicFormula::new(
-                    Term::Name("x".into()),
-                    Term::Name("y".into())
-                )))
+                PrimitiveEffect::AtomicFormula(AtomicFormula::Equality(
+                    EqualityAtomicFormula::new(Term::Name("x".into()), Term::Name("y".into()))
+                ))
             ))
         );
 
         assert!(
-            EffectCondition::parse("(and (= x y) (not (= ?a B)))").is_value(
-                EffectCondition::All(vec![
-                    PrimitiveEffect::AtomicFormula(AtomicFormula::Equality(EqualityAtomicFormula::new(
-                        Term::Name("x".into()),
-                        Term::Name("y".into())
-                    ))),
-                    PrimitiveEffect::NotAtomicFormula(AtomicFormula::Equality(EqualityAtomicFormula::new(
-                        Term::Variable("a".into()),
-                        Term::Name("B".into())
-                    )))
-                ])
-            )
+            EffectCondition::parse("(and (= x y) (not (= ?a B)))").is_value(EffectCondition::All(
+                vec![
+                    PrimitiveEffect::AtomicFormula(AtomicFormula::Equality(
+                        EqualityAtomicFormula::new(Term::Name("x".into()), Term::Name("y".into()))
+                    )),
+                    PrimitiveEffect::NotAtomicFormula(AtomicFormula::Equality(
+                        EqualityAtomicFormula::new(
+                            Term::Variable("a".into()),
+                            Term::Name("B".into())
+                        )
+                    ))
+                ]
+            ))
         );
     }
 }

--- a/src/parsers/d_op.rs
+++ b/src/parsers/d_op.rs
@@ -6,19 +6,19 @@ use nom::combinator::map;
 use nom::Parser;
 
 use crate::parsers::{ParseResult, Span};
-use crate::types::{d_op::names, DOp};
+use crate::types::{d_op::names, DurationOperator};
 
 /// Parses a durative operation, i.e. `<= | >= | =`.
 ///
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_d_op, preamble::*};
-/// # use pddl::{DOp};
-/// assert!(parse_d_op("<=").is_value(DOp::LessThanOrEqual));
-/// assert!(parse_d_op(">=").is_value(DOp::GreaterOrEqual));
-/// assert!(parse_d_op("=").is_value(DOp::Equal));
+/// # use pddl::{DurationOperator};
+/// assert!(parse_d_op("<=").is_value(DurationOperator::LessThanOrEqual));
+/// assert!(parse_d_op(">=").is_value(DurationOperator::GreaterOrEqual));
+/// assert!(parse_d_op("=").is_value(DurationOperator::Equal));
 ///```
-pub fn parse_d_op<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, DOp> {
+pub fn parse_d_op<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, DurationOperator> {
     // :duration-inequalities
     map(
         alt((
@@ -26,21 +26,21 @@ pub fn parse_d_op<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, DOp> {
             tag(names::GREATER_OR_EQUAL),
             tag(names::EQUAL),
         )),
-        |x: Span| DOp::try_from(*x.fragment()).expect("unhandled variant"),
+        |x: Span| DurationOperator::try_from(*x.fragment()).expect("unhandled variant"),
     )
     .parse(input.into())
 }
 
-impl crate::parsers::Parser for DOp {
-    type Item = DOp;
+impl crate::parsers::Parser for DurationOperator {
+    type Item = DurationOperator;
 
     /// Parses a durative operation.
     ///
     /// ## Example
     /// ```
-    /// # use pddl::{DOp, Parser};
-    /// let (_, value) = DOp::parse("<=").unwrap();
-    /// assert_eq!(value, DOp::LessThanOrEqual);
+    /// # use pddl::{DurationOperator, Parser};
+    /// let (_, value) = DurationOperator::parse("<=").unwrap();
+    /// assert_eq!(value, DurationOperator::LessThanOrEqual);
     ///```
     ///
     /// ## See also
@@ -53,12 +53,12 @@ impl crate::parsers::Parser for DOp {
 #[cfg(test)]
 mod tests {
     use crate::parsers::UnwrapValue;
-    use crate::{DOp, Parser};
+    use crate::{DurationOperator, Parser};
 
     #[test]
     fn test_parse() {
-        assert!(DOp::parse("<=").is_value(DOp::LessThanOrEqual));
-        assert!(DOp::parse(">=").is_value(DOp::GreaterOrEqual));
-        assert!(DOp::parse("=").is_value(DOp::Equal));
+        assert!(DurationOperator::parse("<=").is_value(DurationOperator::LessThanOrEqual));
+        assert!(DurationOperator::parse(">=").is_value(DurationOperator::GreaterOrEqual));
+        assert!(DurationOperator::parse("=").is_value(DurationOperator::Equal));
     }
 }

--- a/src/parsers/d_value.rs
+++ b/src/parsers/d_value.rs
@@ -52,9 +52,9 @@ mod tests {
         assert!(DurationValue::parse("1.23").is_value(DurationValue::new_number(1.23)));
 
         assert!(
-            DurationValue::parse("fun-sym").is_value(DurationValue::new_f_exp(FluentExpression::new_function(
-                FunctionHead::Simple("fun-sym".into())
-            )))
+            DurationValue::parse("fun-sym").is_value(DurationValue::new_f_exp(
+                FluentExpression::new_function(FunctionHead::Simple("fun-sym".into()))
+            ))
         );
     }
 }

--- a/src/parsers/d_value.rs
+++ b/src/parsers/d_value.rs
@@ -13,14 +13,14 @@ use crate::types::DurationValue;
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_d_value, preamble::*};
-/// # use pddl::{BinaryOp, DurationValue, FExp, FHead, FunctionSymbol, MultiOp};
+/// # use pddl::{BinaryOp, DurationValue, FluentExpression, FunctionHead, FunctionSymbol, MultiOp};
 /// assert!(parse_d_value("1.23").is_value(
 ///     DurationValue::new_number(1.23)
 /// ));
 ///
 /// assert!(parse_d_value("fun-sym").is_value(
 ///     DurationValue::new_f_exp(
-///         FExp::new_function(FHead::Simple("fun-sym".into()))
+///         FluentExpression::new_function(FunctionHead::Simple("fun-sym".into()))
 ///     )
 /// ));
 ///```
@@ -45,15 +45,15 @@ impl crate::parsers::Parser for DurationValue {
 #[cfg(test)]
 mod tests {
     use crate::parsers::UnwrapValue;
-    use crate::{DurationValue, FExp, FHead, Parser};
+    use crate::{DurationValue, FluentExpression, FunctionHead, Parser};
 
     #[test]
     fn test_parse() {
         assert!(DurationValue::parse("1.23").is_value(DurationValue::new_number(1.23)));
 
         assert!(
-            DurationValue::parse("fun-sym").is_value(DurationValue::new_f_exp(FExp::new_function(
-                FHead::Simple("fun-sym".into())
+            DurationValue::parse("fun-sym").is_value(DurationValue::new_f_exp(FluentExpression::new_function(
+                FunctionHead::Simple("fun-sym".into())
             )))
         );
     }

--- a/src/parsers/d_value.rs
+++ b/src/parsers/d_value.rs
@@ -15,12 +15,12 @@ use crate::types::DurationValue;
 /// # use pddl::parsers::{parse_d_value, preamble::*};
 /// # use pddl::{BinaryOp, DurationValue, FluentExpression, FunctionHead, FunctionSymbol, MultiOp};
 /// assert!(parse_d_value("1.23").is_value(
-///     DurationValue::new_number(1.23)
+///     DurationValue::number(1.23)
 /// ));
 ///
 /// assert!(parse_d_value("fun-sym").is_value(
-///     DurationValue::new_f_exp(
-///         FluentExpression::new_function(FunctionHead::Simple("fun-sym".into()))
+///     DurationValue::fluent_expression(
+///         FluentExpression::function(FunctionHead::Simple("fun-sym".into()))
 ///     )
 /// ));
 ///```
@@ -49,11 +49,11 @@ mod tests {
 
     #[test]
     fn test_parse() {
-        assert!(DurationValue::parse("1.23").is_value(DurationValue::new_number(1.23)));
+        assert!(DurationValue::parse("1.23").is_value(DurationValue::number(1.23)));
 
         assert!(
-            DurationValue::parse("fun-sym").is_value(DurationValue::new_f_exp(
-                FluentExpression::new_function(FunctionHead::Simple("fun-sym".into()))
+            DurationValue::parse("fun-sym").is_value(DurationValue::fluent_expression(
+                FluentExpression::function(FunctionHead::Simple("fun-sym".into()))
             ))
         );
     }

--- a/src/parsers/da_def.rs
+++ b/src/parsers/da_def.rs
@@ -16,7 +16,7 @@ use nom::Parser;
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_action_def, parse_da_def, preamble::*};
-/// # use pddl::{ActionDefinition, ActionSymbol, AtomicFormula, ConditionalEffect, Effects, GoalDefinition, Literal, PrimitiveEffect, Predicate, Preference, PreferenceGD, PreconditionGoalDefinition, Term, Variable};
+/// # use pddl::{ActionDefinition, ActionSymbol, AtomicFormula, ConditionalEffect, Effects, GoalDefinition, Literal, PrimitiveEffect, Predicate, Preference, PreferenceGoalDefinition, PreconditionGoalDefinition, Term, Variable};
 /// let input = r#"(:durative-action move
 ///         :parameters
 ///             (?r - rover

--- a/src/parsers/da_def.rs
+++ b/src/parsers/da_def.rs
@@ -16,7 +16,7 @@ use nom::Parser;
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_action_def, parse_da_def, preamble::*};
-/// # use pddl::{ActionDefinition, ActionSymbol, AtomicFormula, CEffect, Effects, GoalDefinition, Literal, PEffect, Predicate, Preference, PreferenceGD, PreconditionGoalDefinition, Term, Variable};
+/// # use pddl::{ActionDefinition, ActionSymbol, AtomicFormula, ConditionalEffect, Effects, GoalDefinition, Literal, PrimitiveEffect, Predicate, Preference, PreferenceGD, PreconditionGoalDefinition, Term, Variable};
 /// let input = r#"(:durative-action move
 ///         :parameters
 ///             (?r - rover

--- a/src/parsers/da_effect.rs
+++ b/src/parsers/da_effect.rs
@@ -58,8 +58,8 @@ use nom::Parser;
 /// assert!(parse_da_effect("(forall (?a ?b) (at start (= a b)))").is_value(
 ///     DurativeActionEffect::new_forall(
 ///         TypedList::from_iter([
-///             Typed::new_object(Variable::new_string("a")),
-///             Typed::new_object(Variable::new_string("b")),
+///             Typed::object(Variable::new_string("a")),
+///             Typed::object(Variable::new_string("b")),
 ///         ]),
 ///         DurativeActionEffect::Timed(
 ///             TimedEffect::new_conditional(
@@ -158,7 +158,7 @@ mod tests {
     #[test]
     fn test_at_start() {
         assert!(DurativeActionEffect::parse("(at start (= x y))").is_value(
-            DurativeActionEffect::Timed(TimedEffect::new_conditional(
+            DurativeActionEffect::Timed(TimedEffect::conditional(
                 TimeSpecifier::Start,
                 EffectCondition::new(PrimitiveEffect::AtomicFormula(AtomicFormula::Equality(
                     EqualityAtomicFormula::new(Term::Name("x".into()), Term::Name("y".into()))
@@ -169,15 +169,15 @@ mod tests {
 
     #[test]
     fn test_and_empty() {
-        assert!(DurativeActionEffect::parse("(and )").is_value(DurativeActionEffect::new_and([])));
+        assert!(DurativeActionEffect::parse("(and )").is_value(DurativeActionEffect::and([])));
     }
 
     #[test]
     fn test_and() {
         assert!(
             DurativeActionEffect::parse("(and (at start (= x y)) (and ))").is_value(
-                DurativeActionEffect::new_and([
-                    DurativeActionEffect::Timed(TimedEffect::new_conditional(
+                DurativeActionEffect::and([
+                    DurativeActionEffect::Timed(TimedEffect::conditional(
                         TimeSpecifier::Start,
                         EffectCondition::new(PrimitiveEffect::AtomicFormula(
                             AtomicFormula::Equality(EqualityAtomicFormula::new(
@@ -186,7 +186,7 @@ mod tests {
                             ))
                         ))
                     )),
-                    DurativeActionEffect::new_and([])
+                    DurativeActionEffect::and([])
                 ])
             )
         );
@@ -196,12 +196,12 @@ mod tests {
     fn test_forall() {
         assert!(
             DurativeActionEffect::parse("(forall (?a ?b) (at start (= a b)))").is_value(
-                DurativeActionEffect::new_forall(
+                DurativeActionEffect::forall(
                     TypedList::from_iter([
-                        Typed::new_object(Variable::new_string("a")),
-                        Typed::new_object(Variable::new_string("b")),
+                        Typed::object(Variable::new_string("a")),
+                        Typed::object(Variable::new_string("b")),
                     ]),
-                    DurativeActionEffect::Timed(TimedEffect::new_conditional(
+                    DurativeActionEffect::Timed(TimedEffect::conditional(
                         TimeSpecifier::Start,
                         EffectCondition::new(PrimitiveEffect::AtomicFormula(
                             AtomicFormula::Equality(EqualityAtomicFormula::new(

--- a/src/parsers/da_effect.rs
+++ b/src/parsers/da_effect.rs
@@ -14,14 +14,14 @@ use nom::Parser;
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_da_effect, preamble::*};
-/// # use pddl::{AtomicFormula, ConditionalEffect, DurativeActionEffect, EqualityAtomicFormula, PEffect, Term, TimedEffect, TimeSpecifier, Variable};
+/// # use pddl::{AtomicFormula, EffectCondition, DurativeActionEffect, EqualityAtomicFormula, PrimitiveEffect, Term, TimedEffect, TimeSpecifier, Variable};
 /// # use pddl::{Typed, TypedList};
 /// assert!(parse_da_effect("(at start (= x y))").is_value(
 ///     DurativeActionEffect::Timed(
 ///         TimedEffect::new_conditional(
 ///             TimeSpecifier::Start,
-///             ConditionalEffect::new(
-///                 PEffect::AtomicFormula(AtomicFormula::Equality(
+///             EffectCondition::new(
+///                 PrimitiveEffect::AtomicFormula(AtomicFormula::Equality(
 ///                     EqualityAtomicFormula::new(
 ///                         Term::Name("x".into()),
 ///                         Term::Name("y".into()))
@@ -41,8 +41,8 @@ use nom::Parser;
 ///         DurativeActionEffect::Timed(
 ///             TimedEffect::new_conditional(
 ///                 TimeSpecifier::Start,
-///                 ConditionalEffect::new(
-///                     PEffect::AtomicFormula(AtomicFormula::Equality(
+///                 EffectCondition::new(
+///                     PrimitiveEffect::AtomicFormula(AtomicFormula::Equality(
 ///                         EqualityAtomicFormula::new(
 ///                             Term::Name("x".into()),
 ///                             Term::Name("y".into()))
@@ -64,8 +64,8 @@ use nom::Parser;
 ///         DurativeActionEffect::Timed(
 ///             TimedEffect::new_conditional(
 ///                 TimeSpecifier::Start,
-///                 ConditionalEffect::new(
-///                     PEffect::AtomicFormula(AtomicFormula::Equality(
+///                 EffectCondition::new(
+///                     PrimitiveEffect::AtomicFormula(AtomicFormula::Equality(
 ///                         EqualityAtomicFormula::new(
 ///                             Term::Name("a".into()),
 ///                             Term::Name("b".into()))
@@ -123,7 +123,7 @@ mod tests {
     use super::*;
     use crate::parsers::UnwrapValue;
     use crate::{
-        AtomicFormula, ConditionalEffect, EqualityAtomicFormula, PEffect, Parser, Term,
+        AtomicFormula, EffectCondition, EqualityAtomicFormula, PrimitiveEffect, Parser, Term,
         TimeSpecifier, TimedEffect, Typed, TypedList, Variable,
     };
 
@@ -160,7 +160,7 @@ mod tests {
         assert!(DurativeActionEffect::parse("(at start (= x y))").is_value(
             DurativeActionEffect::Timed(TimedEffect::new_conditional(
                 TimeSpecifier::Start,
-                ConditionalEffect::new(PEffect::AtomicFormula(AtomicFormula::Equality(
+                EffectCondition::new(PrimitiveEffect::AtomicFormula(AtomicFormula::Equality(
                     EqualityAtomicFormula::new(Term::Name("x".into()), Term::Name("y".into()))
                 )))
             ))
@@ -179,7 +179,7 @@ mod tests {
                 DurativeActionEffect::new_and([
                     DurativeActionEffect::Timed(TimedEffect::new_conditional(
                         TimeSpecifier::Start,
-                        ConditionalEffect::new(PEffect::AtomicFormula(AtomicFormula::Equality(
+                        EffectCondition::new(PrimitiveEffect::AtomicFormula(AtomicFormula::Equality(
                             EqualityAtomicFormula::new(
                                 Term::Name("x".into()),
                                 Term::Name("y".into())
@@ -203,7 +203,7 @@ mod tests {
                     ]),
                     DurativeActionEffect::Timed(TimedEffect::new_conditional(
                         TimeSpecifier::Start,
-                        ConditionalEffect::new(PEffect::AtomicFormula(AtomicFormula::Equality(
+                        EffectCondition::new(PrimitiveEffect::AtomicFormula(AtomicFormula::Equality(
                             EqualityAtomicFormula::new(
                                 Term::Name("a".into()),
                                 Term::Name("b".into())

--- a/src/parsers/da_effect.rs
+++ b/src/parsers/da_effect.rs
@@ -123,7 +123,7 @@ mod tests {
     use super::*;
     use crate::parsers::UnwrapValue;
     use crate::{
-        AtomicFormula, EffectCondition, EqualityAtomicFormula, PrimitiveEffect, Parser, Term,
+        AtomicFormula, EffectCondition, EqualityAtomicFormula, Parser, PrimitiveEffect, Term,
         TimeSpecifier, TimedEffect, Typed, TypedList, Variable,
     };
 
@@ -179,12 +179,12 @@ mod tests {
                 DurativeActionEffect::new_and([
                     DurativeActionEffect::Timed(TimedEffect::new_conditional(
                         TimeSpecifier::Start,
-                        EffectCondition::new(PrimitiveEffect::AtomicFormula(AtomicFormula::Equality(
-                            EqualityAtomicFormula::new(
+                        EffectCondition::new(PrimitiveEffect::AtomicFormula(
+                            AtomicFormula::Equality(EqualityAtomicFormula::new(
                                 Term::Name("x".into()),
                                 Term::Name("y".into())
-                            )
-                        )))
+                            ))
+                        ))
                     )),
                     DurativeActionEffect::new_and([])
                 ])
@@ -203,12 +203,12 @@ mod tests {
                     ]),
                     DurativeActionEffect::Timed(TimedEffect::new_conditional(
                         TimeSpecifier::Start,
-                        EffectCondition::new(PrimitiveEffect::AtomicFormula(AtomicFormula::Equality(
-                            EqualityAtomicFormula::new(
+                        EffectCondition::new(PrimitiveEffect::AtomicFormula(
+                            AtomicFormula::Equality(EqualityAtomicFormula::new(
                                 Term::Name("a".into()),
                                 Term::Name("b".into())
-                            )
-                        )))
+                            ))
+                        ))
                     ))
                 )
             )

--- a/src/parsers/da_gd.rs
+++ b/src/parsers/da_gd.rs
@@ -14,7 +14,7 @@ use nom::Parser;
 /// ## Examples
 /// ```
 /// # use pddl::parsers::{parse_da_gd, preamble::*};
-/// # use pddl::{AtomicFormula, EqualityAtomicFormula, GoalDefinition, Literal, Preference, PreferenceName, PreferenceGD, Term, Variable, DurativeActionGoalDefinition, PreferenceTimedGoalDefinition, TimedGoalDefinition, TimeSpecifier, Interval};
+/// # use pddl::{AtomicFormula, EqualityAtomicFormula, GoalDefinition, Literal, Preference, PreferenceName, PreferenceGoalDefinition, Term, Variable, DurativeActionGoalDefinition, PreferenceTimedGoalDefinition, TimedGoalDefinition, TimeSpecifier, Interval};
 /// # use pddl::{Typed, TypedList};
 /// assert!(parse_da_gd("(at start (= x y))").is_value(
 ///     DurativeActionGoalDefinition::Timed(
@@ -123,8 +123,8 @@ mod tests {
     use super::*;
     use crate::parsers::UnwrapValue;
     use crate::{
-        AtomicFormula, GoalDefinition, Interval, Parser, PreferenceTimedGoalDefinition, Term, TimeSpecifier, TimedGoalDefinition,
-        Typed, TypedList, Variable,
+        AtomicFormula, GoalDefinition, Interval, Parser, PreferenceTimedGoalDefinition, Term,
+        TimeSpecifier, TimedGoalDefinition, Typed, TypedList, Variable,
     };
 
     #[test]
@@ -143,13 +143,15 @@ mod tests {
     fn test_at_start() {
         assert!(
             DurativeActionGoalDefinition::parse("(at start (= x y))").is_value(
-                DurativeActionGoalDefinition::Timed(PreferenceTimedGoalDefinition::Required(TimedGoalDefinition::new_at(
-                    TimeSpecifier::Start,
-                    GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
-                        Term::Name("x".into()),
-                        Term::Name("y".into())
-                    ))
-                )))
+                DurativeActionGoalDefinition::Timed(PreferenceTimedGoalDefinition::Required(
+                    TimedGoalDefinition::new_at(
+                        TimeSpecifier::Start,
+                        GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
+                            Term::Name("x".into()),
+                            Term::Name("y".into())
+                        ))
+                    )
+                ))
             )
         );
     }
@@ -165,20 +167,24 @@ mod tests {
         assert!(
             DurativeActionGoalDefinition::parse("(and (at start (= x y)) (over all (= a b)))")
                 .is_value(DurativeActionGoalDefinition::new_and([
-                    DurativeActionGoalDefinition::Timed(PreferenceTimedGoalDefinition::Required(TimedGoalDefinition::new_at(
-                        TimeSpecifier::Start,
-                        GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
-                            Term::Name("x".into()),
-                            Term::Name("y".into())
-                        ))
-                    ))),
-                    DurativeActionGoalDefinition::Timed(PreferenceTimedGoalDefinition::Required(TimedGoalDefinition::new_over(
-                        Interval::All,
-                        GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
-                            Term::Name("a".into()),
-                            Term::Name("b".into())
-                        ))
-                    )))
+                    DurativeActionGoalDefinition::Timed(PreferenceTimedGoalDefinition::Required(
+                        TimedGoalDefinition::new_at(
+                            TimeSpecifier::Start,
+                            GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
+                                Term::Name("x".into()),
+                                Term::Name("y".into())
+                            ))
+                        )
+                    )),
+                    DurativeActionGoalDefinition::Timed(PreferenceTimedGoalDefinition::Required(
+                        TimedGoalDefinition::new_over(
+                            Interval::All,
+                            GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
+                                Term::Name("a".into()),
+                                Term::Name("b".into())
+                            ))
+                        )
+                    ))
                 ]))
         );
     }
@@ -192,13 +198,15 @@ mod tests {
                         Typed::new_object(Variable::new_string("a")),
                         Typed::new_object(Variable::new_string("b")),
                     ]),
-                    DurativeActionGoalDefinition::Timed(PreferenceTimedGoalDefinition::Required(TimedGoalDefinition::new_at(
-                        TimeSpecifier::Start,
-                        GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
-                            Term::Name("a".into()),
-                            Term::Name("b".into())
-                        ))
-                    )))
+                    DurativeActionGoalDefinition::Timed(PreferenceTimedGoalDefinition::Required(
+                        TimedGoalDefinition::new_at(
+                            TimeSpecifier::Start,
+                            GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
+                                Term::Name("a".into()),
+                                Term::Name("b".into())
+                            ))
+                        )
+                    ))
                 )
             )
         );

--- a/src/parsers/da_gd.rs
+++ b/src/parsers/da_gd.rs
@@ -19,10 +19,10 @@ use nom::Parser;
 /// assert!(parse_da_gd("(at start (= x y))").is_value(
 ///     DurativeActionGoalDefinition::Timed(
 ///             PreferenceTimedGoalDefinition::Required(
-///                 TimedGoalDefinition::new_at(
+///                 TimedGoalDefinition::at(
 ///                 TimeSpecifier::Start,
 ///                 GoalDefinition::AtomicFormula(
-///                     AtomicFormula::new_equality(
+///                     AtomicFormula::equality(
 ///                         Term::Name("x".into()),
 ///                         Term::Name("y".into())
 ///                     )
@@ -33,16 +33,16 @@ use nom::Parser;
 /// ));
 ///
 /// assert!(parse_da_gd("(and )").is_value(
-///     DurativeActionGoalDefinition::new_and([])
+///     DurativeActionGoalDefinition::and([])
 /// ));
 ///
 /// assert!(parse_da_gd("(and (at start (= x y)) (over all (= a b)))").is_value(
-///     DurativeActionGoalDefinition::new_and([
+///     DurativeActionGoalDefinition::and([
 ///         DurativeActionGoalDefinition::Timed(PreferenceTimedGoalDefinition::Required(
-///             TimedGoalDefinition::new_at(
+///             TimedGoalDefinition::at(
 ///                 TimeSpecifier::Start,
 ///                 GoalDefinition::AtomicFormula(
-///                     AtomicFormula::new_equality(
+///                     AtomicFormula::equality(
 ///                         Term::Name("x".into()),
 ///                         Term::Name("y".into())
 ///                     )
@@ -50,10 +50,10 @@ use nom::Parser;
 ///             )
 ///         )),
 ///         DurativeActionGoalDefinition::Timed(PreferenceTimedGoalDefinition::Required(
-///             TimedGoalDefinition::new_over(
+///             TimedGoalDefinition::over(
 ///                 Interval::All,
 ///                 GoalDefinition::AtomicFormula(
-///                     AtomicFormula::new_equality(
+///                     AtomicFormula::equality(
 ///                         Term::Name("a".into()),
 ///                         Term::Name("b".into())
 ///                     )
@@ -64,17 +64,17 @@ use nom::Parser;
 /// ));
 ///
 /// assert!(parse_da_gd("(forall (?a ?b) (at start (= a b)))").is_value(
-///     DurativeActionGoalDefinition::new_forall(
+///     DurativeActionGoalDefinition::forall(
 ///         TypedList::from_iter([
-///             Typed::new_object(Variable::new_string("a")),
-///             Typed::new_object(Variable::new_string("b")),
+///             Typed::object(Variable::string("a")),
+///             Typed::object(Variable::string("b")),
 ///         ]),
 ///         DurativeActionGoalDefinition::Timed(
 ///             PreferenceTimedGoalDefinition::Required(
-///                 TimedGoalDefinition::new_at(
+///                 TimedGoalDefinition::at(
 ///                     TimeSpecifier::Start,
 ///                     GoalDefinition::AtomicFormula(
-///                         AtomicFormula::new_equality(
+///                         AtomicFormula::equality(
 ///                             Term::Name("a".into()),
 ///                             Term::Name("b".into())
 ///                         )
@@ -103,7 +103,7 @@ pub fn parse_da_gd<'a, T: Into<Span<'a>>>(
                 preceded(multispace1, parse_da_gd),
             ),
         ),
-        |(vars, gd)| DurativeActionGoalDefinition::new_forall(vars, gd),
+        |(vars, gd)| DurativeActionGoalDefinition::forall(vars, gd),
     );
 
     alt((forall, and, pref_timed_gd)).parse(input.into())
@@ -144,9 +144,9 @@ mod tests {
         assert!(
             DurativeActionGoalDefinition::parse("(at start (= x y))").is_value(
                 DurativeActionGoalDefinition::Timed(PreferenceTimedGoalDefinition::Required(
-                    TimedGoalDefinition::new_at(
+                    TimedGoalDefinition::at(
                         TimeSpecifier::Start,
-                        GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
+                        GoalDefinition::AtomicFormula(AtomicFormula::equality(
                             Term::Name("x".into()),
                             Term::Name("y".into())
                         ))
@@ -159,27 +159,27 @@ mod tests {
     #[test]
     fn test_and_empty() {
         assert!(DurativeActionGoalDefinition::parse("(and )")
-            .is_value(DurativeActionGoalDefinition::new_and([])));
+            .is_value(DurativeActionGoalDefinition::and([])));
     }
 
     #[test]
     fn test_and() {
         assert!(
             DurativeActionGoalDefinition::parse("(and (at start (= x y)) (over all (= a b)))")
-                .is_value(DurativeActionGoalDefinition::new_and([
+                .is_value(DurativeActionGoalDefinition::and([
                     DurativeActionGoalDefinition::Timed(PreferenceTimedGoalDefinition::Required(
-                        TimedGoalDefinition::new_at(
+                        TimedGoalDefinition::at(
                             TimeSpecifier::Start,
-                            GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
+                            GoalDefinition::AtomicFormula(AtomicFormula::equality(
                                 Term::Name("x".into()),
                                 Term::Name("y".into())
                             ))
                         )
                     )),
                     DurativeActionGoalDefinition::Timed(PreferenceTimedGoalDefinition::Required(
-                        TimedGoalDefinition::new_over(
+                        TimedGoalDefinition::over(
                             Interval::All,
-                            GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
+                            GoalDefinition::AtomicFormula(AtomicFormula::equality(
                                 Term::Name("a".into()),
                                 Term::Name("b".into())
                             ))
@@ -193,15 +193,15 @@ mod tests {
     fn test_forall() {
         assert!(
             DurativeActionGoalDefinition::parse("(forall (?a ?b) (at start (= a b)))").is_value(
-                DurativeActionGoalDefinition::new_forall(
+                DurativeActionGoalDefinition::forall(
                     TypedList::from_iter([
-                        Typed::new_object(Variable::new_string("a")),
-                        Typed::new_object(Variable::new_string("b")),
+                        Typed::object(Variable::string("a")),
+                        Typed::object(Variable::string("b")),
                     ]),
                     DurativeActionGoalDefinition::Timed(PreferenceTimedGoalDefinition::Required(
-                        TimedGoalDefinition::new_at(
+                        TimedGoalDefinition::at(
                             TimeSpecifier::Start,
-                            GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
+                            GoalDefinition::AtomicFormula(AtomicFormula::equality(
                                 Term::Name("a".into()),
                                 Term::Name("b".into())
                             ))

--- a/src/parsers/da_gd.rs
+++ b/src/parsers/da_gd.rs
@@ -14,12 +14,12 @@ use nom::Parser;
 /// ## Examples
 /// ```
 /// # use pddl::parsers::{parse_da_gd, preamble::*};
-/// # use pddl::{AtomicFormula, EqualityAtomicFormula, GoalDefinition, Literal, Preference, PreferenceName, PreferenceGD, Term, Variable, DurativeActionGoalDefinition, PrefTimedGD, TimedGD, TimeSpecifier, Interval};
+/// # use pddl::{AtomicFormula, EqualityAtomicFormula, GoalDefinition, Literal, Preference, PreferenceName, PreferenceGD, Term, Variable, DurativeActionGoalDefinition, PreferenceTimedGoalDefinition, TimedGoalDefinition, TimeSpecifier, Interval};
 /// # use pddl::{Typed, TypedList};
 /// assert!(parse_da_gd("(at start (= x y))").is_value(
 ///     DurativeActionGoalDefinition::Timed(
-///         PrefTimedGD::Required(
-///             TimedGD::new_at(
+///             PreferenceTimedGoalDefinition::Required(
+///                 TimedGoalDefinition::new_at(
 ///                 TimeSpecifier::Start,
 ///                 GoalDefinition::AtomicFormula(
 ///                     AtomicFormula::new_equality(
@@ -38,8 +38,8 @@ use nom::Parser;
 ///
 /// assert!(parse_da_gd("(and (at start (= x y)) (over all (= a b)))").is_value(
 ///     DurativeActionGoalDefinition::new_and([
-///         DurativeActionGoalDefinition::Timed(PrefTimedGD::Required(
-///             TimedGD::new_at(
+///         DurativeActionGoalDefinition::Timed(PreferenceTimedGoalDefinition::Required(
+///             TimedGoalDefinition::new_at(
 ///                 TimeSpecifier::Start,
 ///                 GoalDefinition::AtomicFormula(
 ///                     AtomicFormula::new_equality(
@@ -49,8 +49,8 @@ use nom::Parser;
 ///                 )
 ///             )
 ///         )),
-///         DurativeActionGoalDefinition::Timed(PrefTimedGD::Required(
-///             TimedGD::new_over(
+///         DurativeActionGoalDefinition::Timed(PreferenceTimedGoalDefinition::Required(
+///             TimedGoalDefinition::new_over(
 ///                 Interval::All,
 ///                 GoalDefinition::AtomicFormula(
 ///                     AtomicFormula::new_equality(
@@ -70,8 +70,8 @@ use nom::Parser;
 ///             Typed::new_object(Variable::new_string("b")),
 ///         ]),
 ///         DurativeActionGoalDefinition::Timed(
-///             PrefTimedGD::Required(
-///                 TimedGD::new_at(
+///             PreferenceTimedGoalDefinition::Required(
+///                 TimedGoalDefinition::new_at(
 ///                     TimeSpecifier::Start,
 ///                     GoalDefinition::AtomicFormula(
 ///                         AtomicFormula::new_equality(
@@ -123,7 +123,7 @@ mod tests {
     use super::*;
     use crate::parsers::UnwrapValue;
     use crate::{
-        AtomicFormula, GoalDefinition, Interval, Parser, PrefTimedGD, Term, TimeSpecifier, TimedGD,
+        AtomicFormula, GoalDefinition, Interval, Parser, PreferenceTimedGoalDefinition, Term, TimeSpecifier, TimedGoalDefinition,
         Typed, TypedList, Variable,
     };
 
@@ -143,7 +143,7 @@ mod tests {
     fn test_at_start() {
         assert!(
             DurativeActionGoalDefinition::parse("(at start (= x y))").is_value(
-                DurativeActionGoalDefinition::Timed(PrefTimedGD::Required(TimedGD::new_at(
+                DurativeActionGoalDefinition::Timed(PreferenceTimedGoalDefinition::Required(TimedGoalDefinition::new_at(
                     TimeSpecifier::Start,
                     GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
                         Term::Name("x".into()),
@@ -165,14 +165,14 @@ mod tests {
         assert!(
             DurativeActionGoalDefinition::parse("(and (at start (= x y)) (over all (= a b)))")
                 .is_value(DurativeActionGoalDefinition::new_and([
-                    DurativeActionGoalDefinition::Timed(PrefTimedGD::Required(TimedGD::new_at(
+                    DurativeActionGoalDefinition::Timed(PreferenceTimedGoalDefinition::Required(TimedGoalDefinition::new_at(
                         TimeSpecifier::Start,
                         GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
                             Term::Name("x".into()),
                             Term::Name("y".into())
                         ))
                     ))),
-                    DurativeActionGoalDefinition::Timed(PrefTimedGD::Required(TimedGD::new_over(
+                    DurativeActionGoalDefinition::Timed(PreferenceTimedGoalDefinition::Required(TimedGoalDefinition::new_over(
                         Interval::All,
                         GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
                             Term::Name("a".into()),
@@ -192,7 +192,7 @@ mod tests {
                         Typed::new_object(Variable::new_string("a")),
                         Typed::new_object(Variable::new_string("b")),
                     ]),
-                    DurativeActionGoalDefinition::Timed(PrefTimedGD::Required(TimedGD::new_at(
+                    DurativeActionGoalDefinition::Timed(PreferenceTimedGoalDefinition::Required(TimedGoalDefinition::new_at(
                         TimeSpecifier::Start,
                         GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
                             Term::Name("a".into()),

--- a/src/parsers/domain_constraints_def.rs
+++ b/src/parsers/domain_constraints_def.rs
@@ -11,12 +11,12 @@ use crate::types::DomainConstraintsDef;
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_domain_constraints_def, parse_functions_def, preamble::*};
-/// # use pddl::{Variable, AtomicFormulaSkeleton, Predicate, PredicateDefinitions, FunctionTypedList, FunctionTyped, AtomicFunctionSkeleton, FunctionSymbol, Functions, ConGD, DomainConstraintsDef};
+/// # use pddl::{Variable, AtomicFormulaSkeleton, Predicate, PredicateDefinitions, FunctionTypedList, FunctionTyped, AtomicFunctionSkeleton, FunctionSymbol, Functions, ConstraintGoalDefinition, DomainConstraintsDef};
 /// # use pddl::{Type, Typed, TypedList};
 ///
 /// let input = "(:constraints (and))";
 /// assert!(parse_domain_constraints_def(input).is_value(
-///     DomainConstraintsDef::new(ConGD::new_and([]))
+///     DomainConstraintsDef::new(ConstraintGoalDefinition::new_and([]))
 /// ));
 /// ```
 pub fn parse_domain_constraints_def<'a, T: Into<Span<'a>>>(
@@ -41,12 +41,12 @@ impl crate::parsers::Parser for DomainConstraintsDef {
 #[cfg(test)]
 mod tests {
     use crate::parsers::UnwrapValue;
-    use crate::{ConGD, DomainConstraintsDef, Parser};
+    use crate::{ConstraintGoalDefinition, DomainConstraintsDef, Parser};
 
     #[test]
     fn test_parse() {
         let input = "(:constraints (and))";
         assert!(DomainConstraintsDef::parse(input)
-            .is_value(DomainConstraintsDef::new(ConGD::new_and([]))));
+            .is_value(DomainConstraintsDef::new(ConstraintGoalDefinition::new_and([]))));
     }
 }

--- a/src/parsers/domain_constraints_def.rs
+++ b/src/parsers/domain_constraints_def.rs
@@ -46,7 +46,10 @@ mod tests {
     #[test]
     fn test_parse() {
         let input = "(:constraints (and))";
-        assert!(DomainConstraintsDef::parse(input)
-            .is_value(DomainConstraintsDef::new(ConstraintGoalDefinition::new_and([]))));
+        assert!(
+            DomainConstraintsDef::parse(input).is_value(DomainConstraintsDef::new(
+                ConstraintGoalDefinition::new_and([])
+            ))
+        );
     }
 }

--- a/src/parsers/domain_constraints_def.rs
+++ b/src/parsers/domain_constraints_def.rs
@@ -16,7 +16,7 @@ use crate::types::DomainConstraintsDef;
 ///
 /// let input = "(:constraints (and))";
 /// assert!(parse_domain_constraints_def(input).is_value(
-///     DomainConstraintsDef::new(ConstraintGoalDefinition::new_and([]))
+///     DomainConstraintsDef::new(ConstraintGoalDefinition::and([]))
 /// ));
 /// ```
 pub fn parse_domain_constraints_def<'a, T: Into<Span<'a>>>(
@@ -46,10 +46,7 @@ mod tests {
     #[test]
     fn test_parse() {
         let input = "(:constraints (and))";
-        assert!(
-            DomainConstraintsDef::parse(input).is_value(DomainConstraintsDef::new(
-                ConstraintGoalDefinition::new_and([])
-            ))
-        );
+        assert!(DomainConstraintsDef::parse(input)
+            .is_value(DomainConstraintsDef::new(ConstraintGoalDefinition::and([]))));
     }
 }

--- a/src/parsers/duration_constraint.rs
+++ b/src/parsers/duration_constraint.rs
@@ -91,7 +91,7 @@ impl crate::parsers::Parser for DurationConstraint {
 mod tests {
     use crate::parsers::UnwrapValue;
     use crate::{
-        DOp, DurationConstraint, DurationValue, Parser, SimpleDurationConstraint, TimeSpecifier,
+        DurationConstraint, DurationOperator, DurationValue, Parser, SimpleDurationConstraint, TimeSpecifier,
     };
 
     #[test]
@@ -102,7 +102,7 @@ mod tests {
         let input = "(= ?duration 5)";
         assert!(
             DurationConstraint::parse(input).is_value(Some(DurationConstraint::new(
-                SimpleDurationConstraint::Op(DOp::Equal, DurationValue::Number(5.into()))
+                SimpleDurationConstraint::Op(DurationOperator::Equal, DurationValue::Number(5.into()))
             )))
         );
 
@@ -112,7 +112,7 @@ mod tests {
                 SimpleDurationConstraint::new_at(
                     TimeSpecifier::End,
                     SimpleDurationConstraint::Op(
-                        DOp::LessThanOrEqual,
+                        DurationOperator::LessThanOrEqual,
                         DurationValue::Number(1.23.into())
                     )
                 )
@@ -125,12 +125,12 @@ mod tests {
                 SimpleDurationConstraint::new_at(
                     TimeSpecifier::End,
                     SimpleDurationConstraint::Op(
-                        DOp::LessThanOrEqual,
+                        DurationOperator::LessThanOrEqual,
                         DurationValue::Number(1.23.into())
                     )
                 ),
                 SimpleDurationConstraint::new_op(
-                    DOp::GreaterOrEqual,
+                    DurationOperator::GreaterOrEqual,
                     DurationValue::Number(1.0.into())
                 )
             ])))

--- a/src/parsers/duration_constraint.rs
+++ b/src/parsers/duration_constraint.rs
@@ -91,7 +91,8 @@ impl crate::parsers::Parser for DurationConstraint {
 mod tests {
     use crate::parsers::UnwrapValue;
     use crate::{
-        DurationConstraint, DurationOperator, DurationValue, Parser, SimpleDurationConstraint, TimeSpecifier,
+        DurationConstraint, DurationOperator, DurationValue, Parser, SimpleDurationConstraint,
+        TimeSpecifier,
     };
 
     #[test]
@@ -102,7 +103,10 @@ mod tests {
         let input = "(= ?duration 5)";
         assert!(
             DurationConstraint::parse(input).is_value(Some(DurationConstraint::new(
-                SimpleDurationConstraint::Op(DurationOperator::Equal, DurationValue::Number(5.into()))
+                SimpleDurationConstraint::Op(
+                    DurationOperator::Equal,
+                    DurationValue::Number(5.into())
+                )
             )))
         );
 

--- a/src/parsers/effects.rs
+++ b/src/parsers/effects.rs
@@ -69,16 +69,18 @@ impl crate::parsers::Parser for Effects {
 #[cfg(test)]
 mod tests {
     use crate::parsers::UnwrapValue;
-    use crate::{AtomicFormula, ConditionalEffect, Effects, EqualityAtomicFormula, PrimitiveEffect, Parser, Term};
+    use crate::{
+        AtomicFormula, ConditionalEffect, Effects, EqualityAtomicFormula, Parser, PrimitiveEffect,
+        Term,
+    };
 
     #[test]
     fn test_parse() {
         assert!(
             Effects::parse("(= x y)").is_value(Effects::new(ConditionalEffect::Effect(
-                PrimitiveEffect::AtomicFormula(AtomicFormula::Equality(EqualityAtomicFormula::new(
-                    Term::Name("x".into()),
-                    Term::Name("y".into())
-                )))
+                PrimitiveEffect::AtomicFormula(AtomicFormula::Equality(
+                    EqualityAtomicFormula::new(Term::Name("x".into()), Term::Name("y".into()))
+                ))
             )))
         );
         assert!(
@@ -86,9 +88,12 @@ mod tests {
                 ConditionalEffect::Effect(PrimitiveEffect::AtomicFormula(AtomicFormula::Equality(
                     EqualityAtomicFormula::new(Term::Name("x".into()), Term::Name("y".into()))
                 ))),
-                ConditionalEffect::Effect(PrimitiveEffect::NotAtomicFormula(AtomicFormula::Equality(
-                    EqualityAtomicFormula::new(Term::Variable("a".into()), Term::Name("B".into()))
-                )))
+                ConditionalEffect::Effect(PrimitiveEffect::NotAtomicFormula(
+                    AtomicFormula::Equality(EqualityAtomicFormula::new(
+                        Term::Variable("a".into()),
+                        Term::Name("B".into())
+                    ))
+                ))
             ]))
         );
     }

--- a/src/parsers/effects.rs
+++ b/src/parsers/effects.rs
@@ -13,11 +13,11 @@ use crate::types::Effects;
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_effect, preamble::*};
-/// # use pddl::{AtomicFormula, CEffect, Effects, EqualityAtomicFormula, PEffect, Term};
+/// # use pddl::{AtomicFormula, ConditionalEffect, Effects, EqualityAtomicFormula, PrimitiveEffect, Term};
 /// assert!(parse_effect("(= x y)").is_value(
 ///     Effects::new(
-///         CEffect::Effect(
-///             PEffect::AtomicFormula(AtomicFormula::Equality(
+///         ConditionalEffect::Effect(
+///             PrimitiveEffect::AtomicFormula(AtomicFormula::Equality(
 ///                 EqualityAtomicFormula::new(
 ///                     Term::Name("x".into()),
 ///                     Term::Name("y".into()))
@@ -28,16 +28,16 @@ use crate::types::Effects;
 /// ));
 /// assert!(parse_effect("(and (= x y) (not (= ?a B)))").is_value(
 ///     Effects::from_iter([
-///         CEffect::Effect(
-///             PEffect::AtomicFormula(AtomicFormula::Equality(
+///         ConditionalEffect::Effect(
+///             PrimitiveEffect::AtomicFormula(AtomicFormula::Equality(
 ///                 EqualityAtomicFormula::new(
 ///                     Term::Name("x".into()),
 ///                     Term::Name("y".into()))
 ///                 )
 ///             )
 ///         ),
-///         CEffect::Effect(
-///             PEffect::NotAtomicFormula(AtomicFormula::Equality(
+///         ConditionalEffect::Effect(
+///             PrimitiveEffect::NotAtomicFormula(AtomicFormula::Equality(
 ///                 EqualityAtomicFormula::new(
 ///                     Term::Variable("a".into()),
 ///                     Term::Name("B".into()))
@@ -69,13 +69,13 @@ impl crate::parsers::Parser for Effects {
 #[cfg(test)]
 mod tests {
     use crate::parsers::UnwrapValue;
-    use crate::{AtomicFormula, CEffect, Effects, EqualityAtomicFormula, PEffect, Parser, Term};
+    use crate::{AtomicFormula, ConditionalEffect, Effects, EqualityAtomicFormula, PrimitiveEffect, Parser, Term};
 
     #[test]
     fn test_parse() {
         assert!(
-            Effects::parse("(= x y)").is_value(Effects::new(CEffect::Effect(
-                PEffect::AtomicFormula(AtomicFormula::Equality(EqualityAtomicFormula::new(
+            Effects::parse("(= x y)").is_value(Effects::new(ConditionalEffect::Effect(
+                PrimitiveEffect::AtomicFormula(AtomicFormula::Equality(EqualityAtomicFormula::new(
                     Term::Name("x".into()),
                     Term::Name("y".into())
                 )))
@@ -83,10 +83,10 @@ mod tests {
         );
         assert!(
             Effects::parse("(and (= x y) (not (= ?a B)))").is_value(Effects::from_iter([
-                CEffect::Effect(PEffect::AtomicFormula(AtomicFormula::Equality(
+                ConditionalEffect::Effect(PrimitiveEffect::AtomicFormula(AtomicFormula::Equality(
                     EqualityAtomicFormula::new(Term::Name("x".into()), Term::Name("y".into()))
                 ))),
-                CEffect::Effect(PEffect::NotAtomicFormula(AtomicFormula::Equality(
+                ConditionalEffect::Effect(PrimitiveEffect::NotAtomicFormula(AtomicFormula::Equality(
                     EqualityAtomicFormula::new(Term::Variable("a".into()), Term::Name("B".into()))
                 )))
             ]))

--- a/src/parsers/f_assign_da.rs
+++ b/src/parsers/f_assign_da.rs
@@ -2,7 +2,7 @@
 
 use crate::parsers::{parens, ParseResult, Span};
 use crate::parsers::{parse_assign_op, parse_f_exp_da, parse_f_head};
-use crate::types::FAssignDa;
+use crate::types::DurativeActionFunctionAssignment;
 use nom::character::complete::multispace1;
 use nom::combinator::map;
 use nom::sequence::preceded;
@@ -15,20 +15,20 @@ use nom::Parser;
 /// # use pddl::parsers::parse_f_assign_da;
 /// assert!(parse_f_assign_da("(assign fun-sym ?duration)").is_ok());
 ///```
-pub fn parse_f_assign_da<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FAssignDa> {
+pub fn parse_f_assign_da<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, DurativeActionFunctionAssignment> {
     map(
         parens((
             parse_assign_op,
             preceded(multispace1, parse_f_head),
             preceded(multispace1, parse_f_exp_da),
         )),
-        FAssignDa::from,
+        DurativeActionFunctionAssignment::from,
     )
     .parse(input.into())
 }
 
-impl crate::parsers::Parser for FAssignDa {
-    type Item = FAssignDa;
+impl crate::parsers::Parser for DurativeActionFunctionAssignment {
+    type Item = DurativeActionFunctionAssignment;
 
     /// See [`parse_f_assign_da`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
@@ -44,6 +44,6 @@ mod tests {
     #[test]
     fn it_works() {
         let input = "(increase (distance-travelled) 5)";
-        let (_, _effect) = FAssignDa::parse(Span::new(input)).unwrap();
+        let (_, _effect) = DurativeActionFunctionAssignment::parse(Span::new(input)).unwrap();
     }
 }

--- a/src/parsers/f_assign_da.rs
+++ b/src/parsers/f_assign_da.rs
@@ -15,7 +15,9 @@ use nom::Parser;
 /// # use pddl::parsers::parse_f_assign_da;
 /// assert!(parse_f_assign_da("(assign fun-sym ?duration)").is_ok());
 ///```
-pub fn parse_f_assign_da<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, DurativeActionFunctionAssignment> {
+pub fn parse_f_assign_da<'a, T: Into<Span<'a>>>(
+    input: T,
+) -> ParseResult<'a, DurativeActionFunctionAssignment> {
     map(
         parens((
             parse_assign_op,

--- a/src/parsers/f_comp.rs
+++ b/src/parsers/f_comp.rs
@@ -7,44 +7,44 @@ use nom::Parser;
 
 use crate::parsers::{parens, ParseResult, Span};
 use crate::parsers::{parse_binary_comp, parse_f_exp};
-use crate::types::FComp;
+use crate::types::FluentComparison;
 
 /// Parses an f-comp.
 ///
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_f_comp, preamble::*};
-/// # use pddl::{FunctionTerm, Variable, FunctionSymbol, Term, FComp, BinaryComp, FExp, BinaryOp};
+/// # use pddl::{FunctionTerm, Variable, FunctionSymbol, Term, FluentComparison, BinaryComparison, FluentExpression, BinaryOp};
 /// assert!(parse_f_comp("(= (+ 1.23 2.34) (+ 1.23 2.34))").is_value(
-///     FComp::new(
-///         BinaryComp::Equal,
-///         FExp::new_binary_op(
+///     FluentComparison::new(
+///         BinaryComparison::Equal,
+///         FluentExpression::new_binary_op(
 ///             BinaryOp::Addition,
-///             FExp::new_number(1.23),
-///             FExp::new_number(2.34),
+///             FluentExpression::new_number(1.23),
+///             FluentExpression::new_number(2.34),
 ///         ),
-///         FExp::new_binary_op(
+///         FluentExpression::new_binary_op(
 ///             BinaryOp::Addition,
-///             FExp::new_number(1.23),
-///             FExp::new_number(2.34),
+///             FluentExpression::new_number(1.23),
+///             FluentExpression::new_number(2.34),
 ///         )
 ///     )
 /// ));
 ///```
-pub fn parse_f_comp<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FComp> {
+pub fn parse_f_comp<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FluentComparison> {
     map(
         parens((
             parse_binary_comp,
             preceded(multispace1, parse_f_exp),
             preceded(multispace1, parse_f_exp),
         )),
-        FComp::from,
+        FluentComparison::from,
     )
     .parse(input.into())
 }
 
-impl crate::parsers::Parser for FComp {
-    type Item = FComp;
+impl crate::parsers::Parser for FluentComparison {
+    type Item = FluentComparison;
 
     /// See [`parse_f_comp`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
@@ -55,22 +55,22 @@ impl crate::parsers::Parser for FComp {
 #[cfg(test)]
 mod tests {
     use crate::parsers::UnwrapValue;
-    use crate::{BinaryComp, BinaryOp, FComp, FExp, Parser};
+    use crate::{BinaryComparison, BinaryOp, FluentComparison, FluentExpression, Parser};
 
     #[test]
     fn test_parse() {
         assert!(
-            FComp::parse("(= (+ 1.23 2.34) (+ 1.23 2.34))").is_value(FComp::new(
-                BinaryComp::Equal,
-                FExp::new_binary_op(
+            FluentComparison::parse("(= (+ 1.23 2.34) (+ 1.23 2.34))").is_value(FluentComparison::new(
+                BinaryComparison::Equal,
+                FluentExpression::new_binary_op(
                     BinaryOp::Addition,
-                    FExp::new_number(1.23),
-                    FExp::new_number(2.34),
+                    FluentExpression::new_number(1.23),
+                    FluentExpression::new_number(2.34),
                 ),
-                FExp::new_binary_op(
+                FluentExpression::new_binary_op(
                     BinaryOp::Addition,
-                    FExp::new_number(1.23),
-                    FExp::new_number(2.34),
+                    FluentExpression::new_number(1.23),
+                    FluentExpression::new_number(2.34),
                 )
             ))
         );

--- a/src/parsers/f_comp.rs
+++ b/src/parsers/f_comp.rs
@@ -60,19 +60,21 @@ mod tests {
     #[test]
     fn test_parse() {
         assert!(
-            FluentComparison::parse("(= (+ 1.23 2.34) (+ 1.23 2.34))").is_value(FluentComparison::new(
-                BinaryComparison::Equal,
-                FluentExpression::new_binary_op(
-                    BinaryOp::Addition,
-                    FluentExpression::new_number(1.23),
-                    FluentExpression::new_number(2.34),
-                ),
-                FluentExpression::new_binary_op(
-                    BinaryOp::Addition,
-                    FluentExpression::new_number(1.23),
-                    FluentExpression::new_number(2.34),
+            FluentComparison::parse("(= (+ 1.23 2.34) (+ 1.23 2.34))").is_value(
+                FluentComparison::new(
+                    BinaryComparison::Equal,
+                    FluentExpression::new_binary_op(
+                        BinaryOp::Addition,
+                        FluentExpression::new_number(1.23),
+                        FluentExpression::new_number(2.34),
+                    ),
+                    FluentExpression::new_binary_op(
+                        BinaryOp::Addition,
+                        FluentExpression::new_number(1.23),
+                        FluentExpression::new_number(2.34),
+                    )
                 )
-            ))
+            )
         );
     }
 }

--- a/src/parsers/f_exp.rs
+++ b/src/parsers/f_exp.rs
@@ -8,47 +8,47 @@ use nom::Parser;
 
 use crate::parsers::{parens, parse_number, space_separated_list1, ParseResult, Span};
 use crate::parsers::{parse_binary_op, parse_f_head, parse_multi_op};
-use crate::types::FExp;
+use crate::types::FluentExpression;
 
 /// Parses an f-exp.
 ///
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_f_exp, preamble::*};
-/// # use pddl::{BinaryOp, FExp, FHead, FunctionSymbol, MultiOp};
+/// # use pddl::{BinaryOp, FluentExpression, FunctionHead, FunctionSymbol, MultiOp};
 /// assert!(parse_f_exp("1.23").is_value(
-///     FExp::new_number(1.23)
+///     FluentExpression::new_number(1.23)
 /// ));
 ///
 /// assert!(parse_f_exp("(+ 1.23 2.34)").is_value(
-///     FExp::new_binary_op(
+///     FluentExpression::new_binary_op(
 ///         BinaryOp::Addition,
-///         FExp::new_number(1.23),
-///         FExp::new_number(2.34)
+///         FluentExpression::new_number(1.23),
+///         FluentExpression::new_number(2.34)
 ///     )
 /// ));
 ///
 /// assert!(parse_f_exp("(+ 1.23 2.34 3.45)").is_value(
-///     FExp::new_multi_op(
+///     FluentExpression::new_multi_op(
 ///         MultiOp::Addition,
-///         FExp::new_number(1.23),
-///         [FExp::new_number(2.34), FExp::new_number(3.45)]
+///         FluentExpression::new_number(1.23),
+///         [FluentExpression::new_number(2.34), FluentExpression::new_number(3.45)]
 ///     )
 /// ));
 ///
 /// assert!(parse_f_exp("(- 1.23)").is_value(
-///     FExp::new_negative(FExp::new_number(1.23))
+///     FluentExpression::new_negative(FluentExpression::new_number(1.23))
 /// ));
 ///
 /// assert!(parse_f_exp("fun-sym").is_value(
-///     FExp::new_function(
-///         FHead::new(FunctionSymbol::new_string("fun-sym"))
+///     FluentExpression::new_function(
+///         FunctionHead::new(FunctionSymbol::new_string("fun-sym"))
 ///     )
 /// ));
 ///```
-pub fn parse_f_exp<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FExp> {
+pub fn parse_f_exp<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FluentExpression> {
     // :numeric-fluents
-    let number = map(parse_number, FExp::new_number);
+    let number = map(parse_number, FluentExpression::new_number);
 
     // :numeric-fluents
     let binary_op = map(
@@ -57,7 +57,7 @@ pub fn parse_f_exp<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FExp> {
             preceded(multispace1, parse_f_exp),
             preceded(multispace1, parse_f_exp),
         )),
-        |(op, lhs, rhs)| FExp::new_binary_op(op, lhs, rhs),
+        |(op, lhs, rhs)| FluentExpression::new_binary_op(op, lhs, rhs),
     );
 
     // :numeric-fluents
@@ -67,23 +67,23 @@ pub fn parse_f_exp<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FExp> {
             preceded(multispace1, parse_f_exp),
             preceded(multispace1, space_separated_list1(parse_f_exp)),
         )),
-        |(op, lhs, rhs)| FExp::new_multi_op(op, lhs, rhs),
+        |(op, lhs, rhs)| FluentExpression::new_multi_op(op, lhs, rhs),
     );
 
     // :numeric-fluents
     let negated = map(
         parens(preceded((char('-'), multispace0), parse_f_exp)),
-        FExp::new_negative,
+        FluentExpression::new_negative,
     );
 
     // :numeric-fluents
-    let f_head = map(parse_f_head, FExp::new_function);
+    let f_head = map(parse_f_head, FluentExpression::new_function);
 
     alt((number, binary_op, multi_op, negated, f_head)).parse(input.into())
 }
 
-impl crate::parsers::Parser for FExp {
-    type Item = FExp;
+impl crate::parsers::Parser for FluentExpression {
+    type Item = FluentExpression;
 
     /// See [`parse_f_exp`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
@@ -94,30 +94,30 @@ impl crate::parsers::Parser for FExp {
 #[cfg(test)]
 mod tests {
     use crate::parsers::UnwrapValue;
-    use crate::{BinaryOp, FExp, FHead, FunctionSymbol, MultiOp, Parser};
+    use crate::{BinaryOp, FluentExpression, FunctionHead, FunctionSymbol, MultiOp, Parser};
 
     #[test]
     fn test_parse() {
-        assert!(FExp::parse("1.23").is_value(FExp::new_number(1.23)));
+        assert!(FluentExpression::parse("1.23").is_value(FluentExpression::new_number(1.23)));
 
-        assert!(FExp::parse("(+ 1.23 2.34)").is_value(FExp::new_binary_op(
+        assert!(FluentExpression::parse("(+ 1.23 2.34)").is_value(FluentExpression::new_binary_op(
             BinaryOp::Addition,
-            FExp::new_number(1.23),
-            FExp::new_number(2.34)
+            FluentExpression::new_number(1.23),
+            FluentExpression::new_number(2.34)
         )));
 
         assert!(
-            FExp::parse("(+ 1.23 2.34 3.45)").is_value(FExp::new_multi_op(
+            FluentExpression::parse("(+ 1.23 2.34 3.45)").is_value(FluentExpression::new_multi_op(
                 MultiOp::Addition,
-                FExp::new_number(1.23),
-                [FExp::new_number(2.34), FExp::new_number(3.45)]
+                FluentExpression::new_number(1.23),
+                [FluentExpression::new_number(2.34), FluentExpression::new_number(3.45)]
             ))
         );
 
-        assert!(FExp::parse("(- 1.23)").is_value(FExp::new_negative(FExp::new_number(1.23))));
+        assert!(FluentExpression::parse("(- 1.23)").is_value(FluentExpression::new_negative(FluentExpression::new_number(1.23))));
 
         assert!(
-            FExp::parse("fun-sym").is_value(FExp::new_function(FHead::new(
+            FluentExpression::parse("fun-sym").is_value(FluentExpression::new_function(FunctionHead::new(
                 FunctionSymbol::new_string("fun-sym")
             )))
         );

--- a/src/parsers/f_exp.rs
+++ b/src/parsers/f_exp.rs
@@ -100,26 +100,35 @@ mod tests {
     fn test_parse() {
         assert!(FluentExpression::parse("1.23").is_value(FluentExpression::new_number(1.23)));
 
-        assert!(FluentExpression::parse("(+ 1.23 2.34)").is_value(FluentExpression::new_binary_op(
-            BinaryOp::Addition,
-            FluentExpression::new_number(1.23),
-            FluentExpression::new_number(2.34)
-        )));
+        assert!(FluentExpression::parse("(+ 1.23 2.34)").is_value(
+            FluentExpression::new_binary_op(
+                BinaryOp::Addition,
+                FluentExpression::new_number(1.23),
+                FluentExpression::new_number(2.34)
+            )
+        ));
 
-        assert!(
-            FluentExpression::parse("(+ 1.23 2.34 3.45)").is_value(FluentExpression::new_multi_op(
+        assert!(FluentExpression::parse("(+ 1.23 2.34 3.45)").is_value(
+            FluentExpression::new_multi_op(
                 MultiOp::Addition,
                 FluentExpression::new_number(1.23),
-                [FluentExpression::new_number(2.34), FluentExpression::new_number(3.45)]
+                [
+                    FluentExpression::new_number(2.34),
+                    FluentExpression::new_number(3.45)
+                ]
+            )
+        ));
+
+        assert!(
+            FluentExpression::parse("(- 1.23)").is_value(FluentExpression::new_negative(
+                FluentExpression::new_number(1.23)
             ))
         );
 
-        assert!(FluentExpression::parse("(- 1.23)").is_value(FluentExpression::new_negative(FluentExpression::new_number(1.23))));
-
         assert!(
-            FluentExpression::parse("fun-sym").is_value(FluentExpression::new_function(FunctionHead::new(
-                FunctionSymbol::new_string("fun-sym")
-            )))
+            FluentExpression::parse("fun-sym").is_value(FluentExpression::new_function(
+                FunctionHead::new(FunctionSymbol::new_string("fun-sym"))
+            ))
         );
     }
 }

--- a/src/parsers/f_exp_da.rs
+++ b/src/parsers/f_exp_da.rs
@@ -37,9 +37,13 @@ use crate::types::DurativeActionFluentExpression;
 ///     )
 /// ));
 ///```
-pub fn parse_f_exp_da<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, DurativeActionFluentExpression> {
+pub fn parse_f_exp_da<'a, T: Into<Span<'a>>>(
+    input: T,
+) -> ParseResult<'a, DurativeActionFluentExpression> {
     // :duration-inequalities
-    let duration = map(tag("?duration"), |_| DurativeActionFluentExpression::new_duration());
+    let duration = map(tag("?duration"), |_| {
+        DurativeActionFluentExpression::new_duration()
+    });
 
     let binary_op = map(
         parens((
@@ -81,26 +85,34 @@ impl crate::parsers::Parser for DurativeActionFluentExpression {
 #[cfg(test)]
 mod tests {
     use crate::parsers::UnwrapValue;
-    use crate::{BinaryOp, FluentExpression, DurativeActionFluentExpression, MultiOp, Parser};
+    use crate::{BinaryOp, DurativeActionFluentExpression, FluentExpression, MultiOp, Parser};
 
     #[test]
     fn test_parse() {
-        assert!(DurativeActionFluentExpression::parse("?duration").is_value(DurativeActionFluentExpression::Duration));
+        assert!(DurativeActionFluentExpression::parse("?duration")
+            .is_value(DurativeActionFluentExpression::Duration));
 
         assert!(
-            DurativeActionFluentExpression::parse("(+ 1.23 2.34)").is_value(DurativeActionFluentExpression::new_binary_op(
-                BinaryOp::Addition,
-                DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(1.23)),
-                DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(2.34))
-            ))
+            DurativeActionFluentExpression::parse("(+ 1.23 2.34)").is_value(
+                DurativeActionFluentExpression::new_binary_op(
+                    BinaryOp::Addition,
+                    DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(1.23)),
+                    DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(2.34))
+                )
+            )
         );
 
         assert!(
-            DurativeActionFluentExpression::parse("(+ 1.23 2.34 3.45)").is_value(DurativeActionFluentExpression::new_multi_op(
-                MultiOp::Addition,
-                DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(1.23)),
-                [FluentExpression::new_number(2.34).into(), FluentExpression::new_number(3.45).into()]
-            ))
+            DurativeActionFluentExpression::parse("(+ 1.23 2.34 3.45)").is_value(
+                DurativeActionFluentExpression::new_multi_op(
+                    MultiOp::Addition,
+                    DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(1.23)),
+                    [
+                        FluentExpression::new_number(2.34).into(),
+                        FluentExpression::new_number(3.45).into()
+                    ]
+                )
+            )
         );
     }
 }

--- a/src/parsers/f_exp_da.rs
+++ b/src/parsers/f_exp_da.rs
@@ -9,37 +9,37 @@ use nom::Parser;
 
 use crate::parsers::{parens, space_separated_list1, ParseResult, Span};
 use crate::parsers::{parse_binary_op, parse_f_exp, parse_multi_op};
-use crate::types::FExpDa;
+use crate::types::DurativeActionFluentExpression;
 
 /// Parses an f-exp-da.
 ///
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_f_exp_da, preamble::*};
-/// # use pddl::{BinaryOp, FExpDa, FExp, FunctionSymbol, MultiOp};
+/// # use pddl::{BinaryOp, DurativeActionFluentExpression, FluentExpression, FunctionSymbol, MultiOp};
 /// assert!(parse_f_exp_da("?duration").is_value(
-///     FExpDa::Duration
+///     DurativeActionFluentExpression::Duration
 /// ));
 ///
 /// assert!(parse_f_exp_da("(+ 1.23 2.34)").is_value(
-///     FExpDa::new_binary_op(
+///     DurativeActionFluentExpression::new_binary_op(
 ///         BinaryOp::Addition,
-///             FExpDa::new_f_exp(FExp::new_number(1.23)),
-///             FExpDa::new_f_exp(FExp::new_number(2.34))
+///             DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(1.23)),
+///             DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(2.34))
 ///     )
 /// ));
 ///
 /// assert!(parse_f_exp_da("(+ 1.23 2.34 3.45)").is_value(
-///     FExpDa::new_multi_op(
+///     DurativeActionFluentExpression::new_multi_op(
 ///         MultiOp::Addition,
-///         FExpDa::new_f_exp(FExp::new_number(1.23)),
-///         [FExp::new_number(2.34).into(), FExp::new_number(3.45).into()]
+///         DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(1.23)),
+///         [FluentExpression::new_number(2.34).into(), FluentExpression::new_number(3.45).into()]
 ///     )
 /// ));
 ///```
-pub fn parse_f_exp_da<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FExpDa> {
+pub fn parse_f_exp_da<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, DurativeActionFluentExpression> {
     // :duration-inequalities
-    let duration = map(tag("?duration"), |_| FExpDa::new_duration());
+    let duration = map(tag("?duration"), |_| DurativeActionFluentExpression::new_duration());
 
     let binary_op = map(
         parens((
@@ -47,7 +47,7 @@ pub fn parse_f_exp_da<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FExpDa
             preceded(multispace1, parse_f_exp_da),
             preceded(multispace1, parse_f_exp_da),
         )),
-        |(op, lhs, rhs)| FExpDa::new_binary_op(op, lhs, rhs),
+        |(op, lhs, rhs)| DurativeActionFluentExpression::new_binary_op(op, lhs, rhs),
     );
 
     let multi_op = map(
@@ -56,21 +56,21 @@ pub fn parse_f_exp_da<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FExpDa
             preceded(multispace1, parse_f_exp_da),
             preceded(multispace1, space_separated_list1(parse_f_exp_da)),
         )),
-        |(op, lhs, rhs)| FExpDa::new_multi_op(op, lhs, rhs),
+        |(op, lhs, rhs)| DurativeActionFluentExpression::new_multi_op(op, lhs, rhs),
     );
 
     let negated = map(
         parens(preceded((char('-'), multispace0), parse_f_exp_da)),
-        FExpDa::new_negative,
+        DurativeActionFluentExpression::new_negative,
     );
 
-    let f_exp = map(parse_f_exp, FExpDa::new_f_exp);
+    let f_exp = map(parse_f_exp, DurativeActionFluentExpression::new_f_exp);
 
     alt((duration, binary_op, multi_op, negated, f_exp)).parse(input.into())
 }
 
-impl crate::parsers::Parser for FExpDa {
-    type Item = FExpDa;
+impl crate::parsers::Parser for DurativeActionFluentExpression {
+    type Item = DurativeActionFluentExpression;
 
     /// See [`parse_f_exp_da`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
@@ -81,25 +81,25 @@ impl crate::parsers::Parser for FExpDa {
 #[cfg(test)]
 mod tests {
     use crate::parsers::UnwrapValue;
-    use crate::{BinaryOp, FExp, FExpDa, MultiOp, Parser};
+    use crate::{BinaryOp, FluentExpression, DurativeActionFluentExpression, MultiOp, Parser};
 
     #[test]
     fn test_parse() {
-        assert!(FExpDa::parse("?duration").is_value(FExpDa::Duration));
+        assert!(DurativeActionFluentExpression::parse("?duration").is_value(DurativeActionFluentExpression::Duration));
 
         assert!(
-            FExpDa::parse("(+ 1.23 2.34)").is_value(FExpDa::new_binary_op(
+            DurativeActionFluentExpression::parse("(+ 1.23 2.34)").is_value(DurativeActionFluentExpression::new_binary_op(
                 BinaryOp::Addition,
-                FExpDa::new_f_exp(FExp::new_number(1.23)),
-                FExpDa::new_f_exp(FExp::new_number(2.34))
+                DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(1.23)),
+                DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(2.34))
             ))
         );
 
         assert!(
-            FExpDa::parse("(+ 1.23 2.34 3.45)").is_value(FExpDa::new_multi_op(
+            DurativeActionFluentExpression::parse("(+ 1.23 2.34 3.45)").is_value(DurativeActionFluentExpression::new_multi_op(
                 MultiOp::Addition,
-                FExpDa::new_f_exp(FExp::new_number(1.23)),
-                [FExp::new_number(2.34).into(), FExp::new_number(3.45).into()]
+                DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(1.23)),
+                [FluentExpression::new_number(2.34).into(), FluentExpression::new_number(3.45).into()]
             ))
         );
     }

--- a/src/parsers/f_exp_t.rs
+++ b/src/parsers/f_exp_t.rs
@@ -9,20 +9,20 @@ use nom::Parser;
 
 use crate::parsers::prefix_expr;
 use crate::parsers::{parse_f_exp, ParseResult, Span};
-use crate::types::FExpT;
+use crate::types::TimedFluentExpression;
 
 /// Parses an f-exp-t.
 ///
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_f_exp, parse_f_exp_t, preamble::*};
-/// # use pddl::{BinaryOp, FExp, FExpT, FHead, FunctionSymbol, MultiOp, Term, Variable};
-/// assert!(parse_f_exp_t("#t").is_value(FExpT::Now));
+/// # use pddl::{BinaryOp, FluentExpression, TimedFluentExpression, FunctionHead, FunctionSymbol, MultiOp, Term, Variable};
+/// assert!(parse_f_exp_t("#t").is_value(TimedFluentExpression::Now));
 ///
 /// assert!(parse_f_exp_t("(* (fuel ?tank) #t)").is_value(
-///     FExpT::new_scaled(
-///         FExp::new_function(
-///             FHead::new_with_terms(
+///     TimedFluentExpression::new_scaled(
+///         FluentExpression::new_function(
+///             FunctionHead::new_with_terms(
 ///                 FunctionSymbol::new_string("fuel"),
 ///                 [Term::Variable(Variable::new_string("tank"))]
 ///             )
@@ -31,9 +31,9 @@ use crate::types::FExpT;
 /// ));
 ///
 /// assert!(parse_f_exp_t("(* #t (fuel ?tank))").is_value(
-///     FExpT::new_scaled(
-///         FExp::new_function(
-///             FHead::new_with_terms(
+///     TimedFluentExpression::new_scaled(
+///         FluentExpression::new_function(
+///             FunctionHead::new_with_terms(
 ///                 FunctionSymbol::new_string("fuel"),
 ///                 [Term::Variable(Variable::new_string("tank"))]
 ///             )
@@ -41,8 +41,8 @@ use crate::types::FExpT;
 ///     )
 /// ));
 ///```
-pub fn parse_f_exp_t<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FExpT> {
-    let now = map(tag("#t"), |_| FExpT::new());
+pub fn parse_f_exp_t<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, TimedFluentExpression> {
+    let now = map(tag("#t"), |_| TimedFluentExpression::new());
     let scaled = map(
         prefix_expr(
             "*",
@@ -51,14 +51,14 @@ pub fn parse_f_exp_t<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FExpT> 
                 terminated(parse_f_exp, (multispace1, tag("#t"))),
             )),
         ),
-        FExpT::new_scaled,
+        TimedFluentExpression::new_scaled,
     );
 
     alt((scaled, now)).parse(input.into())
 }
 
-impl crate::parsers::Parser for FExpT {
-    type Item = FExpT;
+impl crate::parsers::Parser for TimedFluentExpression {
+    type Item = TimedFluentExpression;
 
     /// See [`parse_f_exp_t`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
@@ -69,15 +69,15 @@ impl crate::parsers::Parser for FExpT {
 #[cfg(test)]
 mod tests {
     use crate::parsers::UnwrapValue;
-    use crate::{FExp, FExpT, FHead, FunctionSymbol, Parser, Term, Variable};
+    use crate::{FluentExpression, TimedFluentExpression, FunctionHead, FunctionSymbol, Parser, Term, Variable};
 
     #[test]
     fn test_parse() {
-        assert!(FExpT::parse("#t").is_value(FExpT::Now));
+        assert!(TimedFluentExpression::parse("#t").is_value(TimedFluentExpression::Now));
 
         assert!(
-            FExpT::parse("(* (fuel ?tank) #t)").is_value(FExpT::new_scaled(FExp::new_function(
-                FHead::new_with_terms(
+            TimedFluentExpression::parse("(* (fuel ?tank) #t)").is_value(TimedFluentExpression::new_scaled(FluentExpression::new_function(
+                FunctionHead::new_with_terms(
                     FunctionSymbol::new_string("fuel"),
                     [Term::Variable(Variable::new_string("tank"))]
                 )
@@ -85,8 +85,8 @@ mod tests {
         );
 
         assert!(
-            FExpT::parse("(* #t (fuel ?tank))").is_value(FExpT::new_scaled(FExp::new_function(
-                FHead::new_with_terms(
+            TimedFluentExpression::parse("(* #t (fuel ?tank))").is_value(TimedFluentExpression::new_scaled(FluentExpression::new_function(
+                FunctionHead::new_with_terms(
                     FunctionSymbol::new_string("fuel"),
                     [Term::Variable(Variable::new_string("tank"))]
                 )

--- a/src/parsers/f_exp_t.rs
+++ b/src/parsers/f_exp_t.rs
@@ -69,28 +69,35 @@ impl crate::parsers::Parser for TimedFluentExpression {
 #[cfg(test)]
 mod tests {
     use crate::parsers::UnwrapValue;
-    use crate::{FluentExpression, TimedFluentExpression, FunctionHead, FunctionSymbol, Parser, Term, Variable};
+    use crate::{
+        FluentExpression, FunctionHead, FunctionSymbol, Parser, Term, TimedFluentExpression,
+        Variable,
+    };
 
     #[test]
     fn test_parse() {
         assert!(TimedFluentExpression::parse("#t").is_value(TimedFluentExpression::Now));
 
         assert!(
-            TimedFluentExpression::parse("(* (fuel ?tank) #t)").is_value(TimedFluentExpression::new_scaled(FluentExpression::new_function(
-                FunctionHead::new_with_terms(
-                    FunctionSymbol::new_string("fuel"),
-                    [Term::Variable(Variable::new_string("tank"))]
-                )
-            )))
+            TimedFluentExpression::parse("(* (fuel ?tank) #t)").is_value(
+                TimedFluentExpression::new_scaled(FluentExpression::new_function(
+                    FunctionHead::new_with_terms(
+                        FunctionSymbol::new_string("fuel"),
+                        [Term::Variable(Variable::new_string("tank"))]
+                    )
+                ))
+            )
         );
 
         assert!(
-            TimedFluentExpression::parse("(* #t (fuel ?tank))").is_value(TimedFluentExpression::new_scaled(FluentExpression::new_function(
-                FunctionHead::new_with_terms(
-                    FunctionSymbol::new_string("fuel"),
-                    [Term::Variable(Variable::new_string("tank"))]
-                )
-            )))
+            TimedFluentExpression::parse("(* #t (fuel ?tank))").is_value(
+                TimedFluentExpression::new_scaled(FluentExpression::new_function(
+                    FunctionHead::new_with_terms(
+                        FunctionSymbol::new_string("fuel"),
+                        [Term::Variable(Variable::new_string("tank"))]
+                    )
+                ))
+            )
         );
     }
 }

--- a/src/parsers/f_exp_t.rs
+++ b/src/parsers/f_exp_t.rs
@@ -20,22 +20,22 @@ use crate::types::TimedFluentExpression;
 /// assert!(parse_f_exp_t("#t").is_value(TimedFluentExpression::Now));
 ///
 /// assert!(parse_f_exp_t("(* (fuel ?tank) #t)").is_value(
-///     TimedFluentExpression::new_scaled(
-///         FluentExpression::new_function(
-///             FunctionHead::new_with_terms(
-///                 FunctionSymbol::new_string("fuel"),
-///                 [Term::Variable(Variable::new_string("tank"))]
+///     TimedFluentExpression::scaled(
+///         FluentExpression::function(
+///             FunctionHead::with_terms(
+///                 FunctionSymbol::string("fuel"),
+///                 [Term::Variable(Variable::string("tank"))]
 ///             )
 ///         )
 ///     )
 /// ));
 ///
 /// assert!(parse_f_exp_t("(* #t (fuel ?tank))").is_value(
-///     TimedFluentExpression::new_scaled(
-///         FluentExpression::new_function(
-///             FunctionHead::new_with_terms(
-///                 FunctionSymbol::new_string("fuel"),
-///                 [Term::Variable(Variable::new_string("tank"))]
+///     TimedFluentExpression::scaled(
+///         FluentExpression::function(
+///             FunctionHead::with_terms(
+///                 FunctionSymbol::string("fuel"),
+///                 [Term::Variable(Variable::string("tank"))]
 ///             )
 ///         )
 ///     )
@@ -80,10 +80,10 @@ mod tests {
 
         assert!(
             TimedFluentExpression::parse("(* (fuel ?tank) #t)").is_value(
-                TimedFluentExpression::new_scaled(FluentExpression::new_function(
-                    FunctionHead::new_with_terms(
-                        FunctionSymbol::new_string("fuel"),
-                        [Term::Variable(Variable::new_string("tank"))]
+                TimedFluentExpression::scaled(FluentExpression::function(
+                    FunctionHead::with_terms(
+                        FunctionSymbol::string("fuel"),
+                        [Term::Variable(Variable::string("tank"))]
                     )
                 ))
             )
@@ -91,10 +91,10 @@ mod tests {
 
         assert!(
             TimedFluentExpression::parse("(* #t (fuel ?tank))").is_value(
-                TimedFluentExpression::new_scaled(FluentExpression::new_function(
-                    FunctionHead::new_with_terms(
-                        FunctionSymbol::new_string("fuel"),
-                        [Term::Variable(Variable::new_string("tank"))]
+                TimedFluentExpression::scaled(FluentExpression::function(
+                    FunctionHead::with_terms(
+                        FunctionSymbol::string("fuel"),
+                        [Term::Variable(Variable::string("tank"))]
                     )
                 ))
             )

--- a/src/parsers/f_head.rs
+++ b/src/parsers/f_head.rs
@@ -17,15 +17,15 @@ use crate::types::FunctionHead;
 /// # use pddl::parsers::{parse_f_head, preamble::*};
 /// # use pddl::{FunctionTerm, Variable, FunctionSymbol, Term, FunctionHead};
 /// assert!(parse_f_head("fun-sym").is_value(
-///     FunctionHead::new(FunctionSymbol::new_string("fun-sym"))
+///     FunctionHead::new(FunctionSymbol::string("fun-sym"))
 /// ));
 ///
 /// assert!(parse_f_head("(fun-sym)").is_value(
-///     FunctionHead::new(FunctionSymbol::new_string("fun-sym"))
+///     FunctionHead::new(FunctionSymbol::string("fun-sym"))
 /// ));
 ///
 /// assert!(parse_f_head("(fun-sym term)").is_value(
-///     FunctionHead::new_with_terms(FunctionSymbol::new_string("fun-sym"), [
+///     FunctionHead::with_terms(FunctionSymbol::string("fun-sym"), [
 ///         Term::Name("term".into())
 ///     ])
 /// ));
@@ -38,7 +38,7 @@ pub fn parse_f_head<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Function
             parse_function_symbol,
             preceded(multispace1, space_separated_list0(parse_term)),
         )),
-        |(symbol, terms)| FunctionHead::new_with_terms(symbol, terms),
+        |(symbol, terms)| FunctionHead::with_terms(symbol, terms),
     );
 
     alt((simple, simple_parens, with_terms)).parse(input.into())
@@ -61,14 +61,14 @@ mod tests {
     #[test]
     fn test_parse() {
         assert!(FunctionHead::parse("fun-sym")
-            .is_value(FunctionHead::new(FunctionSymbol::new_string("fun-sym"))));
+            .is_value(FunctionHead::new(FunctionSymbol::string("fun-sym"))));
 
         assert!(FunctionHead::parse("(fun-sym)")
-            .is_value(FunctionHead::new(FunctionSymbol::new_string("fun-sym"))));
+            .is_value(FunctionHead::new(FunctionSymbol::string("fun-sym"))));
 
         assert!(
-            FunctionHead::parse("(fun-sym term)").is_value(FunctionHead::new_with_terms(
-                FunctionSymbol::new_string("fun-sym"),
+            FunctionHead::parse("(fun-sym term)").is_value(FunctionHead::with_terms(
+                FunctionSymbol::string("fun-sym"),
                 [Term::Name("term".into())]
             ))
         );

--- a/src/parsers/f_head.rs
+++ b/src/parsers/f_head.rs
@@ -60,11 +60,11 @@ mod tests {
 
     #[test]
     fn test_parse() {
-        assert!(FunctionHead::parse("fun-sym").is_value(FunctionHead::new(FunctionSymbol::new_string("fun-sym"))));
+        assert!(FunctionHead::parse("fun-sym")
+            .is_value(FunctionHead::new(FunctionSymbol::new_string("fun-sym"))));
 
-        assert!(
-            FunctionHead::parse("(fun-sym)").is_value(FunctionHead::new(FunctionSymbol::new_string("fun-sym")))
-        );
+        assert!(FunctionHead::parse("(fun-sym)")
+            .is_value(FunctionHead::new(FunctionSymbol::new_string("fun-sym"))));
 
         assert!(
             FunctionHead::parse("(fun-sym term)").is_value(FunctionHead::new_with_terms(

--- a/src/parsers/f_head.rs
+++ b/src/parsers/f_head.rs
@@ -8,44 +8,44 @@ use nom::Parser;
 
 use crate::parsers::{parens, space_separated_list0, ParseResult, Span};
 use crate::parsers::{parse_function_symbol, parse_term};
-use crate::types::FHead;
+use crate::types::FunctionHead;
 
 /// Parses an f-head.
 ///
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_f_head, preamble::*};
-/// # use pddl::{FunctionTerm, Variable, FunctionSymbol, Term, FHead};
+/// # use pddl::{FunctionTerm, Variable, FunctionSymbol, Term, FunctionHead};
 /// assert!(parse_f_head("fun-sym").is_value(
-///     FHead::new(FunctionSymbol::new_string("fun-sym"))
+///     FunctionHead::new(FunctionSymbol::new_string("fun-sym"))
 /// ));
 ///
 /// assert!(parse_f_head("(fun-sym)").is_value(
-///     FHead::new(FunctionSymbol::new_string("fun-sym"))
+///     FunctionHead::new(FunctionSymbol::new_string("fun-sym"))
 /// ));
 ///
 /// assert!(parse_f_head("(fun-sym term)").is_value(
-///     FHead::new_with_terms(FunctionSymbol::new_string("fun-sym"), [
+///     FunctionHead::new_with_terms(FunctionSymbol::new_string("fun-sym"), [
 ///         Term::Name("term".into())
 ///     ])
 /// ));
 ///```
-pub fn parse_f_head<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FHead> {
-    let simple = map(parse_function_symbol, FHead::new);
-    let simple_parens = map(parens(parse_function_symbol), FHead::new);
+pub fn parse_f_head<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, FunctionHead> {
+    let simple = map(parse_function_symbol, FunctionHead::new);
+    let simple_parens = map(parens(parse_function_symbol), FunctionHead::new);
     let with_terms = map(
         parens((
             parse_function_symbol,
             preceded(multispace1, space_separated_list0(parse_term)),
         )),
-        |(symbol, terms)| FHead::new_with_terms(symbol, terms),
+        |(symbol, terms)| FunctionHead::new_with_terms(symbol, terms),
     );
 
     alt((simple, simple_parens, with_terms)).parse(input.into())
 }
 
-impl crate::parsers::Parser for FHead {
-    type Item = FHead;
+impl crate::parsers::Parser for FunctionHead {
+    type Item = FunctionHead;
 
     /// See [`parse_f_head`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
@@ -56,18 +56,18 @@ impl crate::parsers::Parser for FHead {
 #[cfg(test)]
 mod tests {
     use crate::parsers::UnwrapValue;
-    use crate::{FHead, FunctionSymbol, Parser, Term};
+    use crate::{FunctionHead, FunctionSymbol, Parser, Term};
 
     #[test]
     fn test_parse() {
-        assert!(FHead::parse("fun-sym").is_value(FHead::new(FunctionSymbol::new_string("fun-sym"))));
+        assert!(FunctionHead::parse("fun-sym").is_value(FunctionHead::new(FunctionSymbol::new_string("fun-sym"))));
 
         assert!(
-            FHead::parse("(fun-sym)").is_value(FHead::new(FunctionSymbol::new_string("fun-sym")))
+            FunctionHead::parse("(fun-sym)").is_value(FunctionHead::new(FunctionSymbol::new_string("fun-sym")))
         );
 
         assert!(
-            FHead::parse("(fun-sym term)").is_value(FHead::new_with_terms(
+            FunctionHead::parse("(fun-sym term)").is_value(FunctionHead::new_with_terms(
                 FunctionSymbol::new_string("fun-sym"),
                 [Term::Name("term".into())]
             ))

--- a/src/parsers/function_typed_list.rs
+++ b/src/parsers/function_typed_list.rs
@@ -21,9 +21,9 @@ use crate::types::{FunctionType, FunctionTyped, FunctionTypedList};
 /// assert!(function_typed_list(parse_atomic_function_skeleton).parse(
 ///     "(battery-amount ?r - rover)".into()
 /// )
-/// .is_value(FunctionTypedList::from_iter([FunctionTyped::new_number(
+/// .is_value(FunctionTypedList::from_iter([FunctionTyped::number(
 ///     AtomicFunctionSkeleton::new(
-///         FunctionSymbol::new_string("battery-amount"),
+///         FunctionSymbol::string("battery-amount"),
 ///         TypedList::from_iter([
 ///             Typed::new(
 ///                 Variable::from("r"),
@@ -40,7 +40,7 @@ where
     F: Clone + Parser<Span<'a>, Output = O, Error = ParseError<'a>>,
 {
     // `x*`
-    let implicitly_typed = map(inner.clone(), |o| FunctionTyped::new_number(o));
+    let implicitly_typed = map(inner.clone(), |o| FunctionTyped::number(o));
     let implicitly_typed_list = space_separated_list0(implicitly_typed);
 
     // `x⁺ - <type>`
@@ -82,9 +82,9 @@ mod tests {
     fn test_parse() {
         assert!(function_typed_list(parse_atomic_function_skeleton)
             .parse("(battery-amount ?r - rover)".into())
-            .is_value(FunctionTypedList::from_iter([FunctionTyped::new_number(
+            .is_value(FunctionTypedList::from_iter([FunctionTyped::number(
                 AtomicFunctionSkeleton::new(
-                    FunctionSymbol::new_string("battery-amount"),
+                    FunctionSymbol::string("battery-amount"),
                     TypedList::from_iter([Typed::new(
                         Variable::from("r"),
                         Type::Exactly("rover".into())
@@ -94,9 +94,9 @@ mod tests {
 
         assert!(function_typed_list(parse_atomic_function_skeleton)
             .parse("(move ?from ?to - location)".into())
-            .is_value(FunctionTypedList::from_iter([FunctionTyped::new_number(
+            .is_value(FunctionTypedList::from_iter([FunctionTyped::number(
                 AtomicFunctionSkeleton::new(
-                    FunctionSymbol::new_string("move"),
+                    FunctionSymbol::string("move"),
                     TypedList::from_iter([
                         Typed::new(Variable::from("from"), Type::Exactly("location".into())),
                         Typed::new(Variable::from("to"), Type::Exactly("location".into()))

--- a/src/parsers/functions_def.rs
+++ b/src/parsers/functions_def.rs
@@ -17,9 +17,9 @@ use crate::types::Functions;
 /// let input = "(:functions (battery-amount ?r - rover))";
 /// assert!(parse_functions_def(input).is_value(
 ///     Functions::from_iter([
-///         FunctionTyped::new_number(
+///         FunctionTyped::number(
 ///             AtomicFunctionSkeleton::new(
-///                 FunctionSymbol::new_string("battery-amount"),
+///                 FunctionSymbol::string("battery-amount"),
 ///                 TypedList::from_iter([
 ///                     Typed::new(Variable::from("r"), Type::Exactly("rover".into()))
 ///                 ])
@@ -59,14 +59,16 @@ mod tests {
     #[test]
     fn test_parse() {
         let input = "(:functions (battery-amount ?r - rover))";
-        assert!(Functions::parse(input).is_value(Functions::from_iter([
-            FunctionTyped::new_number(AtomicFunctionSkeleton::new(
-                FunctionSymbol::new_string("battery-amount"),
-                TypedList::from_iter([Typed::new(
-                    Variable::from("r"),
-                    Type::Exactly("rover".into())
-                )])
-            ))
-        ])));
+        assert!(
+            Functions::parse(input).is_value(Functions::from_iter([FunctionTyped::number(
+                AtomicFunctionSkeleton::new(
+                    FunctionSymbol::string("battery-amount"),
+                    TypedList::from_iter([Typed::new(
+                        Variable::from("r"),
+                        Type::Exactly("rover".into())
+                    )])
+                )
+            )]))
+        );
     }
 }

--- a/src/parsers/gd.rs
+++ b/src/parsers/gd.rs
@@ -205,8 +205,8 @@ impl crate::parsers::Parser for GoalDefinition {
 mod tests {
     use crate::parsers::UnwrapValue;
     use crate::{
-        AtomicFormula, BinaryComparison, BinaryOp, FluentComparison, FluentExpression, GoalDefinition, Parser, Term,
-        TypedList, Variable,
+        AtomicFormula, BinaryComparison, BinaryOp, FluentComparison, FluentExpression,
+        GoalDefinition, Parser, Term, TypedList, Variable,
     };
 
     #[test]

--- a/src/parsers/gd.rs
+++ b/src/parsers/gd.rs
@@ -22,7 +22,7 @@ use crate::types::GoalDefinition;
 /// // Atomic formula
 /// assert!(parse_gd("(= x y)").is_value(
 ///     GoalDefinition::AtomicFormula(
-///         AtomicFormula::new_equality(
+///         AtomicFormula::equality(
 ///             Term::Name("x".into()),
 ///             Term::Name("y".into())
 ///         )
@@ -31,9 +31,9 @@ use crate::types::GoalDefinition;
 ///
 /// // Literal
 /// assert!(parse_gd("(not (= x y))").is_value(
-///     GoalDefinition::new_not(
-///         GoalDefinition::new_atomic_formula(
-///             AtomicFormula::new_equality(
+///     GoalDefinition::not(
+///         GoalDefinition::atomic_formula(
+///             AtomicFormula::equality(
 ///                 Term::Name("x".into()),
 ///                 Term::Name("y".into())
 ///             )
@@ -43,14 +43,14 @@ use crate::types::GoalDefinition;
 ///
 /// // Conjunction (and)
 /// assert!(parse_gd("(and (not (= x y)) (= x z))").is_value(
-///     GoalDefinition::new_and([
-///         GoalDefinition::new_not(GoalDefinition::new_atomic_formula(
-///             AtomicFormula::new_equality(
+///     GoalDefinition::and([
+///         GoalDefinition::not(GoalDefinition::atomic_formula(
+///             AtomicFormula::equality(
 ///                 Term::Name("x".into()),
 ///                 Term::Name("y".into())
 ///             )
 ///         )),
-///         GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
+///         GoalDefinition::AtomicFormula(AtomicFormula::equality(
 ///             Term::Name("x".into()),
 ///             Term::Name("z".into())
 ///         ))
@@ -59,14 +59,14 @@ use crate::types::GoalDefinition;
 ///
 /// // Disjunction (or)
 /// assert!(parse_gd("(or (not (= x y)) (= x z))").is_value(
-///     GoalDefinition::new_or([
-///         GoalDefinition::new_not(GoalDefinition::new_atomic_formula(
-///             AtomicFormula::new_equality(
+///     GoalDefinition::or([
+///         GoalDefinition::not(GoalDefinition::atomic_formula(
+///             AtomicFormula::equality(
 ///                 Term::Name("x".into()),
 ///                 Term::Name("y".into())
 ///             )
 ///         )),
-///         GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
+///         GoalDefinition::AtomicFormula(AtomicFormula::equality(
 ///             Term::Name("x".into()),
 ///             Term::Name("z".into())
 ///         ))
@@ -75,14 +75,14 @@ use crate::types::GoalDefinition;
 ///
 /// // Implication
 /// assert!(parse_gd("(imply (not (= x y)) (= x z))").is_value(
-///     GoalDefinition::new_imply(
-///         GoalDefinition::new_not(GoalDefinition::new_atomic_formula(
-///             AtomicFormula::new_equality(
+///     GoalDefinition::imply(
+///         GoalDefinition::not(GoalDefinition::atomic_formula(
+///             AtomicFormula::equality(
 ///                 Term::Name("x".into()),
 ///                 Term::Name("y".into())
 ///             )
 ///         )),
-///         GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
+///         GoalDefinition::AtomicFormula(AtomicFormula::equality(
 ///             Term::Name("x".into()),
 ///             Term::Name("z".into())
 ///         ))
@@ -91,10 +91,10 @@ use crate::types::GoalDefinition;
 ///
 /// // Existential preconditions
 /// assert!(parse_gd("(exists (?x ?y) (not (= ?x ?y)))").is_value(
-///     GoalDefinition::new_exists(
+///     GoalDefinition::exists(
 ///         TypedList::from_iter([Variable::new_string("x").into(), Variable::new_string("y").into()]),
-///         GoalDefinition::new_not(GoalDefinition::new_atomic_formula(
-///             AtomicFormula::new_equality(
+///         GoalDefinition::not(GoalDefinition::atomic_formula(
+///             AtomicFormula::equality(
 ///                 Term::Variable("x".into()),
 ///                 Term::Variable("y".into())
 ///             )
@@ -104,10 +104,10 @@ use crate::types::GoalDefinition;
 ///
 /// // Universal preconditions
 /// assert!(parse_gd("(forall (?x ?y) (not (= ?x ?y)))").is_value(
-///     GoalDefinition::new_forall(
+///     GoalDefinition::forall(
 ///         TypedList::from_iter([Variable::new_string("x").into(), Variable::new_string("y").into()]),
-///         GoalDefinition::new_not(GoalDefinition::new_atomic_formula(
-///             AtomicFormula::new_equality(
+///         GoalDefinition::not(GoalDefinition::atomic_formula(
+///             AtomicFormula::equality(
 ///                 Term::Variable("x".into()),
 ///                 Term::Variable("y".into())
 ///             )
@@ -116,18 +116,18 @@ use crate::types::GoalDefinition;
 /// ));
 ///
 /// assert!(parse_gd("(= (+ 1.23 2.34) (+ 1.23 2.34))").is_value(
-///     GoalDefinition::new_f_comp(
+///     GoalDefinition::fluent_comparison(
 ///         FluentComparison::new(
 ///             BinaryComparison::Equal,
-///             FluentExpression::new_binary_op(
+///             FluentExpression::binary_op(
 ///                 BinaryOp::Addition,
-///                 FluentExpression::new_number(1.23),
-///                 FluentExpression::new_number(2.34),
+///                 FluentExpression::number(1.23),
+///                 FluentExpression::number(2.34),
 ///             ),
-///             FluentExpression::new_binary_op(
+///             FluentExpression::binary_op(
 ///                 BinaryOp::Addition,
-///                 FluentExpression::new_number(1.23),
-///                 FluentExpression::new_number(2.34),
+///                 FluentExpression::number(1.23),
+///                 FluentExpression::number(2.34),
 ///             )
 ///         )
 ///     )
@@ -213,14 +213,14 @@ mod tests {
     fn test_parse() {
         assert!(
             GoalDefinition::parse("(= x y)").is_value(GoalDefinition::AtomicFormula(
-                AtomicFormula::new_equality(Term::Name("x".into()), Term::Name("y".into()))
+                AtomicFormula::equality(Term::Name("x".into()), Term::Name("y".into()))
             ))
         );
 
         // Literal
         assert!(
-            GoalDefinition::parse("(not (= x y))").is_value(GoalDefinition::new_not(
-                GoalDefinition::new_atomic_formula(AtomicFormula::new_equality(
+            GoalDefinition::parse("(not (= x y))").is_value(GoalDefinition::not(
+                GoalDefinition::atomic_formula(AtomicFormula::equality(
                     Term::Name("x".into()),
                     Term::Name("y".into())
                 ))
@@ -229,26 +229,26 @@ mod tests {
 
         // Conjunction (and)
         assert!(
-            GoalDefinition::parse("(and (not (= x y)) (= x z))").is_value(GoalDefinition::new_and(
-                [
-                    GoalDefinition::new_not(GoalDefinition::new_atomic_formula(
-                        AtomicFormula::new_equality(Term::Name("x".into()), Term::Name("y".into()))
-                    )),
-                    GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
-                        Term::Name("x".into()),
-                        Term::Name("z".into())
-                    ))
-                ]
-            ))
+            GoalDefinition::parse("(and (not (= x y)) (= x z))").is_value(GoalDefinition::and([
+                GoalDefinition::not(GoalDefinition::atomic_formula(AtomicFormula::equality(
+                    Term::Name("x".into()),
+                    Term::Name("y".into())
+                ))),
+                GoalDefinition::AtomicFormula(AtomicFormula::equality(
+                    Term::Name("x".into()),
+                    Term::Name("z".into())
+                ))
+            ]))
         );
 
         // Disjunction (or)
         assert!(
-            GoalDefinition::parse("(or (not (= x y)) (= x z))").is_value(GoalDefinition::new_or([
-                GoalDefinition::new_not(GoalDefinition::new_atomic_formula(
-                    AtomicFormula::new_equality(Term::Name("x".into()), Term::Name("y".into()))
-                )),
-                GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
+            GoalDefinition::parse("(or (not (= x y)) (= x z))").is_value(GoalDefinition::or([
+                GoalDefinition::not(GoalDefinition::atomic_formula(AtomicFormula::equality(
+                    Term::Name("x".into()),
+                    Term::Name("y".into())
+                ))),
+                GoalDefinition::AtomicFormula(AtomicFormula::equality(
                     Term::Name("x".into()),
                     Term::Name("z".into())
                 ))
@@ -257,33 +257,30 @@ mod tests {
 
         // Implication
         assert!(
-            GoalDefinition::parse("(imply (not (= x y)) (= x z))").is_value(
-                GoalDefinition::new_imply(
-                    GoalDefinition::new_not(GoalDefinition::new_atomic_formula(
-                        AtomicFormula::new_equality(Term::Name("x".into()), Term::Name("y".into()))
-                    )),
-                    GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
-                        Term::Name("x".into()),
-                        Term::Name("z".into())
-                    ))
-                )
-            )
+            GoalDefinition::parse("(imply (not (= x y)) (= x z))").is_value(GoalDefinition::imply(
+                GoalDefinition::not(GoalDefinition::atomic_formula(AtomicFormula::equality(
+                    Term::Name("x".into()),
+                    Term::Name("y".into())
+                ))),
+                GoalDefinition::AtomicFormula(AtomicFormula::equality(
+                    Term::Name("x".into()),
+                    Term::Name("z".into())
+                ))
+            ))
         );
 
         // Existential preconditions
         assert!(
             GoalDefinition::parse("(exists (?x ?y) (not (= ?x ?y)))").is_value(
-                GoalDefinition::new_exists(
+                GoalDefinition::exists(
                     TypedList::from_iter([
                         Variable::new_string("x").into(),
                         Variable::new_string("y").into()
                     ]),
-                    GoalDefinition::new_not(GoalDefinition::new_atomic_formula(
-                        AtomicFormula::new_equality(
-                            Term::Variable("x".into()),
-                            Term::Variable("y".into())
-                        )
-                    ))
+                    GoalDefinition::not(GoalDefinition::atomic_formula(AtomicFormula::equality(
+                        Term::Variable("x".into()),
+                        Term::Variable("y".into())
+                    )))
                 )
             )
         );
@@ -291,34 +288,32 @@ mod tests {
         // Universal preconditions
         assert!(
             GoalDefinition::parse("(forall (?x ?y) (not (= ?x ?y)))").is_value(
-                GoalDefinition::new_forall(
+                GoalDefinition::forall(
                     TypedList::from_iter([
                         Variable::new_string("x").into(),
                         Variable::new_string("y").into()
                     ]),
-                    GoalDefinition::new_not(GoalDefinition::new_atomic_formula(
-                        AtomicFormula::new_equality(
-                            Term::Variable("x".into()),
-                            Term::Variable("y".into())
-                        )
-                    ))
+                    GoalDefinition::not(GoalDefinition::atomic_formula(AtomicFormula::equality(
+                        Term::Variable("x".into()),
+                        Term::Variable("y".into())
+                    )))
                 )
             )
         );
 
         assert!(
             GoalDefinition::parse("(= (+ 1.23 2.34) (+ 1.23 2.34))").is_value(
-                GoalDefinition::new_f_comp(FluentComparison::new(
+                GoalDefinition::fluent_comparison(FluentComparison::new(
                     BinaryComparison::Equal,
-                    FluentExpression::new_binary_op(
+                    FluentExpression::binary_op(
                         BinaryOp::Addition,
-                        FluentExpression::new_number(1.23),
-                        FluentExpression::new_number(2.34),
+                        FluentExpression::number(1.23),
+                        FluentExpression::number(2.34),
                     ),
-                    FluentExpression::new_binary_op(
+                    FluentExpression::binary_op(
                         BinaryOp::Addition,
-                        FluentExpression::new_number(1.23),
-                        FluentExpression::new_number(2.34),
+                        FluentExpression::number(1.23),
+                        FluentExpression::number(2.34),
                     )
                 ))
             )

--- a/src/parsers/gd.rs
+++ b/src/parsers/gd.rs
@@ -17,7 +17,7 @@ use crate::types::GoalDefinition;
 /// ## Examples
 /// ```
 /// # use pddl::parsers::{parse_gd, preamble::*};
-/// # use pddl::{AtomicFormula, BinaryComp, BinaryOp, EqualityAtomicFormula, FComp, FExp, GoalDefinition, Literal, Term, Variable};
+/// # use pddl::{AtomicFormula, BinaryComparison, BinaryOp, EqualityAtomicFormula, FluentComparison, FluentExpression, GoalDefinition, Literal, Term, Variable};
 /// # use pddl::TypedList;
 /// // Atomic formula
 /// assert!(parse_gd("(= x y)").is_value(
@@ -117,17 +117,17 @@ use crate::types::GoalDefinition;
 ///
 /// assert!(parse_gd("(= (+ 1.23 2.34) (+ 1.23 2.34))").is_value(
 ///     GoalDefinition::new_f_comp(
-///         FComp::new(
-///             BinaryComp::Equal,
-///             FExp::new_binary_op(
+///         FluentComparison::new(
+///             BinaryComparison::Equal,
+///             FluentExpression::new_binary_op(
 ///                 BinaryOp::Addition,
-///                 FExp::new_number(1.23),
-///                 FExp::new_number(2.34),
+///                 FluentExpression::new_number(1.23),
+///                 FluentExpression::new_number(2.34),
 ///             ),
-///             FExp::new_binary_op(
+///             FluentExpression::new_binary_op(
 ///                 BinaryOp::Addition,
-///                 FExp::new_number(1.23),
-///                 FExp::new_number(2.34),
+///                 FluentExpression::new_number(1.23),
+///                 FluentExpression::new_number(2.34),
 ///             )
 ///         )
 ///     )
@@ -205,8 +205,8 @@ impl crate::parsers::Parser for GoalDefinition {
 mod tests {
     use crate::parsers::UnwrapValue;
     use crate::{
-        AtomicFormula, BinaryComp, BinaryOp, FComp, FExp, GoalDefinition, Parser, Term, TypedList,
-        Variable,
+        AtomicFormula, BinaryComparison, BinaryOp, FluentComparison, FluentExpression, GoalDefinition, Parser, Term,
+        TypedList, Variable,
     };
 
     #[test]
@@ -308,17 +308,17 @@ mod tests {
 
         assert!(
             GoalDefinition::parse("(= (+ 1.23 2.34) (+ 1.23 2.34))").is_value(
-                GoalDefinition::new_f_comp(FComp::new(
-                    BinaryComp::Equal,
-                    FExp::new_binary_op(
+                GoalDefinition::new_f_comp(FluentComparison::new(
+                    BinaryComparison::Equal,
+                    FluentExpression::new_binary_op(
                         BinaryOp::Addition,
-                        FExp::new_number(1.23),
-                        FExp::new_number(2.34),
+                        FluentExpression::new_number(1.23),
+                        FluentExpression::new_number(2.34),
                     ),
-                    FExp::new_binary_op(
+                    FluentExpression::new_binary_op(
                         BinaryOp::Addition,
-                        FExp::new_number(1.23),
-                        FExp::new_number(2.34),
+                        FluentExpression::new_number(1.23),
+                        FluentExpression::new_number(2.34),
                     )
                 ))
             )

--- a/src/parsers/goal_def.rs
+++ b/src/parsers/goal_def.rs
@@ -10,12 +10,12 @@ use nom::Parser;
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_problem_goal_def, preamble::*};
-/// # use pddl::{AtomicFormula, GoalDefinition, ProblemGoalDefinition, PreferenceGD, PreconditionGoalDefinition, Term};
+/// # use pddl::{AtomicFormula, GoalDefinition, ProblemGoalDefinition, PreferenceGoalDefinition, PreconditionGoalDefinition, Term};
 /// let input = "(:goal (= x y))";
 /// assert!(parse_problem_goal_def(input).is_value(
 ///     ProblemGoalDefinition::from(
 ///         PreconditionGoalDefinition::Preference(
-///             PreferenceGD::Goal(
+///             PreferenceGoalDefinition::Goal(
 ///                 GoalDefinition::AtomicFormula(
 ///                     AtomicFormula::new_equality(
 ///                         Term::Name("x".into()),
@@ -27,8 +27,14 @@ use nom::Parser;
 ///     )
 /// ));
 /// ```
-pub fn parse_problem_goal_def<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, ProblemGoalDefinition> {
-    map(prefix_expr(":goal", parse_pre_gd), ProblemGoalDefinition::new).parse(input.into())
+pub fn parse_problem_goal_def<'a, T: Into<Span<'a>>>(
+    input: T,
+) -> ParseResult<'a, ProblemGoalDefinition> {
+    map(
+        prefix_expr(":goal", parse_pre_gd),
+        ProblemGoalDefinition::new,
+    )
+    .parse(input.into())
 }
 
 impl crate::parsers::Parser for ProblemGoalDefinition {
@@ -44,20 +50,22 @@ impl crate::parsers::Parser for ProblemGoalDefinition {
 mod tests {
     use crate::parsers::UnwrapValue;
     use crate::{
-        AtomicFormula, GoalDefinition, Parser, PreconditionGoalDefinition, PreferenceGD,
-        ProblemGoalDefinition, Term,
+        AtomicFormula, GoalDefinition, Parser, PreconditionGoalDefinition,
+        PreferenceGoalDefinition, ProblemGoalDefinition, Term,
     };
 
     #[test]
     fn test_parse() {
         let input = "(:goal (= x y))";
-        assert!(ProblemGoalDefinition::parse(input).is_value(ProblemGoalDefinition::from(
-            PreconditionGoalDefinition::Preference(PreferenceGD::Goal(
-                GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
-                    Term::Name("x".into()),
-                    Term::Name("y".into())
+        assert!(
+            ProblemGoalDefinition::parse(input).is_value(ProblemGoalDefinition::from(
+                PreconditionGoalDefinition::Preference(PreferenceGoalDefinition::Goal(
+                    GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
+                        Term::Name("x".into()),
+                        Term::Name("y".into())
+                    ))
                 ))
             ))
-        )));
+        );
     }
 }

--- a/src/parsers/goal_def.rs
+++ b/src/parsers/goal_def.rs
@@ -1,7 +1,7 @@
 //! Provides parsers for pre-GD goal definitions.
 
 use crate::parsers::{parse_pre_gd, prefix_expr, ParseResult, Span};
-use crate::types::GoalDef;
+use crate::types::ProblemGoalDefinition;
 use nom::combinator::map;
 use nom::Parser;
 
@@ -10,10 +10,10 @@ use nom::Parser;
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_problem_goal_def, preamble::*};
-/// # use pddl::{AtomicFormula, GoalDef, GoalDefinition, PreferenceGD, PreconditionGoalDefinition, Term};
+/// # use pddl::{AtomicFormula, GoalDefinition, ProblemGoalDefinition, PreferenceGD, PreconditionGoalDefinition, Term};
 /// let input = "(:goal (= x y))";
 /// assert!(parse_problem_goal_def(input).is_value(
-///     GoalDef::from(
+///     ProblemGoalDefinition::from(
 ///         PreconditionGoalDefinition::Preference(
 ///             PreferenceGD::Goal(
 ///                 GoalDefinition::AtomicFormula(
@@ -27,12 +27,12 @@ use nom::Parser;
 ///     )
 /// ));
 /// ```
-pub fn parse_problem_goal_def<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, GoalDef> {
-    map(prefix_expr(":goal", parse_pre_gd), GoalDef::new).parse(input.into())
+pub fn parse_problem_goal_def<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, ProblemGoalDefinition> {
+    map(prefix_expr(":goal", parse_pre_gd), ProblemGoalDefinition::new).parse(input.into())
 }
 
-impl crate::parsers::Parser for GoalDef {
-    type Item = GoalDef;
+impl crate::parsers::Parser for ProblemGoalDefinition {
+    type Item = ProblemGoalDefinition;
 
     /// See [`parse_problem_goal_def`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
@@ -44,14 +44,14 @@ impl crate::parsers::Parser for GoalDef {
 mod tests {
     use crate::parsers::UnwrapValue;
     use crate::{
-        AtomicFormula, GoalDef, GoalDefinition, Parser, PreconditionGoalDefinition, PreferenceGD,
-        Term,
+        AtomicFormula, GoalDefinition, Parser, PreconditionGoalDefinition, PreferenceGD,
+        ProblemGoalDefinition, Term,
     };
 
     #[test]
     fn test_parse() {
         let input = "(:goal (= x y))";
-        assert!(GoalDef::parse(input).is_value(GoalDef::from(
+        assert!(ProblemGoalDefinition::parse(input).is_value(ProblemGoalDefinition::from(
             PreconditionGoalDefinition::Preference(PreferenceGD::Goal(
                 GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
                     Term::Name("x".into()),

--- a/src/parsers/metric_f_exp.rs
+++ b/src/parsers/metric_f_exp.rs
@@ -5,7 +5,7 @@ use crate::parsers::{
     space_separated_list0, space_separated_list1, ws, ParseResult, Span,
 };
 use crate::parsers::{parse_binary_op, parse_multi_op};
-use crate::types::MetricFExp;
+use crate::types::MetricFluentExpression;
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::character::complete::{char, multispace0, multispace1};
@@ -18,55 +18,55 @@ use nom::Parser;
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_metric_f_exp, preamble::*};
-/// # use pddl::{BinaryOp, MetricFExp, FunctionSymbol, MultiOp, Name, PreferenceName};
+/// # use pddl::{BinaryOp, MetricFluentExpression, FunctionSymbol, MultiOp, Name, PreferenceName};
 /// assert!(parse_metric_f_exp("1.23").is_value(
-///     MetricFExp::new_number(1.23)
+///     MetricFluentExpression::new_number(1.23)
 /// ));
 ///
 /// assert!(parse_metric_f_exp("(- total-time)").is_value(
-///     MetricFExp::new_negative(
-///         MetricFExp::TotalTime
+///     MetricFluentExpression::new_negative(
+///         MetricFluentExpression::TotalTime
 ///     )
 /// ));
 ///
 /// assert!(parse_metric_f_exp("(+ 1.23 2.34)").is_value(
-///     MetricFExp::new_binary_op(
+///     MetricFluentExpression::new_binary_op(
 ///         BinaryOp::Addition,
-///         MetricFExp::new_number(1.23),
-///         MetricFExp::new_number(2.34)
+///         MetricFluentExpression::new_number(1.23),
+///         MetricFluentExpression::new_number(2.34)
 ///     )
 /// ));
 ///
 /// assert!(parse_metric_f_exp("(+ 1.23 2.34 3.45)").is_value(
-///     MetricFExp::new_multi_op(
+///     MetricFluentExpression::new_multi_op(
 ///         MultiOp::Addition,
-///         MetricFExp::new_number(1.23),
-///         [MetricFExp::new_number(2.34), MetricFExp::new_number(3.45)]
+///         MetricFluentExpression::new_number(1.23),
+///         [MetricFluentExpression::new_number(2.34), MetricFluentExpression::new_number(3.45)]
 ///     )
 /// ));
 ///
 /// assert!(parse_metric_f_exp("(is-violated preference)").is_value(
-///     MetricFExp::new_is_violated(
+///     MetricFluentExpression::new_is_violated(
 ///         PreferenceName::from("preference")
 ///     )
 /// ));
 ///
 /// assert!(parse_metric_f_exp("fun-sym").is_value(
-///     MetricFExp::new_function(
+///     MetricFluentExpression::new_function(
 ///         FunctionSymbol::new_string("fun-sym"),
 ///         []
 ///     )
 /// ));
 ///
 /// assert!(parse_metric_f_exp("(fun-sym)").is_value(
-///     MetricFExp::new_function(
+///     MetricFluentExpression::new_function(
 ///         FunctionSymbol::new_string("fun-sym"),
 ///         []
 ///     )
 /// ));
 ///
 /// assert!(parse_metric_f_exp("(fun-sym a b c)").is_value(
-///     MetricFExp::new_function(
+///     MetricFluentExpression::new_function(
 ///         FunctionSymbol::new_string("fun-sym"),
 ///         [
 ///             Name::new("a"),
@@ -76,14 +76,14 @@ use nom::Parser;
 ///     )
 /// ));
 ///```
-pub fn parse_metric_f_exp<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, MetricFExp> {
+pub fn parse_metric_f_exp<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, MetricFluentExpression> {
     let binary_op = map(
         parens((
             parse_binary_op,
             preceded(multispace1, parse_metric_f_exp),
             preceded(multispace1, parse_metric_f_exp),
         )),
-        |(op, lhs, rhs)| MetricFExp::new_binary_op(op, lhs, rhs),
+        |(op, lhs, rhs)| MetricFluentExpression::new_binary_op(op, lhs, rhs),
     );
 
     let multi_op = map(
@@ -92,30 +92,30 @@ pub fn parse_metric_f_exp<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Me
             preceded(multispace1, parse_metric_f_exp),
             preceded(multispace1, space_separated_list1(parse_metric_f_exp)),
         )),
-        |(op, lhs, rhs)| MetricFExp::new_multi_op(op, lhs, rhs),
+        |(op, lhs, rhs)| MetricFluentExpression::new_multi_op(op, lhs, rhs),
     );
 
     let negated = map(
         parens(preceded((char('-'), multispace0), parse_metric_f_exp)),
-        MetricFExp::new_negative,
+        MetricFluentExpression::new_negative,
     );
 
-    let number = map(parse_number, MetricFExp::new_number);
+    let number = map(parse_number, MetricFluentExpression::new_number);
 
     let simple_function = map(parse_function_symbol, |sym| {
-        MetricFExp::new_function(sym, [])
+        MetricFluentExpression::new_function(sym, [])
     });
     let complex_function = map(
         parens((parse_function_symbol, ws(space_separated_list0(parse_name)))),
-        |(sym, names)| MetricFExp::new_function(sym, names),
+        |(sym, names)| MetricFluentExpression::new_function(sym, names),
     );
 
-    let total_time = map(tag("total-time"), |_| MetricFExp::new_total_time());
+    let total_time = map(tag("total-time"), |_| MetricFluentExpression::new_total_time());
 
     // :preferences
     let is_violated = map(
         prefix_expr("is-violated", parse_pref_name),
-        MetricFExp::new_is_violated,
+        MetricFluentExpression::new_is_violated,
     );
 
     alt((
@@ -131,8 +131,8 @@ pub fn parse_metric_f_exp<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Me
     .parse(input.into())
 }
 
-impl crate::parsers::Parser for MetricFExp {
-    type Item = MetricFExp;
+impl crate::parsers::Parser for MetricFluentExpression {
+    type Item = MetricFluentExpression;
 
     /// See [`parse_metric_f_exp`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
@@ -143,51 +143,51 @@ impl crate::parsers::Parser for MetricFExp {
 #[cfg(test)]
 mod tests {
     use crate::parsers::preamble::*;
-    use crate::{BinaryOp, FunctionSymbol, MetricFExp, MultiOp, Name, PreferenceName};
+    use crate::{BinaryOp, FunctionSymbol, MetricFluentExpression, MultiOp, Name, PreferenceName};
 
     #[test]
     fn test_parse() {
-        assert!(MetricFExp::parse("1.23").is_value(MetricFExp::new_number(1.23)));
+        assert!(MetricFluentExpression::parse("1.23").is_value(MetricFluentExpression::new_number(1.23)));
 
-        assert!(MetricFExp::parse("(- total-time)")
-            .is_value(MetricFExp::new_negative(MetricFExp::TotalTime)));
+        assert!(MetricFluentExpression::parse("(- total-time)")
+            .is_value(MetricFluentExpression::new_negative(MetricFluentExpression::TotalTime)));
 
         assert!(
-            MetricFExp::parse("(+ 1.23 2.34)").is_value(MetricFExp::new_binary_op(
+            MetricFluentExpression::parse("(+ 1.23 2.34)").is_value(MetricFluentExpression::new_binary_op(
                 BinaryOp::Addition,
-                MetricFExp::new_number(1.23),
-                MetricFExp::new_number(2.34)
+                MetricFluentExpression::new_number(1.23),
+                MetricFluentExpression::new_number(2.34)
             ))
         );
 
         assert!(
-            MetricFExp::parse("(+ 1.23 2.34 3.45)").is_value(MetricFExp::new_multi_op(
+            MetricFluentExpression::parse("(+ 1.23 2.34 3.45)").is_value(MetricFluentExpression::new_multi_op(
                 MultiOp::Addition,
-                MetricFExp::new_number(1.23),
-                [MetricFExp::new_number(2.34), MetricFExp::new_number(3.45)]
+                MetricFluentExpression::new_number(1.23),
+                [MetricFluentExpression::new_number(2.34), MetricFluentExpression::new_number(3.45)]
             ))
         );
 
-        assert!(MetricFExp::parse("(is-violated preference)").is_value(
-            MetricFExp::new_is_violated(PreferenceName::from("preference"))
+        assert!(MetricFluentExpression::parse("(is-violated preference)").is_value(
+            MetricFluentExpression::new_is_violated(PreferenceName::from("preference"))
         ));
 
         assert!(
-            MetricFExp::parse("fun-sym").is_value(MetricFExp::new_function(
+            MetricFluentExpression::parse("fun-sym").is_value(MetricFluentExpression::new_function(
                 FunctionSymbol::new_string("fun-sym"),
                 []
             ))
         );
 
         assert!(
-            MetricFExp::parse("(fun-sym)").is_value(MetricFExp::new_function(
+            MetricFluentExpression::parse("(fun-sym)").is_value(MetricFluentExpression::new_function(
                 FunctionSymbol::new_string("fun-sym"),
                 []
             ))
         );
 
         assert!(
-            MetricFExp::parse("(fun-sym a b c)").is_value(MetricFExp::new_function(
+            MetricFluentExpression::parse("(fun-sym a b c)").is_value(MetricFluentExpression::new_function(
                 FunctionSymbol::new_string("fun-sym"),
                 [Name::new("a"), Name::new("b"), Name::new("c")]
             ))

--- a/src/parsers/metric_f_exp.rs
+++ b/src/parsers/metric_f_exp.rs
@@ -20,54 +20,54 @@ use nom::Parser;
 /// # use pddl::parsers::{parse_metric_f_exp, preamble::*};
 /// # use pddl::{BinaryOp, MetricFluentExpression, FunctionSymbol, MultiOp, Name, PreferenceName};
 /// assert!(parse_metric_f_exp("1.23").is_value(
-///     MetricFluentExpression::new_number(1.23)
+///     MetricFluentExpression::number(1.23)
 /// ));
 ///
 /// assert!(parse_metric_f_exp("(- total-time)").is_value(
-///     MetricFluentExpression::new_negative(
+///     MetricFluentExpression::negative(
 ///         MetricFluentExpression::TotalTime
 ///     )
 /// ));
 ///
 /// assert!(parse_metric_f_exp("(+ 1.23 2.34)").is_value(
-///     MetricFluentExpression::new_binary_op(
+///     MetricFluentExpression::binary_op(
 ///         BinaryOp::Addition,
-///         MetricFluentExpression::new_number(1.23),
-///         MetricFluentExpression::new_number(2.34)
+///         MetricFluentExpression::number(1.23),
+///         MetricFluentExpression::number(2.34)
 ///     )
 /// ));
 ///
 /// assert!(parse_metric_f_exp("(+ 1.23 2.34 3.45)").is_value(
-///     MetricFluentExpression::new_multi_op(
+///     MetricFluentExpression::multi_op(
 ///         MultiOp::Addition,
-///         MetricFluentExpression::new_number(1.23),
-///         [MetricFluentExpression::new_number(2.34), MetricFluentExpression::new_number(3.45)]
+///         MetricFluentExpression::number(1.23),
+///         [MetricFluentExpression::number(2.34), MetricFluentExpression::number(3.45)]
 ///     )
 /// ));
 ///
 /// assert!(parse_metric_f_exp("(is-violated preference)").is_value(
-///     MetricFluentExpression::new_is_violated(
+///     MetricFluentExpression::is_violated(
 ///         PreferenceName::from("preference")
 ///     )
 /// ));
 ///
 /// assert!(parse_metric_f_exp("fun-sym").is_value(
-///     MetricFluentExpression::new_function(
-///         FunctionSymbol::new_string("fun-sym"),
+///     MetricFluentExpression::function(
+///         FunctionSymbol::string("fun-sym"),
 ///         []
 ///     )
 /// ));
 ///
 /// assert!(parse_metric_f_exp("(fun-sym)").is_value(
-///     MetricFluentExpression::new_function(
-///         FunctionSymbol::new_string("fun-sym"),
+///     MetricFluentExpression::function(
+///         FunctionSymbol::string("fun-sym"),
 ///         []
 ///     )
 /// ));
 ///
 /// assert!(parse_metric_f_exp("(fun-sym a b c)").is_value(
-///     MetricFluentExpression::new_function(
-///         FunctionSymbol::new_string("fun-sym"),
+///     MetricFluentExpression::function(
+///         FunctionSymbol::string("fun-sym"),
 ///         [
 ///             Name::new("a"),
 ///             Name::new("b"),
@@ -85,7 +85,7 @@ pub fn parse_metric_f_exp<'a, T: Into<Span<'a>>>(
             preceded(multispace1, parse_metric_f_exp),
             preceded(multispace1, parse_metric_f_exp),
         )),
-        |(op, lhs, rhs)| MetricFluentExpression::new_binary_op(op, lhs, rhs),
+        |(op, lhs, rhs)| MetricFluentExpression::binary_op(op, lhs, rhs),
     );
 
     let multi_op = map(
@@ -94,7 +94,7 @@ pub fn parse_metric_f_exp<'a, T: Into<Span<'a>>>(
             preceded(multispace1, parse_metric_f_exp),
             preceded(multispace1, space_separated_list1(parse_metric_f_exp)),
         )),
-        |(op, lhs, rhs)| MetricFluentExpression::new_multi_op(op, lhs, rhs),
+        |(op, lhs, rhs)| MetricFluentExpression::multi_op(op, lhs, rhs),
     );
 
     let negated = map(
@@ -105,16 +105,14 @@ pub fn parse_metric_f_exp<'a, T: Into<Span<'a>>>(
     let number = map(parse_number, MetricFluentExpression::new_number);
 
     let simple_function = map(parse_function_symbol, |sym| {
-        MetricFluentExpression::new_function(sym, [])
+        MetricFluentExpression::function(sym, [])
     });
     let complex_function = map(
         parens((parse_function_symbol, ws(space_separated_list0(parse_name)))),
-        |(sym, names)| MetricFluentExpression::new_function(sym, names),
+        |(sym, names)| MetricFluentExpression::function(sym, names),
     );
 
-    let total_time = map(tag("total-time"), |_| {
-        MetricFluentExpression::new_total_time()
-    });
+    let total_time = map(tag("total-time"), |_| MetricFluentExpression::total_time());
 
     // :preferences
     let is_violated = map(
@@ -151,29 +149,30 @@ mod tests {
 
     #[test]
     fn test_parse() {
-        assert!(MetricFluentExpression::parse("1.23")
-            .is_value(MetricFluentExpression::new_number(1.23)));
+        assert!(
+            MetricFluentExpression::parse("1.23").is_value(MetricFluentExpression::number(1.23))
+        );
 
         assert!(MetricFluentExpression::parse("(- total-time)").is_value(
-            MetricFluentExpression::new_negative(MetricFluentExpression::TotalTime)
+            MetricFluentExpression::negative(MetricFluentExpression::TotalTime)
         ));
 
         assert!(MetricFluentExpression::parse("(+ 1.23 2.34)").is_value(
-            MetricFluentExpression::new_binary_op(
+            MetricFluentExpression::binary_op(
                 BinaryOp::Addition,
-                MetricFluentExpression::new_number(1.23),
-                MetricFluentExpression::new_number(2.34)
+                MetricFluentExpression::number(1.23),
+                MetricFluentExpression::number(2.34)
             )
         ));
 
         assert!(
             MetricFluentExpression::parse("(+ 1.23 2.34 3.45)").is_value(
-                MetricFluentExpression::new_multi_op(
+                MetricFluentExpression::multi_op(
                     MultiOp::Addition,
-                    MetricFluentExpression::new_number(1.23),
+                    MetricFluentExpression::number(1.23),
                     [
-                        MetricFluentExpression::new_number(2.34),
-                        MetricFluentExpression::new_number(3.45)
+                        MetricFluentExpression::number(2.34),
+                        MetricFluentExpression::number(3.45)
                     ]
                 )
             )
@@ -181,21 +180,21 @@ mod tests {
 
         assert!(
             MetricFluentExpression::parse("(is-violated preference)").is_value(
-                MetricFluentExpression::new_is_violated(PreferenceName::from("preference"))
+                MetricFluentExpression::is_violated(PreferenceName::from("preference"))
             )
         );
 
         assert!(MetricFluentExpression::parse("fun-sym").is_value(
-            MetricFluentExpression::new_function(FunctionSymbol::new_string("fun-sym"), [])
+            MetricFluentExpression::function(FunctionSymbol::string("fun-sym"), [])
         ));
 
         assert!(MetricFluentExpression::parse("(fun-sym)").is_value(
-            MetricFluentExpression::new_function(FunctionSymbol::new_string("fun-sym"), [])
+            MetricFluentExpression::function(FunctionSymbol::string("fun-sym"), [])
         ));
 
         assert!(MetricFluentExpression::parse("(fun-sym a b c)").is_value(
-            MetricFluentExpression::new_function(
-                FunctionSymbol::new_string("fun-sym"),
+            MetricFluentExpression::function(
+                FunctionSymbol::string("fun-sym"),
                 [Name::new("a"), Name::new("b"), Name::new("c")]
             )
         ));

--- a/src/parsers/metric_f_exp.rs
+++ b/src/parsers/metric_f_exp.rs
@@ -76,7 +76,9 @@ use nom::Parser;
 ///     )
 /// ));
 ///```
-pub fn parse_metric_f_exp<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, MetricFluentExpression> {
+pub fn parse_metric_f_exp<'a, T: Into<Span<'a>>>(
+    input: T,
+) -> ParseResult<'a, MetricFluentExpression> {
     let binary_op = map(
         parens((
             parse_binary_op,
@@ -110,7 +112,9 @@ pub fn parse_metric_f_exp<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Me
         |(sym, names)| MetricFluentExpression::new_function(sym, names),
     );
 
-    let total_time = map(tag("total-time"), |_| MetricFluentExpression::new_total_time());
+    let total_time = map(tag("total-time"), |_| {
+        MetricFluentExpression::new_total_time()
+    });
 
     // :preferences
     let is_violated = map(
@@ -147,50 +151,53 @@ mod tests {
 
     #[test]
     fn test_parse() {
-        assert!(MetricFluentExpression::parse("1.23").is_value(MetricFluentExpression::new_number(1.23)));
+        assert!(MetricFluentExpression::parse("1.23")
+            .is_value(MetricFluentExpression::new_number(1.23)));
 
-        assert!(MetricFluentExpression::parse("(- total-time)")
-            .is_value(MetricFluentExpression::new_negative(MetricFluentExpression::TotalTime)));
+        assert!(MetricFluentExpression::parse("(- total-time)").is_value(
+            MetricFluentExpression::new_negative(MetricFluentExpression::TotalTime)
+        ));
 
-        assert!(
-            MetricFluentExpression::parse("(+ 1.23 2.34)").is_value(MetricFluentExpression::new_binary_op(
+        assert!(MetricFluentExpression::parse("(+ 1.23 2.34)").is_value(
+            MetricFluentExpression::new_binary_op(
                 BinaryOp::Addition,
                 MetricFluentExpression::new_number(1.23),
                 MetricFluentExpression::new_number(2.34)
-            ))
-        );
-
-        assert!(
-            MetricFluentExpression::parse("(+ 1.23 2.34 3.45)").is_value(MetricFluentExpression::new_multi_op(
-                MultiOp::Addition,
-                MetricFluentExpression::new_number(1.23),
-                [MetricFluentExpression::new_number(2.34), MetricFluentExpression::new_number(3.45)]
-            ))
-        );
-
-        assert!(MetricFluentExpression::parse("(is-violated preference)").is_value(
-            MetricFluentExpression::new_is_violated(PreferenceName::from("preference"))
+            )
         ));
 
         assert!(
-            MetricFluentExpression::parse("fun-sym").is_value(MetricFluentExpression::new_function(
-                FunctionSymbol::new_string("fun-sym"),
-                []
-            ))
+            MetricFluentExpression::parse("(+ 1.23 2.34 3.45)").is_value(
+                MetricFluentExpression::new_multi_op(
+                    MultiOp::Addition,
+                    MetricFluentExpression::new_number(1.23),
+                    [
+                        MetricFluentExpression::new_number(2.34),
+                        MetricFluentExpression::new_number(3.45)
+                    ]
+                )
+            )
         );
 
         assert!(
-            MetricFluentExpression::parse("(fun-sym)").is_value(MetricFluentExpression::new_function(
-                FunctionSymbol::new_string("fun-sym"),
-                []
-            ))
+            MetricFluentExpression::parse("(is-violated preference)").is_value(
+                MetricFluentExpression::new_is_violated(PreferenceName::from("preference"))
+            )
         );
 
-        assert!(
-            MetricFluentExpression::parse("(fun-sym a b c)").is_value(MetricFluentExpression::new_function(
+        assert!(MetricFluentExpression::parse("fun-sym").is_value(
+            MetricFluentExpression::new_function(FunctionSymbol::new_string("fun-sym"), [])
+        ));
+
+        assert!(MetricFluentExpression::parse("(fun-sym)").is_value(
+            MetricFluentExpression::new_function(FunctionSymbol::new_string("fun-sym"), [])
+        ));
+
+        assert!(MetricFluentExpression::parse("(fun-sym a b c)").is_value(
+            MetricFluentExpression::new_function(
                 FunctionSymbol::new_string("fun-sym"),
                 [Name::new("a"), Name::new("b"), Name::new("c")]
-            ))
-        );
+            )
+        ));
     }
 }

--- a/src/parsers/metric_spec.rs
+++ b/src/parsers/metric_spec.rs
@@ -13,11 +13,11 @@ use crate::types::MetricSpec;
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_problem_metric_spec, preamble::*};
-/// # use pddl::{MetricFExp, MetricSpec, Optimization};
+/// # use pddl::{MetricFluentExpression, MetricSpec, Optimization};
 /// assert!(parse_problem_metric_spec("(:metric minimize total-time)").is_value(
 ///     MetricSpec::new(
 ///         Optimization::Minimize,
-///         MetricFExp::TotalTime
+///         MetricFluentExpression::TotalTime
 ///     )
 /// ));
 ///```
@@ -48,14 +48,14 @@ impl crate::parsers::Parser for MetricSpec {
 #[cfg(test)]
 mod tests {
     use crate::parsers::UnwrapValue;
-    use crate::{MetricFExp, MetricSpec, Optimization, Parser};
+    use crate::{MetricFluentExpression, MetricSpec, Optimization, Parser};
 
     #[test]
     fn test_parse() {
         assert!(
             MetricSpec::parse("(:metric minimize total-time)").is_value(MetricSpec::new(
                 Optimization::Minimize,
-                MetricFExp::TotalTime
+                MetricFluentExpression::TotalTime
             ))
         );
     }

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -132,7 +132,8 @@ pub use binary_op::parse_binary_op;
 pub use c_effect::{parse_c_effect, parse_forall_c_effect, parse_when_c_effect};
 pub use comments::ignore_eol_comment;
 pub use con_gd::parse_con_gd;
-pub use cond_effect::parse_cond_effect;
+#[allow(deprecated)]
+pub use cond_effect::{parse_cond_effect, parse_effect_condition};
 pub use constants_def::parse_constants_def;
 pub use d_op::parse_d_op;
 pub use d_value::parse_d_value;
@@ -186,7 +187,8 @@ pub use simple_duration_constraint::parse_simple_duration_constraint;
 pub use structure_def::parse_structure_def;
 pub use term::parse_term;
 pub use time_specifier::parse_time_specifier;
-pub use timed_effect::parse_timed_effect;
+#[allow(deprecated)]
+pub use timed_effect::{parse_timed_eff, parse_timed_effect};
 pub use timed_gd::parse_timed_gd;
 pub use timeless_def::parse_timeless_def;
 pub use types_def::parse_types_def;

--- a/src/parsers/p_effect.rs
+++ b/src/parsers/p_effect.rs
@@ -116,8 +116,8 @@ mod tests {
     use super::*;
     use crate::parsers::UnwrapValue;
     use crate::{
-        AssignOp, AtomicFormula, EqualityAtomicFormula, FluentExpression, FunctionHead, FunctionSymbol, FunctionTerm,
-        Parser, Term,
+        AssignOp, AtomicFormula, EqualityAtomicFormula, FluentExpression, FunctionHead,
+        FunctionSymbol, FunctionTerm, Parser, Term,
     };
 
     #[test]
@@ -139,50 +139,54 @@ mod tests {
 
     #[test]
     fn test_parse() {
-        assert!(PrimitiveEffect::parse("(= x y)").is_value(PrimitiveEffect::AtomicFormula(
-            AtomicFormula::Equality(EqualityAtomicFormula::new(
-                Term::Name("x".into()),
-                Term::Name("y".into())
-            ))
-        )));
-
         assert!(
-            PrimitiveEffect::parse("(not (= ?a B))").is_value(PrimitiveEffect::NotAtomicFormula(
+            PrimitiveEffect::parse("(= x y)").is_value(PrimitiveEffect::AtomicFormula(
                 AtomicFormula::Equality(EqualityAtomicFormula::new(
-                    Term::Variable("a".into()),
-                    Term::Name("B".into())
+                    Term::Name("x".into()),
+                    Term::Name("y".into())
                 ))
             ))
         );
 
-        assert!(
-            PrimitiveEffect::parse("(assign fun-sym 1.23)").is_value(PrimitiveEffect::new_numeric_fluent(
+        assert!(PrimitiveEffect::parse("(not (= ?a B))").is_value(
+            PrimitiveEffect::NotAtomicFormula(AtomicFormula::Equality(EqualityAtomicFormula::new(
+                Term::Variable("a".into()),
+                Term::Name("B".into())
+            )))
+        ));
+
+        assert!(PrimitiveEffect::parse("(assign fun-sym 1.23)").is_value(
+            PrimitiveEffect::new_numeric_fluent(
                 AssignOp::Assign,
                 FunctionHead::new(FunctionSymbol::new_string("fun-sym")),
                 FluentExpression::new_number(1.23)
-            ))
-        );
+            )
+        ));
 
-        assert!(
-            PrimitiveEffect::parse("(assign fun-sym 1.23)").is_value(PrimitiveEffect::new_numeric_fluent(
+        assert!(PrimitiveEffect::parse("(assign fun-sym 1.23)").is_value(
+            PrimitiveEffect::new_numeric_fluent(
                 AssignOp::Assign,
                 FunctionHead::new(FunctionSymbol::new_string("fun-sym")),
                 FluentExpression::new_number(1.23)
-            ))
+            )
+        ));
+
+        assert!(
+            PrimitiveEffect::parse("(assign (fun-sym) undefined)").is_value(
+                PrimitiveEffect::new_object_fluent(
+                    FunctionTerm::new(FunctionSymbol::new_string("fun-sym"), []),
+                    None
+                )
+            )
         );
 
-        assert!(PrimitiveEffect::parse("(assign (fun-sym) undefined)").is_value(
-            PrimitiveEffect::new_object_fluent(
-                FunctionTerm::new(FunctionSymbol::new_string("fun-sym"), []),
-                None
+        assert!(
+            PrimitiveEffect::parse("(assign (fun-sym) something)").is_value(
+                PrimitiveEffect::new_object_fluent(
+                    FunctionTerm::new(FunctionSymbol::new_string("fun-sym"), []),
+                    Some(Term::Name("something".into()))
+                )
             )
-        ));
-
-        assert!(PrimitiveEffect::parse("(assign (fun-sym) something)").is_value(
-            PrimitiveEffect::new_object_fluent(
-                FunctionTerm::new(FunctionSymbol::new_string("fun-sym"), []),
-                Some(Term::Name("something".into()))
-            )
-        ));
+        );
     }
 }

--- a/src/parsers/p_effect.rs
+++ b/src/parsers/p_effect.rs
@@ -5,7 +5,7 @@ use crate::parsers::{
     ParseResult, Span,
 };
 use crate::parsers::{parens, prefix_expr};
-use crate::types::PEffect;
+use crate::types::PrimitiveEffect;
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::character::complete::multispace1;
@@ -18,9 +18,9 @@ use nom::Parser;
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_p_effect, preamble::*};
-/// # use pddl::{AssignOp, AtomicFormula, EqualityAtomicFormula, FExp, FHead, FunctionSymbol, FunctionTerm, PEffect, Term};
+/// # use pddl::{AssignOp, AtomicFormula, EqualityAtomicFormula, FluentExpression, FunctionHead, FunctionSymbol, FunctionTerm, PrimitiveEffect, Term};
 /// assert!(parse_p_effect("(= x y)").is_value(
-///     PEffect::AtomicFormula(AtomicFormula::Equality(
+///     PrimitiveEffect::AtomicFormula(AtomicFormula::Equality(
 ///         EqualityAtomicFormula::new(
 ///             Term::Name("x".into()),
 ///             Term::Name("y".into()))
@@ -29,7 +29,7 @@ use nom::Parser;
 /// ));
 ///
 /// assert!(parse_p_effect("(not (= ?a B))").is_value(
-///     PEffect::NotAtomicFormula(AtomicFormula::Equality(
+///     PrimitiveEffect::NotAtomicFormula(AtomicFormula::Equality(
 ///         EqualityAtomicFormula::new(
 ///             Term::Variable("a".into()),
 ///             Term::Name("B".into()))
@@ -38,39 +38,39 @@ use nom::Parser;
 /// ));
 ///
 /// assert!(parse_p_effect("(assign fun-sym 1.23)").is_value(
-///     PEffect::new_numeric_fluent(
+///     PrimitiveEffect::new_numeric_fluent(
 ///         AssignOp::Assign,
-///         FHead::new(FunctionSymbol::new_string("fun-sym")),
-///         FExp::new_number(1.23)
+///         FunctionHead::new(FunctionSymbol::new_string("fun-sym")),
+///         FluentExpression::new_number(1.23)
 ///     )
 /// ));
 ///
 /// assert!(parse_p_effect("(assign fun-sym 1.23)").is_value(
-///     PEffect::new_numeric_fluent(
+///     PrimitiveEffect::new_numeric_fluent(
 ///         AssignOp::Assign,
-///         FHead::new(FunctionSymbol::new_string("fun-sym")),
-///         FExp::new_number(1.23)
+///         FunctionHead::new(FunctionSymbol::new_string("fun-sym")),
+///         FluentExpression::new_number(1.23)
 ///     )
 /// ));
 ///
 /// assert!(parse_p_effect("(assign (fun-sym) undefined)").is_value(
-///     PEffect::new_object_fluent(
+///     PrimitiveEffect::new_object_fluent(
 ///         FunctionTerm::new(FunctionSymbol::new_string("fun-sym"), []),
 ///         None
 ///     )
 /// ));
 ///
 /// assert!(parse_p_effect("(assign (fun-sym) something)").is_value(
-///     PEffect::new_object_fluent(
+///     PrimitiveEffect::new_object_fluent(
 ///         FunctionTerm::new(FunctionSymbol::new_string("fun-sym"), []),
 ///         Some(Term::Name("something".into()))
 ///     )
 /// ));
 /// ```
-pub fn parse_p_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, PEffect> {
-    let is = map(atomic_formula(parse_term), PEffect::new);
+pub fn parse_p_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, PrimitiveEffect> {
+    let is = map(atomic_formula(parse_term), PrimitiveEffect::new);
     let is_not = map(prefix_expr("not", atomic_formula(parse_term)), |af| {
-        PEffect::new_not(af)
+        PrimitiveEffect::new_not(af)
     });
 
     // :numeric-fluents
@@ -80,7 +80,7 @@ pub fn parse_p_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, PEffec
             preceded(multispace1, parse_f_head),
             preceded(multispace1, parse_f_exp),
         )),
-        |(op, head, exp)| PEffect::new_numeric_fluent(op, head, exp),
+        |(op, head, exp)| PrimitiveEffect::new_numeric_fluent(op, head, exp),
     );
 
     // :object-fluents
@@ -89,21 +89,21 @@ pub fn parse_p_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, PEffec
             "assign",
             terminated(parse_function_term, (multispace1, tag("undefined"))),
         ),
-        |f_term| PEffect::new_object_fluent(f_term, None),
+        |f_term| PrimitiveEffect::new_object_fluent(f_term, None),
     );
     let object = map(
         prefix_expr(
             "assign",
             (parse_function_term, preceded(multispace1, parse_term)),
         ),
-        |(f_term, term)| PEffect::new_object_fluent(f_term, Some(term)),
+        |(f_term, term)| PrimitiveEffect::new_object_fluent(f_term, Some(term)),
     );
 
     alt((is_not, object_undefined, object, numeric, is)).parse(input.into())
 }
 
-impl crate::parsers::Parser for PEffect {
-    type Item = PEffect;
+impl crate::parsers::Parser for PrimitiveEffect {
+    type Item = PrimitiveEffect;
 
     /// See [`parse_p_effect`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
@@ -116,7 +116,7 @@ mod tests {
     use super::*;
     use crate::parsers::UnwrapValue;
     use crate::{
-        AssignOp, AtomicFormula, EqualityAtomicFormula, FExp, FHead, FunctionSymbol, FunctionTerm,
+        AssignOp, AtomicFormula, EqualityAtomicFormula, FluentExpression, FunctionHead, FunctionSymbol, FunctionTerm,
         Parser, Term,
     };
 
@@ -130,7 +130,7 @@ mod tests {
     fn not_works() {
         let input = "(not (at B ?m))";
         let mut is_not = map(prefix_expr("not", atomic_formula(parse_term)), |af| {
-            PEffect::new_not(af)
+            PrimitiveEffect::new_not(af)
         });
 
         let result: Result<(_, _), _> = nom::Parser::parse(&mut is_not, input.into());
@@ -139,7 +139,7 @@ mod tests {
 
     #[test]
     fn test_parse() {
-        assert!(PEffect::parse("(= x y)").is_value(PEffect::AtomicFormula(
+        assert!(PrimitiveEffect::parse("(= x y)").is_value(PrimitiveEffect::AtomicFormula(
             AtomicFormula::Equality(EqualityAtomicFormula::new(
                 Term::Name("x".into()),
                 Term::Name("y".into())
@@ -147,7 +147,7 @@ mod tests {
         )));
 
         assert!(
-            PEffect::parse("(not (= ?a B))").is_value(PEffect::NotAtomicFormula(
+            PrimitiveEffect::parse("(not (= ?a B))").is_value(PrimitiveEffect::NotAtomicFormula(
                 AtomicFormula::Equality(EqualityAtomicFormula::new(
                     Term::Variable("a".into()),
                     Term::Name("B".into())
@@ -156,30 +156,30 @@ mod tests {
         );
 
         assert!(
-            PEffect::parse("(assign fun-sym 1.23)").is_value(PEffect::new_numeric_fluent(
+            PrimitiveEffect::parse("(assign fun-sym 1.23)").is_value(PrimitiveEffect::new_numeric_fluent(
                 AssignOp::Assign,
-                FHead::new(FunctionSymbol::new_string("fun-sym")),
-                FExp::new_number(1.23)
+                FunctionHead::new(FunctionSymbol::new_string("fun-sym")),
+                FluentExpression::new_number(1.23)
             ))
         );
 
         assert!(
-            PEffect::parse("(assign fun-sym 1.23)").is_value(PEffect::new_numeric_fluent(
+            PrimitiveEffect::parse("(assign fun-sym 1.23)").is_value(PrimitiveEffect::new_numeric_fluent(
                 AssignOp::Assign,
-                FHead::new(FunctionSymbol::new_string("fun-sym")),
-                FExp::new_number(1.23)
+                FunctionHead::new(FunctionSymbol::new_string("fun-sym")),
+                FluentExpression::new_number(1.23)
             ))
         );
 
-        assert!(PEffect::parse("(assign (fun-sym) undefined)").is_value(
-            PEffect::new_object_fluent(
+        assert!(PrimitiveEffect::parse("(assign (fun-sym) undefined)").is_value(
+            PrimitiveEffect::new_object_fluent(
                 FunctionTerm::new(FunctionSymbol::new_string("fun-sym"), []),
                 None
             )
         ));
 
-        assert!(PEffect::parse("(assign (fun-sym) something)").is_value(
-            PEffect::new_object_fluent(
+        assert!(PrimitiveEffect::parse("(assign (fun-sym) something)").is_value(
+            PrimitiveEffect::new_object_fluent(
                 FunctionTerm::new(FunctionSymbol::new_string("fun-sym"), []),
                 Some(Term::Name("something".into()))
             )

--- a/src/parsers/p_effect.rs
+++ b/src/parsers/p_effect.rs
@@ -38,31 +38,31 @@ use nom::Parser;
 /// ));
 ///
 /// assert!(parse_p_effect("(assign fun-sym 1.23)").is_value(
-///     PrimitiveEffect::new_numeric_fluent(
+///     PrimitiveEffect::numeric_fluent(
 ///         AssignOp::Assign,
-///         FunctionHead::new(FunctionSymbol::new_string("fun-sym")),
-///         FluentExpression::new_number(1.23)
+///         FunctionHead::new(FunctionSymbol::string("fun-sym")),
+///         FluentExpression::number(1.23)
 ///     )
 /// ));
 ///
 /// assert!(parse_p_effect("(assign fun-sym 1.23)").is_value(
-///     PrimitiveEffect::new_numeric_fluent(
+///     PrimitiveEffect::numeric_fluent(
 ///         AssignOp::Assign,
-///         FunctionHead::new(FunctionSymbol::new_string("fun-sym")),
-///         FluentExpression::new_number(1.23)
+///         FunctionHead::new(FunctionSymbol::string("fun-sym")),
+///         FluentExpression::number(1.23)
 ///     )
 /// ));
 ///
 /// assert!(parse_p_effect("(assign (fun-sym) undefined)").is_value(
-///     PrimitiveEffect::new_object_fluent(
-///         FunctionTerm::new(FunctionSymbol::new_string("fun-sym"), []),
+///     PrimitiveEffect::object_fluent(
+///         FunctionTerm::new(FunctionSymbol::string("fun-sym"), []),
 ///         None
 ///     )
 /// ));
 ///
 /// assert!(parse_p_effect("(assign (fun-sym) something)").is_value(
-///     PrimitiveEffect::new_object_fluent(
-///         FunctionTerm::new(FunctionSymbol::new_string("fun-sym"), []),
+///     PrimitiveEffect::object_fluent(
+///         FunctionTerm::new(FunctionSymbol::string("fun-sym"), []),
 ///         Some(Term::Name("something".into()))
 ///     )
 /// ));
@@ -70,7 +70,7 @@ use nom::Parser;
 pub fn parse_p_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, PrimitiveEffect> {
     let is = map(atomic_formula(parse_term), PrimitiveEffect::new);
     let is_not = map(prefix_expr("not", atomic_formula(parse_term)), |af| {
-        PrimitiveEffect::new_not(af)
+        PrimitiveEffect::not(af)
     });
 
     // :numeric-fluents
@@ -80,7 +80,7 @@ pub fn parse_p_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Primit
             preceded(multispace1, parse_f_head),
             preceded(multispace1, parse_f_exp),
         )),
-        |(op, head, exp)| PrimitiveEffect::new_numeric_fluent(op, head, exp),
+        |(op, head, exp)| PrimitiveEffect::numeric_fluent(op, head, exp),
     );
 
     // :object-fluents
@@ -89,14 +89,14 @@ pub fn parse_p_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Primit
             "assign",
             terminated(parse_function_term, (multispace1, tag("undefined"))),
         ),
-        |f_term| PrimitiveEffect::new_object_fluent(f_term, None),
+        |f_term| PrimitiveEffect::object_fluent(f_term, None),
     );
     let object = map(
         prefix_expr(
             "assign",
             (parse_function_term, preceded(multispace1, parse_term)),
         ),
-        |(f_term, term)| PrimitiveEffect::new_object_fluent(f_term, Some(term)),
+        |(f_term, term)| PrimitiveEffect::object_fluent(f_term, Some(term)),
     );
 
     alt((is_not, object_undefined, object, numeric, is)).parse(input.into())
@@ -130,7 +130,7 @@ mod tests {
     fn not_works() {
         let input = "(not (at B ?m))";
         let mut is_not = map(prefix_expr("not", atomic_formula(parse_term)), |af| {
-            PrimitiveEffect::new_not(af)
+            PrimitiveEffect::not(af)
         });
 
         let result: Result<(_, _), _> = nom::Parser::parse(&mut is_not, input.into());
@@ -156,25 +156,25 @@ mod tests {
         ));
 
         assert!(PrimitiveEffect::parse("(assign fun-sym 1.23)").is_value(
-            PrimitiveEffect::new_numeric_fluent(
+            PrimitiveEffect::numeric_fluent(
                 AssignOp::Assign,
-                FunctionHead::new(FunctionSymbol::new_string("fun-sym")),
-                FluentExpression::new_number(1.23)
+                FunctionHead::new(FunctionSymbol::string("fun-sym")),
+                FluentExpression::number(1.23)
             )
         ));
 
         assert!(PrimitiveEffect::parse("(assign fun-sym 1.23)").is_value(
-            PrimitiveEffect::new_numeric_fluent(
+            PrimitiveEffect::numeric_fluent(
                 AssignOp::Assign,
-                FunctionHead::new(FunctionSymbol::new_string("fun-sym")),
-                FluentExpression::new_number(1.23)
+                FunctionHead::new(FunctionSymbol::string("fun-sym")),
+                FluentExpression::number(1.23)
             )
         ));
 
         assert!(
             PrimitiveEffect::parse("(assign (fun-sym) undefined)").is_value(
-                PrimitiveEffect::new_object_fluent(
-                    FunctionTerm::new(FunctionSymbol::new_string("fun-sym"), []),
+                PrimitiveEffect::object_fluent(
+                    FunctionTerm::new(FunctionSymbol::string("fun-sym"), []),
                     None
                 )
             )
@@ -182,8 +182,8 @@ mod tests {
 
         assert!(
             PrimitiveEffect::parse("(assign (fun-sym) something)").is_value(
-                PrimitiveEffect::new_object_fluent(
-                    FunctionTerm::new(FunctionSymbol::new_string("fun-sym"), []),
+                PrimitiveEffect::object_fluent(
+                    FunctionTerm::new(FunctionSymbol::string("fun-sym"), []),
                     Some(Term::Name("something".into()))
                 )
             )

--- a/src/parsers/pre_gd.rs
+++ b/src/parsers/pre_gd.rs
@@ -16,10 +16,10 @@ use crate::PreconditionGoalDefinitions;
 /// ## Examples
 /// ```
 /// # use pddl::parsers::{parse_pre_gd, preamble::*};
-/// # use pddl::{AtomicFormula, EqualityAtomicFormula, GoalDefinition, Literal, Preference, PreferenceName, PreferenceGD, PreconditionGoalDefinitions, PreconditionGoalDefinition, Term, Variable, Type, Typed, TypedList};
+/// # use pddl::{AtomicFormula, EqualityAtomicFormula, GoalDefinition, Literal, Preference, PreferenceName, PreferenceGoalDefinition, PreconditionGoalDefinitions, PreconditionGoalDefinition, Term, Variable, Type, Typed, TypedList};
 /// assert!(parse_pre_gd(Span::new("(= x y)")).is_value(
 ///     PreconditionGoalDefinitions::new_preference(
-///         PreferenceGD::Goal(
+///         PreferenceGoalDefinition::Goal(
 ///             GoalDefinition::AtomicFormula(
 ///                 AtomicFormula::new_equality(
 ///                     Term::Name("x".into()),
@@ -32,7 +32,7 @@ use crate::PreconditionGoalDefinitions;
 ///
 /// assert!(parse_pre_gd(Span::new("(and (= x y) (= a b))")).is_value(
 ///     PreconditionGoalDefinitions::from_iter([
-///         PreconditionGoalDefinition::Preference(PreferenceGD::Goal(
+///         PreconditionGoalDefinition::Preference(PreferenceGoalDefinition::Goal(
 ///             GoalDefinition::AtomicFormula(
 ///                 AtomicFormula::new_equality(
 ///                     Term::Name("x".into()),
@@ -40,7 +40,7 @@ use crate::PreconditionGoalDefinitions;
 ///                 )
 ///             )
 ///         )),
-///         PreconditionGoalDefinition::Preference(PreferenceGD::Goal(
+///         PreconditionGoalDefinition::Preference(PreferenceGoalDefinition::Goal(
 ///             GoalDefinition::AtomicFormula(
 ///                 AtomicFormula::new_equality(
 ///                     Term::Name("a".into()),
@@ -57,7 +57,7 @@ use crate::PreconditionGoalDefinitions;
 ///             Typed::new(Variable::new_string("a"), Type::OBJECT),
 ///             Typed::new(Variable::new_string("b"), Type::OBJECT),
 ///         ]),
-///         PreconditionGoalDefinition::new_preference(PreferenceGD::Goal(
+///         PreconditionGoalDefinition::new_preference(PreferenceGoalDefinition::Goal(
 ///             GoalDefinition::AtomicFormula(
 ///                 AtomicFormula::new_equality(
 ///                     Term::Name("a".into()),
@@ -110,14 +110,14 @@ mod tests {
     use crate::parsers::preamble::*;
     use crate::{
         AtomicFormula, GoalDefinition, PreconditionGoalDefinition, PreconditionGoalDefinitions,
-        PreferenceGD, Term, Type, Typed, TypedList, Variable,
+        PreferenceGoalDefinition, Term, Type, Typed, TypedList, Variable,
     };
 
     #[test]
     fn test_parse() {
         assert!(
             PreconditionGoalDefinitions::parse(Span::new("(= x y)")).is_value(
-                PreconditionGoalDefinitions::new_preference(PreferenceGD::Goal(
+                PreconditionGoalDefinitions::new_preference(PreferenceGoalDefinition::Goal(
                     GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
                         Term::Name("x".into()),
                         Term::Name("y".into())
@@ -129,13 +129,13 @@ mod tests {
         assert!(
             PreconditionGoalDefinitions::parse(Span::new("(and (= x y) (= a b))")).is_value(
                 PreconditionGoalDefinitions::from_iter([
-                    PreconditionGoalDefinition::Preference(PreferenceGD::Goal(
+                    PreconditionGoalDefinition::Preference(PreferenceGoalDefinition::Goal(
                         GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
                             Term::Name("x".into()),
                             Term::Name("y".into())
                         ))
                     )),
-                    PreconditionGoalDefinition::Preference(PreferenceGD::Goal(
+                    PreconditionGoalDefinition::Preference(PreferenceGoalDefinition::Goal(
                         GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
                             Term::Name("a".into()),
                             Term::Name("b".into())
@@ -152,7 +152,7 @@ mod tests {
                         Typed::new(Variable::new_string("a"), Type::OBJECT),
                         Typed::new(Variable::new_string("b"), Type::OBJECT),
                     ]),
-                    PreconditionGoalDefinition::new_preference(PreferenceGD::Goal(
+                    PreconditionGoalDefinition::new_preference(PreferenceGoalDefinition::Goal(
                         GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
                             Term::Name("a".into()),
                             Term::Name("b".into())

--- a/src/parsers/pref_con_gd.rs
+++ b/src/parsers/pref_con_gd.rs
@@ -4,7 +4,7 @@ use crate::parsers::{
     parens, parse_con_gd, parse_pref_name, parse_variable, prefix_expr, space_separated_list0,
     typed_list, ParseResult, Span,
 };
-use crate::PrefConGDs;
+use crate::PreferenceConstraintGoalDefinitions;
 use nom::branch::alt;
 use nom::character::complete::multispace1;
 use nom::combinator::map;
@@ -16,7 +16,7 @@ use nom::Parser;
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_pref_con_gd, preamble::*};
-/// # use pddl::{AtomicFormula, Con2GD, ConGD, GoalDefinition, Number, PrefConGD, PrefConGDs, Term, ToTyped, Type, TypedList, Variable};
+/// # use pddl::{AtomicFormula, ConstraintGoalDefinitionInner, ConstraintGoalDefinition, GoalDefinition, Number, PreferenceConstraintGoalDefinition, PreferenceConstraintGoalDefinitions, Term, ToTyped, Type, TypedList, Variable};
 /// // (= x y)
 /// let gd_a =
 ///     GoalDefinition::new_atomic_formula(
@@ -38,25 +38,25 @@ use nom::Parser;
 ///     );
 ///
 /// assert!(parse_pref_con_gd("(and)").is_value(
-///     PrefConGDs::default()
+///     PreferenceConstraintGoalDefinitions::default()
 /// ));
 ///
 /// assert!(parse_pref_con_gd("(and (at end (= x y)) (at end (not (= x z))))").is_value(
-///     PrefConGDs::from_iter([
-///         PrefConGD::new_goal(ConGD::new_at_end(gd_a.clone())),
-///         PrefConGD::new_goal(ConGD::new_at_end(gd_b.clone())),
+///     PreferenceConstraintGoalDefinitions::from_iter([
+///         PreferenceConstraintGoalDefinition::new_goal(ConstraintGoalDefinition::new_at_end(gd_a.clone())),
+///         PreferenceConstraintGoalDefinition::new_goal(ConstraintGoalDefinition::new_at_end(gd_b.clone())),
 ///     ])
 /// ));
 ///
 /// assert!(parse_pref_con_gd("(forall (?x ?z) (sometime (= ?x ?z)))").is_value(
-///     PrefConGDs::new_forall(
+///     PreferenceConstraintGoalDefinitions::new_forall(
 ///         TypedList::from_iter([
 ///             Variable::from("x").to_typed(Type::OBJECT),
 ///             Variable::from("z").to_typed(Type::OBJECT),
 ///         ]),
-///         PrefConGDs::new_goal(ConGD::new_sometime(
+///         PreferenceConstraintGoalDefinitions::new_goal(ConstraintGoalDefinition::new_sometime(
 ///                 // gd ...
-///                 # Con2GD::Goal(
+///                 # ConstraintGoalDefinitionInner::Goal(
 ///                     # GoalDefinition::new_atomic_formula(
 ///                     #    AtomicFormula::new_equality(
 ///                     #        Term::Variable("x".into()),
@@ -70,21 +70,21 @@ use nom::Parser;
 /// ));
 ///
 /// assert!(parse_pref_con_gd("(at end (= x y))").is_value(
-///     PrefConGDs::new_goal(ConGD::AtEnd(gd_a.clone()))
+///     PreferenceConstraintGoalDefinitions::new_goal(ConstraintGoalDefinition::AtEnd(gd_a.clone()))
 /// ));
 ///
 /// assert!(parse_pref_con_gd("(preference (at end (= x y)))").is_value(
-///     PrefConGDs::new_preference(None, ConGD::AtEnd(gd_a.clone()))
+///     PreferenceConstraintGoalDefinitions::new_preference(None, ConstraintGoalDefinition::AtEnd(gd_a.clone()))
 /// ));
 ///
 /// assert!(parse_pref_con_gd("(preference name (at end (= x y)))").is_value(
-///     PrefConGDs::new_preference(Some("name".into()), ConGD::AtEnd(gd_a.clone()))
+///     PreferenceConstraintGoalDefinitions::new_preference(Some("name".into()), ConstraintGoalDefinition::AtEnd(gd_a.clone()))
 /// ));
 /// ```
-pub fn parse_pref_con_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, PrefConGDs> {
+pub fn parse_pref_con_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, PreferenceConstraintGoalDefinitions> {
     let and = map(
         prefix_expr("and", space_separated_list0(parse_pref_con_gd)),
-        |x| PrefConGDs::from_iter(x.into_iter().flatten()),
+        |x| PreferenceConstraintGoalDefinitions::from_iter(x.into_iter().flatten()),
     );
 
     // :universal-preconditions
@@ -96,7 +96,7 @@ pub fn parse_pref_con_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Pre
                 preceded(multispace1, parse_pref_con_gd),
             ),
         ),
-        |(vars, gd)| PrefConGDs::new_forall(vars, gd),
+        |(vars, gd)| PreferenceConstraintGoalDefinitions::new_forall(vars, gd),
     );
 
     // :preferences
@@ -105,21 +105,21 @@ pub fn parse_pref_con_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Pre
             "preference",
             (parse_pref_name, preceded(multispace1, parse_con_gd)),
         ),
-        |(name, gd)| PrefConGDs::new_preference(Some(name), gd),
+        |(name, gd)| PreferenceConstraintGoalDefinitions::new_preference(Some(name), gd),
     );
 
     // :preferences
     let unnamed_preference = map(prefix_expr("preference", parse_con_gd), |gd| {
-        PrefConGDs::new_preference(None, gd)
+        PreferenceConstraintGoalDefinitions::new_preference(None, gd)
     });
 
-    let goal = map(parse_con_gd, PrefConGDs::new_goal);
+    let goal = map(parse_con_gd, PreferenceConstraintGoalDefinitions::new_goal);
 
     alt((and, forall, named_preference, unnamed_preference, goal)).parse(input.into())
 }
 
-impl crate::parsers::Parser for PrefConGDs {
-    type Item = PrefConGDs;
+impl crate::parsers::Parser for PreferenceConstraintGoalDefinitions {
+    type Item = PreferenceConstraintGoalDefinitions;
 
     /// See [`parse_pref_con_gd`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
@@ -131,7 +131,7 @@ impl crate::parsers::Parser for PrefConGDs {
 mod tests {
     use crate::parsers::preamble::*;
     use crate::{
-        AtomicFormula, Con2GD, ConGD, GoalDefinition, PrefConGD, PrefConGDs, Term, ToTyped, Type,
+        AtomicFormula, ConstraintGoalDefinitionInner, ConstraintGoalDefinition, GoalDefinition, PreferenceConstraintGoalDefinition, PreferenceConstraintGoalDefinitions, Term, ToTyped, Type,
         TypedList, Variable,
     };
 
@@ -148,25 +148,25 @@ mod tests {
             AtomicFormula::new_equality(Term::Name("x".into()), Term::Name("z".into())),
         ));
 
-        assert!(PrefConGDs::parse("(and)").is_value(PrefConGDs::default()));
+        assert!(PreferenceConstraintGoalDefinitions::parse("(and)").is_value(PreferenceConstraintGoalDefinitions::default()));
 
         assert!(
-            PrefConGDs::parse("(and (at end (= x y)) (at end (not (= x z))))").is_value(
-                PrefConGDs::from_iter([
-                    PrefConGD::new_goal(ConGD::new_at_end(gd_a.clone())),
-                    PrefConGD::new_goal(ConGD::new_at_end(gd_b.clone())),
+            PreferenceConstraintGoalDefinitions::parse("(and (at end (= x y)) (at end (not (= x z))))").is_value(
+                PreferenceConstraintGoalDefinitions::from_iter([
+                    PreferenceConstraintGoalDefinition::new_goal(ConstraintGoalDefinition::new_at_end(gd_a.clone())),
+                    PreferenceConstraintGoalDefinition::new_goal(ConstraintGoalDefinition::new_at_end(gd_b.clone())),
                 ])
             )
         );
 
         assert!(
-            PrefConGDs::parse("(forall (?x ?z) (sometime (= ?x ?z)))").is_value(
-                PrefConGDs::new_forall(
+            PreferenceConstraintGoalDefinitions::parse("(forall (?x ?z) (sometime (= ?x ?z)))").is_value(
+                PreferenceConstraintGoalDefinitions::new_forall(
                     TypedList::from_iter([
                         Variable::from("x").to_typed(Type::OBJECT),
                         Variable::from("z").to_typed(Type::OBJECT),
                     ]),
-                    PrefConGDs::new_goal(ConGD::new_sometime(Con2GD::Goal(
+                    PreferenceConstraintGoalDefinitions::new_goal(ConstraintGoalDefinition::new_sometime(ConstraintGoalDefinitionInner::Goal(
                         GoalDefinition::new_atomic_formula(AtomicFormula::new_equality(
                             Term::Variable("x".into()),
                             Term::Variable("z".into())
@@ -176,15 +176,15 @@ mod tests {
             )
         );
 
-        assert!(PrefConGDs::parse("(at end (= x y))")
-            .is_value(PrefConGDs::new_goal(ConGD::AtEnd(gd_a.clone()))));
+        assert!(PreferenceConstraintGoalDefinitions::parse("(at end (= x y))")
+            .is_value(PreferenceConstraintGoalDefinitions::new_goal(ConstraintGoalDefinition::AtEnd(gd_a.clone()))));
 
-        assert!(PrefConGDs::parse("(preference (at end (= x y)))")
-            .is_value(PrefConGDs::new_preference(None, ConGD::AtEnd(gd_a.clone()))));
+        assert!(PreferenceConstraintGoalDefinitions::parse("(preference (at end (= x y)))")
+            .is_value(PreferenceConstraintGoalDefinitions::new_preference(None, ConstraintGoalDefinition::AtEnd(gd_a.clone()))));
 
         assert!(
-            PrefConGDs::parse("(preference name (at end (= x y)))").is_value(
-                PrefConGDs::new_preference(Some("name".into()), ConGD::AtEnd(gd_a.clone()))
+            PreferenceConstraintGoalDefinitions::parse("(preference name (at end (= x y)))").is_value(
+                PreferenceConstraintGoalDefinitions::new_preference(Some("name".into()), ConstraintGoalDefinition::AtEnd(gd_a.clone()))
             )
         );
     }

--- a/src/parsers/pref_con_gd.rs
+++ b/src/parsers/pref_con_gd.rs
@@ -81,7 +81,9 @@ use nom::Parser;
 ///     PreferenceConstraintGoalDefinitions::new_preference(Some("name".into()), ConstraintGoalDefinition::AtEnd(gd_a.clone()))
 /// ));
 /// ```
-pub fn parse_pref_con_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, PreferenceConstraintGoalDefinitions> {
+pub fn parse_pref_con_gd<'a, T: Into<Span<'a>>>(
+    input: T,
+) -> ParseResult<'a, PreferenceConstraintGoalDefinitions> {
     let and = map(
         prefix_expr("and", space_separated_list0(parse_pref_con_gd)),
         |x| PreferenceConstraintGoalDefinitions::from_iter(x.into_iter().flatten()),
@@ -131,8 +133,9 @@ impl crate::parsers::Parser for PreferenceConstraintGoalDefinitions {
 mod tests {
     use crate::parsers::preamble::*;
     use crate::{
-        AtomicFormula, ConstraintGoalDefinitionInner, ConstraintGoalDefinition, GoalDefinition, PreferenceConstraintGoalDefinition, PreferenceConstraintGoalDefinitions, Term, ToTyped, Type,
-        TypedList, Variable,
+        AtomicFormula, ConstraintGoalDefinition, ConstraintGoalDefinitionInner, GoalDefinition,
+        PreferenceConstraintGoalDefinition, PreferenceConstraintGoalDefinitions, Term, ToTyped,
+        Type, TypedList, Variable,
     };
 
     #[test]
@@ -148,44 +151,62 @@ mod tests {
             AtomicFormula::new_equality(Term::Name("x".into()), Term::Name("z".into())),
         ));
 
-        assert!(PreferenceConstraintGoalDefinitions::parse("(and)").is_value(PreferenceConstraintGoalDefinitions::default()));
+        assert!(PreferenceConstraintGoalDefinitions::parse("(and)")
+            .is_value(PreferenceConstraintGoalDefinitions::default()));
+
+        assert!(PreferenceConstraintGoalDefinitions::parse(
+            "(and (at end (= x y)) (at end (not (= x z))))"
+        )
+        .is_value(PreferenceConstraintGoalDefinitions::from_iter([
+            PreferenceConstraintGoalDefinition::new_goal(ConstraintGoalDefinition::new_at_end(
+                gd_a.clone()
+            )),
+            PreferenceConstraintGoalDefinition::new_goal(ConstraintGoalDefinition::new_at_end(
+                gd_b.clone()
+            )),
+        ])));
+
+        assert!(PreferenceConstraintGoalDefinitions::parse(
+            "(forall (?x ?z) (sometime (= ?x ?z)))"
+        )
+        .is_value(PreferenceConstraintGoalDefinitions::new_forall(
+            TypedList::from_iter([
+                Variable::from("x").to_typed(Type::OBJECT),
+                Variable::from("z").to_typed(Type::OBJECT),
+            ]),
+            PreferenceConstraintGoalDefinitions::new_goal(ConstraintGoalDefinition::new_sometime(
+                ConstraintGoalDefinitionInner::Goal(GoalDefinition::new_atomic_formula(
+                    AtomicFormula::new_equality(
+                        Term::Variable("x".into()),
+                        Term::Variable("z".into())
+                    )
+                ))
+            ))
+        )));
 
         assert!(
-            PreferenceConstraintGoalDefinitions::parse("(and (at end (= x y)) (at end (not (= x z))))").is_value(
-                PreferenceConstraintGoalDefinitions::from_iter([
-                    PreferenceConstraintGoalDefinition::new_goal(ConstraintGoalDefinition::new_at_end(gd_a.clone())),
-                    PreferenceConstraintGoalDefinition::new_goal(ConstraintGoalDefinition::new_at_end(gd_b.clone())),
-                ])
+            PreferenceConstraintGoalDefinitions::parse("(at end (= x y))").is_value(
+                PreferenceConstraintGoalDefinitions::new_goal(ConstraintGoalDefinition::AtEnd(
+                    gd_a.clone()
+                ))
             )
         );
 
         assert!(
-            PreferenceConstraintGoalDefinitions::parse("(forall (?x ?z) (sometime (= ?x ?z)))").is_value(
-                PreferenceConstraintGoalDefinitions::new_forall(
-                    TypedList::from_iter([
-                        Variable::from("x").to_typed(Type::OBJECT),
-                        Variable::from("z").to_typed(Type::OBJECT),
-                    ]),
-                    PreferenceConstraintGoalDefinitions::new_goal(ConstraintGoalDefinition::new_sometime(ConstraintGoalDefinitionInner::Goal(
-                        GoalDefinition::new_atomic_formula(AtomicFormula::new_equality(
-                            Term::Variable("x".into()),
-                            Term::Variable("z".into())
-                        ))
-                    )))
+            PreferenceConstraintGoalDefinitions::parse("(preference (at end (= x y)))").is_value(
+                PreferenceConstraintGoalDefinitions::new_preference(
+                    None,
+                    ConstraintGoalDefinition::AtEnd(gd_a.clone())
                 )
             )
         );
 
-        assert!(PreferenceConstraintGoalDefinitions::parse("(at end (= x y))")
-            .is_value(PreferenceConstraintGoalDefinitions::new_goal(ConstraintGoalDefinition::AtEnd(gd_a.clone()))));
-
-        assert!(PreferenceConstraintGoalDefinitions::parse("(preference (at end (= x y)))")
-            .is_value(PreferenceConstraintGoalDefinitions::new_preference(None, ConstraintGoalDefinition::AtEnd(gd_a.clone()))));
-
         assert!(
-            PreferenceConstraintGoalDefinitions::parse("(preference name (at end (= x y)))").is_value(
-                PreferenceConstraintGoalDefinitions::new_preference(Some("name".into()), ConstraintGoalDefinition::AtEnd(gd_a.clone()))
-            )
+            PreferenceConstraintGoalDefinitions::parse("(preference name (at end (= x y)))")
+                .is_value(PreferenceConstraintGoalDefinitions::new_preference(
+                    Some("name".into()),
+                    ConstraintGoalDefinition::AtEnd(gd_a.clone())
+                ))
         );
     }
 }

--- a/src/parsers/pref_con_gd.rs
+++ b/src/parsers/pref_con_gd.rs
@@ -19,8 +19,8 @@ use nom::Parser;
 /// # use pddl::{AtomicFormula, ConstraintGoalDefinitionInner, ConstraintGoalDefinition, GoalDefinition, Number, PreferenceConstraintGoalDefinition, PreferenceConstraintGoalDefinitions, Term, ToTyped, Type, TypedList, Variable};
 /// // (= x y)
 /// let gd_a =
-///     GoalDefinition::new_atomic_formula(
-///         AtomicFormula::new_equality(
+///     GoalDefinition::atomic_formula(
+///         AtomicFormula::equality(
 ///             Term::Name("x".into()),
 ///             Term::Name("y".into())
 ///         )
@@ -28,9 +28,9 @@ use nom::Parser;
 ///
 /// // (not (= x z))
 /// let gd_b =
-///     GoalDefinition::new_not(
-///         GoalDefinition::new_atomic_formula(
-///             AtomicFormula::new_equality(
+///     GoalDefinition::not(
+///         GoalDefinition::atomic_formula(
+///             AtomicFormula::equality(
 ///                 Term::Name("x".into()),
 ///                 Term::Name("z".into())
 ///             )
@@ -43,22 +43,22 @@ use nom::Parser;
 ///
 /// assert!(parse_pref_con_gd("(and (at end (= x y)) (at end (not (= x z))))").is_value(
 ///     PreferenceConstraintGoalDefinitions::from_iter([
-///         PreferenceConstraintGoalDefinition::new_goal(ConstraintGoalDefinition::new_at_end(gd_a.clone())),
-///         PreferenceConstraintGoalDefinition::new_goal(ConstraintGoalDefinition::new_at_end(gd_b.clone())),
+///         PreferenceConstraintGoalDefinition::goal(ConstraintGoalDefinition::at_end(gd_a.clone())),
+///         PreferenceConstraintGoalDefinition::goal(ConstraintGoalDefinition::at_end(gd_b.clone())),
 ///     ])
 /// ));
 ///
 /// assert!(parse_pref_con_gd("(forall (?x ?z) (sometime (= ?x ?z)))").is_value(
-///     PreferenceConstraintGoalDefinitions::new_forall(
+///     PreferenceConstraintGoalDefinitions::forall(
 ///         TypedList::from_iter([
 ///             Variable::from("x").to_typed(Type::OBJECT),
 ///             Variable::from("z").to_typed(Type::OBJECT),
 ///         ]),
-///         PreferenceConstraintGoalDefinitions::new_goal(ConstraintGoalDefinition::new_sometime(
+///         PreferenceConstraintGoalDefinitions::goal(ConstraintGoalDefinition::sometime(
 ///                 // gd ...
 ///                 # ConstraintGoalDefinitionInner::Goal(
-///                     # GoalDefinition::new_atomic_formula(
-///                     #    AtomicFormula::new_equality(
+///                     # GoalDefinition::atomic_formula(
+///                     #    AtomicFormula::equality(
 ///                     #        Term::Variable("x".into()),
 ///                     #        Term::Variable("z".into())
 ///                     #    )
@@ -70,15 +70,15 @@ use nom::Parser;
 /// ));
 ///
 /// assert!(parse_pref_con_gd("(at end (= x y))").is_value(
-///     PreferenceConstraintGoalDefinitions::new_goal(ConstraintGoalDefinition::AtEnd(gd_a.clone()))
+///     PreferenceConstraintGoalDefinitions::goal(ConstraintGoalDefinition::AtEnd(gd_a.clone()))
 /// ));
 ///
 /// assert!(parse_pref_con_gd("(preference (at end (= x y)))").is_value(
-///     PreferenceConstraintGoalDefinitions::new_preference(None, ConstraintGoalDefinition::AtEnd(gd_a.clone()))
+///     PreferenceConstraintGoalDefinitions::preference(None, ConstraintGoalDefinition::AtEnd(gd_a.clone()))
 /// ));
 ///
 /// assert!(parse_pref_con_gd("(preference name (at end (= x y)))").is_value(
-///     PreferenceConstraintGoalDefinitions::new_preference(Some("name".into()), ConstraintGoalDefinition::AtEnd(gd_a.clone()))
+///     PreferenceConstraintGoalDefinitions::preference(Some("name".into()), ConstraintGoalDefinition::AtEnd(gd_a.clone()))
 /// ));
 /// ```
 pub fn parse_pref_con_gd<'a, T: Into<Span<'a>>>(
@@ -98,7 +98,7 @@ pub fn parse_pref_con_gd<'a, T: Into<Span<'a>>>(
                 preceded(multispace1, parse_pref_con_gd),
             ),
         ),
-        |(vars, gd)| PreferenceConstraintGoalDefinitions::new_forall(vars, gd),
+        |(vars, gd)| PreferenceConstraintGoalDefinitions::forall(vars, gd),
     );
 
     // :preferences
@@ -107,12 +107,12 @@ pub fn parse_pref_con_gd<'a, T: Into<Span<'a>>>(
             "preference",
             (parse_pref_name, preceded(multispace1, parse_con_gd)),
         ),
-        |(name, gd)| PreferenceConstraintGoalDefinitions::new_preference(Some(name), gd),
+        |(name, gd)| PreferenceConstraintGoalDefinitions::preference(Some(name), gd),
     );
 
     // :preferences
     let unnamed_preference = map(prefix_expr("preference", parse_con_gd), |gd| {
-        PreferenceConstraintGoalDefinitions::new_preference(None, gd)
+        PreferenceConstraintGoalDefinitions::preference(None, gd)
     });
 
     let goal = map(parse_con_gd, PreferenceConstraintGoalDefinitions::new_goal);
@@ -141,15 +141,16 @@ mod tests {
     #[test]
     fn test_parse() {
         // (= x y)
-        let gd_a = GoalDefinition::new_atomic_formula(AtomicFormula::new_equality(
+        let gd_a = GoalDefinition::atomic_formula(AtomicFormula::equality(
             Term::Name("x".into()),
             Term::Name("y".into()),
         ));
 
         // (not (= x z))
-        let gd_b = GoalDefinition::new_not(GoalDefinition::new_atomic_formula(
-            AtomicFormula::new_equality(Term::Name("x".into()), Term::Name("z".into())),
-        ));
+        let gd_b = GoalDefinition::not(GoalDefinition::atomic_formula(AtomicFormula::equality(
+            Term::Name("x".into()),
+            Term::Name("z".into()),
+        )));
 
         assert!(PreferenceConstraintGoalDefinitions::parse("(and)")
             .is_value(PreferenceConstraintGoalDefinitions::default()));
@@ -158,10 +159,10 @@ mod tests {
             "(and (at end (= x y)) (at end (not (= x z))))"
         )
         .is_value(PreferenceConstraintGoalDefinitions::from_iter([
-            PreferenceConstraintGoalDefinition::new_goal(ConstraintGoalDefinition::new_at_end(
+            PreferenceConstraintGoalDefinition::goal(ConstraintGoalDefinition::at_end(
                 gd_a.clone()
             )),
-            PreferenceConstraintGoalDefinition::new_goal(ConstraintGoalDefinition::new_at_end(
+            PreferenceConstraintGoalDefinition::goal(ConstraintGoalDefinition::at_end(
                 gd_b.clone()
             )),
         ])));
@@ -169,24 +170,21 @@ mod tests {
         assert!(PreferenceConstraintGoalDefinitions::parse(
             "(forall (?x ?z) (sometime (= ?x ?z)))"
         )
-        .is_value(PreferenceConstraintGoalDefinitions::new_forall(
+        .is_value(PreferenceConstraintGoalDefinitions::forall(
             TypedList::from_iter([
                 Variable::from("x").to_typed(Type::OBJECT),
                 Variable::from("z").to_typed(Type::OBJECT),
             ]),
-            PreferenceConstraintGoalDefinitions::new_goal(ConstraintGoalDefinition::new_sometime(
-                ConstraintGoalDefinitionInner::Goal(GoalDefinition::new_atomic_formula(
-                    AtomicFormula::new_equality(
-                        Term::Variable("x".into()),
-                        Term::Variable("z".into())
-                    )
+            PreferenceConstraintGoalDefinitions::goal(ConstraintGoalDefinition::sometime(
+                ConstraintGoalDefinitionInner::Goal(GoalDefinition::atomic_formula(
+                    AtomicFormula::equality(Term::Variable("x".into()), Term::Variable("z".into()))
                 ))
             ))
         )));
 
         assert!(
             PreferenceConstraintGoalDefinitions::parse("(at end (= x y))").is_value(
-                PreferenceConstraintGoalDefinitions::new_goal(ConstraintGoalDefinition::AtEnd(
+                PreferenceConstraintGoalDefinitions::goal(ConstraintGoalDefinition::AtEnd(
                     gd_a.clone()
                 ))
             )
@@ -194,7 +192,7 @@ mod tests {
 
         assert!(
             PreferenceConstraintGoalDefinitions::parse("(preference (at end (= x y)))").is_value(
-                PreferenceConstraintGoalDefinitions::new_preference(
+                PreferenceConstraintGoalDefinitions::preference(
                     None,
                     ConstraintGoalDefinition::AtEnd(gd_a.clone())
                 )
@@ -203,7 +201,7 @@ mod tests {
 
         assert!(
             PreferenceConstraintGoalDefinitions::parse("(preference name (at end (= x y)))")
-                .is_value(PreferenceConstraintGoalDefinitions::new_preference(
+                .is_value(PreferenceConstraintGoalDefinitions::preference(
                     Some("name".into()),
                     ConstraintGoalDefinition::AtEnd(gd_a.clone())
                 ))

--- a/src/parsers/pref_gd.rs
+++ b/src/parsers/pref_gd.rs
@@ -8,17 +8,17 @@ use nom::Parser;
 
 use crate::parsers::{parse_gd, parse_pref_name};
 use crate::parsers::{prefix_expr, ParseResult, Span};
-use crate::types::{Preference, PreferenceGD};
+use crate::types::{Preference, PreferenceGoalDefinition};
 
 /// Parser for goal definitions.
 ///
 /// ## Examples
 /// ```
 /// # use pddl::parsers::{parse_pref_gd, preamble::*};
-/// # use pddl::{AtomicFormula, EqualityAtomicFormula, GoalDefinition, Literal, Preference, PreferenceName, PreferenceGD, Term, Variable};
+/// # use pddl::{AtomicFormula, EqualityAtomicFormula, GoalDefinition, Literal, Preference, PreferenceName, PreferenceGoalDefinition, Term, Variable};
 /// // Simple goal definition.
 /// assert!(parse_pref_gd("(= x y)").is_value(
-///     PreferenceGD::Goal(
+///     PreferenceGoalDefinition::Goal(
 ///         GoalDefinition::AtomicFormula(
 ///             AtomicFormula::new_equality(
 ///                 Term::Name("x".into()),
@@ -30,7 +30,7 @@ use crate::types::{Preference, PreferenceGD};
 ///
 /// // Named preference.
 /// assert!(parse_pref_gd("(preference p (= x y))").is_value(
-///     PreferenceGD::Preference(
+///     PreferenceGoalDefinition::Preference(
 ///         Preference::new(
 ///             Some(PreferenceName::from("p")),
 ///             GoalDefinition::AtomicFormula(
@@ -45,7 +45,7 @@ use crate::types::{Preference, PreferenceGD};
 ///
 /// // Unnamed preference.
 /// assert!(parse_pref_gd("(preference (= x y))").is_value(
-///     PreferenceGD::Preference(
+///     PreferenceGoalDefinition::Preference(
 ///         Preference::new(
 ///             None,
 ///             GoalDefinition::AtomicFormula(
@@ -58,27 +58,27 @@ use crate::types::{Preference, PreferenceGD};
 ///     )
 /// ));
 /// ```
-pub fn parse_pref_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, PreferenceGD> {
+pub fn parse_pref_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, PreferenceGoalDefinition> {
     // :preferences
     let pref_named = map(
         prefix_expr(
             "preference",
             (opt(parse_pref_name), preceded(multispace1, parse_gd)),
         ),
-        |(pref, gd)| PreferenceGD::from_preference(Preference::new(pref, gd)),
+        |(pref, gd)| PreferenceGoalDefinition::from_preference(Preference::new(pref, gd)),
     );
 
     let pref_unnamed = map(prefix_expr("preference", parse_gd), |gd| {
-        PreferenceGD::from_preference(Preference::new(None, gd))
+        PreferenceGoalDefinition::from_preference(Preference::new(None, gd))
     });
 
-    let gd = map(parse_gd, PreferenceGD::from_gd);
+    let gd = map(parse_gd, PreferenceGoalDefinition::from_gd);
 
     alt((pref_named, pref_unnamed, gd)).parse(input.into())
 }
 
-impl crate::parsers::Parser for PreferenceGD {
-    type Item = PreferenceGD;
+impl crate::parsers::Parser for PreferenceGoalDefinition {
+    type Item = PreferenceGoalDefinition;
 
     /// See [`parse_pref_gd`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
@@ -89,42 +89,43 @@ impl crate::parsers::Parser for PreferenceGD {
 #[cfg(test)]
 mod tests {
     use crate::parsers::preamble::*;
-    use crate::{AtomicFormula, GoalDefinition, Preference, PreferenceGD, PreferenceName, Term};
+    use crate::{
+        AtomicFormula, GoalDefinition, Preference, PreferenceGoalDefinition, PreferenceName, Term,
+    };
 
     #[test]
     fn test_parse() {
         // Simple goal definition.
-        assert!(PreferenceGD::parse("(= x y)").is_value(PreferenceGD::Goal(
-            GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
-                Term::Name("x".into()),
-                Term::Name("y".into())
+        assert!(PreferenceGoalDefinition::parse("(= x y)").is_value(
+            PreferenceGoalDefinition::Goal(GoalDefinition::AtomicFormula(
+                AtomicFormula::new_equality(Term::Name("x".into()), Term::Name("y".into()))
             ))
-        )));
+        ));
 
         // Named preference.
         assert!(
-            PreferenceGD::parse("(preference p (= x y))").is_value(PreferenceGD::Preference(
-                Preference::new(
+            PreferenceGoalDefinition::parse("(preference p (= x y))").is_value(
+                PreferenceGoalDefinition::Preference(Preference::new(
                     Some(PreferenceName::from("p")),
                     GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
                         Term::Name("x".into()),
                         Term::Name("y".into())
                     ))
-                )
-            ))
+                ))
+            )
         );
 
         // Unnamed preference.
         assert!(
-            PreferenceGD::parse("(preference (= x y))").is_value(PreferenceGD::Preference(
-                Preference::new(
+            PreferenceGoalDefinition::parse("(preference (= x y))").is_value(
+                PreferenceGoalDefinition::Preference(Preference::new(
                     None,
                     GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
                         Term::Name("x".into()),
                         Term::Name("y".into())
                     ))
-                )
-            ))
+                ))
+            )
         );
     }
 }

--- a/src/parsers/pref_timed_gd.rs
+++ b/src/parsers/pref_timed_gd.rs
@@ -18,7 +18,7 @@ use crate::types::PreferenceTimedGoalDefinition;
 /// # use pddl::{AtomicFormula, GoalDefinition, Interval, PreferenceTimedGoalDefinition, Term, TimedGoalDefinition, TimeSpecifier};
 /// assert!(parse_pref_timed_gd("(at start (= x y))").is_value(
 ///     PreferenceTimedGoalDefinition::Required(
-///         TimedGoalDefinition::new_at(
+///         TimedGoalDefinition::at(
 ///             TimeSpecifier::Start,
 ///             GoalDefinition::AtomicFormula(
 ///                 AtomicFormula::new_equality(
@@ -34,7 +34,7 @@ use crate::types::PreferenceTimedGoalDefinition;
 /// assert!(parse_pref_timed_gd("(preference (over all (= x y)))").is_value(
 ///     PreferenceTimedGoalDefinition::Preference(
 ///         None,
-///         TimedGoalDefinition::new_over(
+///         TimedGoalDefinition::over(
 ///             Interval::All,
 ///             GoalDefinition::AtomicFormula(
 ///                 AtomicFormula::new_equality(
@@ -49,7 +49,7 @@ use crate::types::PreferenceTimedGoalDefinition;
 /// assert!(parse_pref_timed_gd("(preference pref-name (over all (= x y)))").is_value(
 ///     PreferenceTimedGoalDefinition::Preference(
 ///         Some("pref-name".into()),
-///         TimedGoalDefinition::new_over(
+///         TimedGoalDefinition::over(
 ///             Interval::All,
 ///             GoalDefinition::AtomicFormula(
 ///                 AtomicFormula::new_equality(
@@ -102,7 +102,7 @@ mod tests {
     fn test_parse() {
         assert!(
             PreferenceTimedGoalDefinition::parse("(at start (= x y))").is_value(
-                PreferenceTimedGoalDefinition::Required(TimedGoalDefinition::new_at(
+                PreferenceTimedGoalDefinition::Required(TimedGoalDefinition::at(
                     TimeSpecifier::Start,
                     GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
                         Term::Name("x".into()),
@@ -116,7 +116,7 @@ mod tests {
             PreferenceTimedGoalDefinition::parse("(preference (over all (= x y)))").is_value(
                 PreferenceTimedGoalDefinition::Preference(
                     None,
-                    TimedGoalDefinition::new_over(
+                    TimedGoalDefinition::over(
                         Interval::All,
                         GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
                             Term::Name("x".into()),
@@ -131,7 +131,7 @@ mod tests {
             PreferenceTimedGoalDefinition::parse("(preference pref-name (over all (= x y)))")
                 .is_value(PreferenceTimedGoalDefinition::Preference(
                     Some("pref-name".into()),
-                    TimedGoalDefinition::new_over(
+                    TimedGoalDefinition::over(
                         Interval::All,
                         GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
                             Term::Name("x".into()),

--- a/src/parsers/pref_timed_gd.rs
+++ b/src/parsers/pref_timed_gd.rs
@@ -8,17 +8,17 @@ use nom::Parser;
 
 use crate::parsers::{parse_pref_name, parse_timed_gd};
 use crate::parsers::{prefix_expr, ParseResult, Span};
-use crate::types::PrefTimedGD;
+use crate::types::PreferenceTimedGoalDefinition;
 
 /// Parser for (preferred) timed goal definitions.
 ///
 /// ## Examples
 /// ```
 /// # use pddl::parsers::{parse_pref_timed_gd, preamble::*};
-/// # use pddl::{AtomicFormula, GoalDefinition, Interval, PrefTimedGD, Term, TimedGD, TimeSpecifier};
+/// # use pddl::{AtomicFormula, GoalDefinition, Interval, PreferenceTimedGoalDefinition, Term, TimedGoalDefinition, TimeSpecifier};
 /// assert!(parse_pref_timed_gd("(at start (= x y))").is_value(
-///     PrefTimedGD::Required(
-///         TimedGD::new_at(
+///     PreferenceTimedGoalDefinition::Required(
+///         TimedGoalDefinition::new_at(
 ///             TimeSpecifier::Start,
 ///             GoalDefinition::AtomicFormula(
 ///                 AtomicFormula::new_equality(
@@ -32,9 +32,9 @@ use crate::types::PrefTimedGD;
 ///
 ///
 /// assert!(parse_pref_timed_gd("(preference (over all (= x y)))").is_value(
-///     PrefTimedGD::Preference(
+///     PreferenceTimedGoalDefinition::Preference(
 ///         None,
-///         TimedGD::new_over(
+///         TimedGoalDefinition::new_over(
 ///             Interval::All,
 ///             GoalDefinition::AtomicFormula(
 ///                 AtomicFormula::new_equality(
@@ -47,9 +47,9 @@ use crate::types::PrefTimedGD;
 /// ));
 ///
 /// assert!(parse_pref_timed_gd("(preference pref-name (over all (= x y)))").is_value(
-///     PrefTimedGD::Preference(
+///     PreferenceTimedGoalDefinition::Preference(
 ///         Some("pref-name".into()),
-///         TimedGD::new_over(
+///         TimedGoalDefinition::new_over(
 ///             Interval::All,
 ///             GoalDefinition::AtomicFormula(
 ///                 AtomicFormula::new_equality(
@@ -61,8 +61,8 @@ use crate::types::PrefTimedGD;
 ///     )
 /// ));
 /// ```
-pub fn parse_pref_timed_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, PrefTimedGD> {
-    let required = map(parse_timed_gd, PrefTimedGD::from);
+pub fn parse_pref_timed_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, PreferenceTimedGoalDefinition> {
+    let required = map(parse_timed_gd, PreferenceTimedGoalDefinition::from);
 
     // :preferences
     let preference = map(
@@ -73,14 +73,14 @@ pub fn parse_pref_timed_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, P
                 parse_timed_gd,
             ),
         ),
-        PrefTimedGD::from,
+        PreferenceTimedGoalDefinition::from,
     );
 
     alt((preference, required)).parse(input.into())
 }
 
-impl crate::parsers::Parser for PrefTimedGD {
-    type Item = PrefTimedGD;
+impl crate::parsers::Parser for PreferenceTimedGoalDefinition {
+    type Item = PreferenceTimedGoalDefinition;
 
     /// See [`parse_pref_timed_gd`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
@@ -92,14 +92,14 @@ impl crate::parsers::Parser for PrefTimedGD {
 mod tests {
     use crate::parsers::preamble::*;
     use crate::{
-        AtomicFormula, GoalDefinition, Interval, PrefTimedGD, Term, TimeSpecifier, TimedGD,
+        AtomicFormula, GoalDefinition, Interval, PreferenceTimedGoalDefinition, Term, TimeSpecifier, TimedGoalDefinition,
     };
 
     #[test]
     fn test_parse() {
         assert!(
-            PrefTimedGD::parse("(at start (= x y))").is_value(PrefTimedGD::Required(
-                TimedGD::new_at(
+            PreferenceTimedGoalDefinition::parse("(at start (= x y))").is_value(PreferenceTimedGoalDefinition::Required(
+                TimedGoalDefinition::new_at(
                     TimeSpecifier::Start,
                     GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
                         Term::Name("x".into()),
@@ -110,10 +110,10 @@ mod tests {
         );
 
         assert!(
-            PrefTimedGD::parse("(preference (over all (= x y)))").is_value(
-                PrefTimedGD::Preference(
+            PreferenceTimedGoalDefinition::parse("(preference (over all (= x y)))").is_value(
+                PreferenceTimedGoalDefinition::Preference(
                     None,
-                    TimedGD::new_over(
+                    TimedGoalDefinition::new_over(
                         Interval::All,
                         GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
                             Term::Name("x".into()),
@@ -125,10 +125,10 @@ mod tests {
         );
 
         assert!(
-            PrefTimedGD::parse("(preference pref-name (over all (= x y)))").is_value(
-                PrefTimedGD::Preference(
+            PreferenceTimedGoalDefinition::parse("(preference pref-name (over all (= x y)))").is_value(
+                PreferenceTimedGoalDefinition::Preference(
                     Some("pref-name".into()),
-                    TimedGD::new_over(
+                    TimedGoalDefinition::new_over(
                         Interval::All,
                         GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
                             Term::Name("x".into()),

--- a/src/parsers/pref_timed_gd.rs
+++ b/src/parsers/pref_timed_gd.rs
@@ -61,7 +61,9 @@ use crate::types::PreferenceTimedGoalDefinition;
 ///     )
 /// ));
 /// ```
-pub fn parse_pref_timed_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, PreferenceTimedGoalDefinition> {
+pub fn parse_pref_timed_gd<'a, T: Into<Span<'a>>>(
+    input: T,
+) -> ParseResult<'a, PreferenceTimedGoalDefinition> {
     let required = map(parse_timed_gd, PreferenceTimedGoalDefinition::from);
 
     // :preferences
@@ -92,21 +94,22 @@ impl crate::parsers::Parser for PreferenceTimedGoalDefinition {
 mod tests {
     use crate::parsers::preamble::*;
     use crate::{
-        AtomicFormula, GoalDefinition, Interval, PreferenceTimedGoalDefinition, Term, TimeSpecifier, TimedGoalDefinition,
+        AtomicFormula, GoalDefinition, Interval, PreferenceTimedGoalDefinition, Term,
+        TimeSpecifier, TimedGoalDefinition,
     };
 
     #[test]
     fn test_parse() {
         assert!(
-            PreferenceTimedGoalDefinition::parse("(at start (= x y))").is_value(PreferenceTimedGoalDefinition::Required(
-                TimedGoalDefinition::new_at(
+            PreferenceTimedGoalDefinition::parse("(at start (= x y))").is_value(
+                PreferenceTimedGoalDefinition::Required(TimedGoalDefinition::new_at(
                     TimeSpecifier::Start,
                     GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
                         Term::Name("x".into()),
                         Term::Name("y".into())
                     ))
-                )
-            ))
+                ))
+            )
         );
 
         assert!(
@@ -125,8 +128,8 @@ mod tests {
         );
 
         assert!(
-            PreferenceTimedGoalDefinition::parse("(preference pref-name (over all (= x y)))").is_value(
-                PreferenceTimedGoalDefinition::Preference(
+            PreferenceTimedGoalDefinition::parse("(preference pref-name (over all (= x y)))")
+                .is_value(PreferenceTimedGoalDefinition::Preference(
                     Some("pref-name".into()),
                     TimedGoalDefinition::new_over(
                         Interval::All,
@@ -135,8 +138,7 @@ mod tests {
                             Term::Name("y".into())
                         ))
                     )
-                )
-            )
+                ))
         );
     }
 }

--- a/src/parsers/problem_constraints_def.rs
+++ b/src/parsers/problem_constraints_def.rs
@@ -15,7 +15,7 @@ use crate::types::ProblemConstraintsDef;
 /// let input = "(:constraints (preference test (and)))";
 /// assert!(parse_problem_constraints_def(input).is_value(
 ///     ProblemConstraintsDef::new(
-///         PreferenceConstraintGoalDefinitions::new_preference(Some("test".into()), ConstraintGoalDefinition::new_and([]))
+///         PreferenceConstraintGoalDefinitions::preference(Some("test".into()), ConstraintGoalDefinition::and([]))
 ///     )
 /// ));
 /// ```
@@ -51,9 +51,9 @@ mod tests {
         let input = "(:constraints (preference test (and)))";
         assert!(
             ProblemConstraintsDef::parse(input).is_value(ProblemConstraintsDef::new(
-                PreferenceConstraintGoalDefinitions::new_preference(
+                PreferenceConstraintGoalDefinitions::preference(
                     Some("test".into()),
-                    ConstraintGoalDefinition::new_and([])
+                    ConstraintGoalDefinition::and([])
                 )
             ))
         );

--- a/src/parsers/problem_constraints_def.rs
+++ b/src/parsers/problem_constraints_def.rs
@@ -11,11 +11,11 @@ use crate::types::ProblemConstraintsDef;
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_problem_constraints_def, preamble::*};
-/// # use pddl::{ConGD, ProblemConstraintsDef, PrefConGDs};
+/// # use pddl::{ConstraintGoalDefinition, ProblemConstraintsDef, PreferenceConstraintGoalDefinitions};
 /// let input = "(:constraints (preference test (and)))";
 /// assert!(parse_problem_constraints_def(input).is_value(
 ///     ProblemConstraintsDef::new(
-///         PrefConGDs::new_preference(Some("test".into()), ConGD::new_and([]))
+///         PreferenceConstraintGoalDefinitions::new_preference(Some("test".into()), ConstraintGoalDefinition::new_and([]))
 ///     )
 /// ));
 /// ```
@@ -42,14 +42,14 @@ impl crate::parsers::Parser for ProblemConstraintsDef {
 #[cfg(test)]
 mod tests {
     use crate::parsers::preamble::*;
-    use crate::{ConGD, PrefConGDs, ProblemConstraintsDef};
+    use crate::{ConstraintGoalDefinition, PreferenceConstraintGoalDefinitions, ProblemConstraintsDef};
 
     #[test]
     fn test_parse() {
         let input = "(:constraints (preference test (and)))";
         assert!(
             ProblemConstraintsDef::parse(input).is_value(ProblemConstraintsDef::new(
-                PrefConGDs::new_preference(Some("test".into()), ConGD::new_and([]))
+                PreferenceConstraintGoalDefinitions::new_preference(Some("test".into()), ConstraintGoalDefinition::new_and([]))
             ))
         );
     }

--- a/src/parsers/problem_constraints_def.rs
+++ b/src/parsers/problem_constraints_def.rs
@@ -42,14 +42,19 @@ impl crate::parsers::Parser for ProblemConstraintsDef {
 #[cfg(test)]
 mod tests {
     use crate::parsers::preamble::*;
-    use crate::{ConstraintGoalDefinition, PreferenceConstraintGoalDefinitions, ProblemConstraintsDef};
+    use crate::{
+        ConstraintGoalDefinition, PreferenceConstraintGoalDefinitions, ProblemConstraintsDef,
+    };
 
     #[test]
     fn test_parse() {
         let input = "(:constraints (preference test (and)))";
         assert!(
             ProblemConstraintsDef::parse(input).is_value(ProblemConstraintsDef::new(
-                PreferenceConstraintGoalDefinitions::new_preference(Some("test".into()), ConstraintGoalDefinition::new_and([]))
+                PreferenceConstraintGoalDefinitions::new_preference(
+                    Some("test".into()),
+                    ConstraintGoalDefinition::new_and([])
+                )
             ))
         );
     }

--- a/src/parsers/simple_duration_constraint.rs
+++ b/src/parsers/simple_duration_constraint.rs
@@ -73,14 +73,14 @@ impl crate::parsers::Parser for SimpleDurationConstraint {
 #[cfg(test)]
 mod tests {
     use crate::parsers::preamble::*;
-    use crate::{DOp, DurationValue, SimpleDurationConstraint, TimeSpecifier};
+    use crate::{DurationOperator, DurationValue, SimpleDurationConstraint, TimeSpecifier};
 
     #[test]
     fn test_parse() {
         let input = "(>= ?duration 1.23)";
         assert!(
             SimpleDurationConstraint::parse(input).is_value(SimpleDurationConstraint::new_op(
-                DOp::GreaterOrEqual,
+                DurationOperator::GreaterOrEqual,
                 DurationValue::new_number(1.23)
             ))
         );
@@ -89,7 +89,7 @@ mod tests {
         assert!(
             SimpleDurationConstraint::parse(input).is_value(SimpleDurationConstraint::new_at(
                 TimeSpecifier::End,
-                SimpleDurationConstraint::Op(DOp::LessThanOrEqual, DurationValue::new_number(1.23))
+                SimpleDurationConstraint::Op(DurationOperator::LessThanOrEqual, DurationValue::new_number(1.23))
             ))
         );
     }

--- a/src/parsers/simple_duration_constraint.rs
+++ b/src/parsers/simple_duration_constraint.rs
@@ -19,19 +19,19 @@ use crate::types::SimpleDurationConstraint;
 /// # use pddl::{DOp, DurationValue, FunctionType, SimpleDurationConstraint, TimeSpecifier};
 /// let input = "(>= ?duration 1.23)";
 /// assert!(parse_simple_duration_constraint(input).is_value(
-///     SimpleDurationConstraint::new_op(
+///     SimpleDurationConstraint::op(
 ///         DOp::GreaterOrEqual,
-///         DurationValue::new_number(1.23)
+///         DurationValue::number(1.23)
 ///     )
 /// ));
 ///
 /// let input = "(at end (<= ?duration 1.23))";
 /// assert!(parse_simple_duration_constraint(input).is_value(
-///     SimpleDurationConstraint::new_at(
+///     SimpleDurationConstraint::at(
 ///         TimeSpecifier::End,
 ///         SimpleDurationConstraint::Op(
 ///             DOp::LessThanOrEqual,
-///             DurationValue::new_number(1.23)
+///             DurationValue::number(1.23)
 ///         )
 ///     )
 /// ));
@@ -79,19 +79,19 @@ mod tests {
     fn test_parse() {
         let input = "(>= ?duration 1.23)";
         assert!(
-            SimpleDurationConstraint::parse(input).is_value(SimpleDurationConstraint::new_op(
+            SimpleDurationConstraint::parse(input).is_value(SimpleDurationConstraint::op(
                 DurationOperator::GreaterOrEqual,
-                DurationValue::new_number(1.23)
+                DurationValue::number(1.23)
             ))
         );
 
         let input = "(at end (<= ?duration 1.23))";
         assert!(
-            SimpleDurationConstraint::parse(input).is_value(SimpleDurationConstraint::new_at(
+            SimpleDurationConstraint::parse(input).is_value(SimpleDurationConstraint::at(
                 TimeSpecifier::End,
                 SimpleDurationConstraint::Op(
                     DurationOperator::LessThanOrEqual,
-                    DurationValue::new_number(1.23)
+                    DurationValue::number(1.23)
                 )
             ))
         );

--- a/src/parsers/simple_duration_constraint.rs
+++ b/src/parsers/simple_duration_constraint.rs
@@ -89,7 +89,10 @@ mod tests {
         assert!(
             SimpleDurationConstraint::parse(input).is_value(SimpleDurationConstraint::new_at(
                 TimeSpecifier::End,
-                SimpleDurationConstraint::Op(DurationOperator::LessThanOrEqual, DurationValue::new_number(1.23))
+                SimpleDurationConstraint::Op(
+                    DurationOperator::LessThanOrEqual,
+                    DurationValue::new_number(1.23)
+                )
             ))
         );
     }

--- a/src/parsers/structure_def.rs
+++ b/src/parsers/structure_def.rs
@@ -13,7 +13,7 @@ use crate::types::StructureDef;
 ///
 /// ```
 /// # use pddl::parsers::{parse_structure_def, preamble::*};
-/// # use pddl::{ActionDefinition, ActionSymbol, AtomicFormula, ConditionalEffect, Effects, GoalDefinition, Literal, PrimitiveEffect, Predicate, Preference, PreferenceGD, PreconditionGoalDefinitions, StructureDef, Term, Variable};
+/// # use pddl::{ActionDefinition, ActionSymbol, AtomicFormula, ConditionalEffect, Effects, GoalDefinition, Literal, PrimitiveEffect, Predicate, Preference, PreferenceGoalDefinition, PreconditionGoalDefinitions, StructureDef, Term, Variable};
 /// # use pddl::{Name, ToTyped, TypedList};
 /// let input = r#"(:action take-out
 ///                     :parameters (?x - physob)
@@ -29,7 +29,7 @@ use crate::types::StructureDef;
 ///         TypedList::from_iter([
 ///             Variable::from("x").to_typed("physob")
 ///         ]),
-///         PreconditionGoalDefinitions::new_preference(PreferenceGD::from_gd(
+///         PreconditionGoalDefinitions::new_preference(PreferenceGoalDefinition::from_gd(
 ///             GoalDefinition::new_not(
 ///                 GoalDefinition::new_atomic_formula(
 ///                     AtomicFormula::new_equality(
@@ -72,9 +72,9 @@ impl crate::parsers::Parser for StructureDef {
 mod tests {
     use crate::parsers::preamble::*;
     use crate::{
-        ActionDefinition, ActionSymbol, AtomicFormula, ConditionalEffect, Effects, GoalDefinition, Name,
-        PrimitiveEffect, PreconditionGoalDefinitions, Predicate, PreferenceGD, StructureDef, Term, ToTyped,
-        TypedList, Variable,
+        ActionDefinition, ActionSymbol, AtomicFormula, ConditionalEffect, Effects, GoalDefinition,
+        Name, PreconditionGoalDefinitions, Predicate, PreferenceGoalDefinition, PrimitiveEffect,
+        StructureDef, Term, ToTyped, TypedList, Variable,
     };
 
     #[test]
@@ -91,7 +91,7 @@ mod tests {
             action.is_value(StructureDef::new_action(ActionDefinition::new(
                 ActionSymbol::from("take-out"),
                 TypedList::from_iter([Variable::from("x").to_typed("physob")]),
-                PreconditionGoalDefinitions::new_preference(PreferenceGD::from_gd(
+                PreconditionGoalDefinitions::new_preference(PreferenceGoalDefinition::from_gd(
                     GoalDefinition::new_not(GoalDefinition::new_atomic_formula(
                         AtomicFormula::new_equality(
                             Term::Variable(Variable::from("x")),

--- a/src/parsers/structure_def.rs
+++ b/src/parsers/structure_def.rs
@@ -24,15 +24,15 @@ use crate::types::StructureDef;
 /// let action = parse_structure_def(input);
 ///
 /// assert!(action.is_value(
-///     StructureDef::new_action(ActionDefinition::new(
+///     StructureDef::action(ActionDefinition::new(
 ///         ActionSymbol::from("take-out"),
 ///         TypedList::from_iter([
 ///             Variable::from("x").to_typed("physob")
 ///         ]),
-///         PreconditionGoalDefinitions::new_preference(PreferenceGoalDefinition::from_gd(
-///             GoalDefinition::new_not(
-///                 GoalDefinition::new_atomic_formula(
-///                     AtomicFormula::new_equality(
+///         PreconditionGoalDefinitions::preference(PreferenceGoalDefinition::from_gd(
+///             GoalDefinition::not(
+///                 GoalDefinition::atomic_formula(
+///                     AtomicFormula::equality(
 ///                         Term::Variable(Variable::from("x")),
 ///                         Term::Name(Name::new("B"))
 ///                     )
@@ -41,7 +41,7 @@ use crate::types::StructureDef;
 ///         )),
 ///         Some(Effects::new(ConditionalEffect::new_primitive_effect(
 ///             PrimitiveEffect::NotAtomicFormula(
-///                 AtomicFormula::new_predicate(
+///                 AtomicFormula::predicate(
 ///                     Predicate::from("in"),
 ///                     vec![Term::Variable(Variable::from("x"))]
 ///                 )
@@ -87,25 +87,21 @@ mod tests {
 
         let action = StructureDef::parse(input);
 
-        assert!(
-            action.is_value(StructureDef::new_action(ActionDefinition::new(
-                ActionSymbol::from("take-out"),
-                TypedList::from_iter([Variable::from("x").to_typed("physob")]),
-                PreconditionGoalDefinitions::new_preference(PreferenceGoalDefinition::from_gd(
-                    GoalDefinition::new_not(GoalDefinition::new_atomic_formula(
-                        AtomicFormula::new_equality(
-                            Term::Variable(Variable::from("x")),
-                            Term::Name(Name::new("B"))
-                        )
-                    ))
-                )),
-                Some(Effects::new(ConditionalEffect::new_primitive_effect(
-                    PrimitiveEffect::NotAtomicFormula(AtomicFormula::new_predicate(
-                        Predicate::from("in"),
-                        vec![Term::Variable(Variable::from("x"))]
-                    ))
+        assert!(action.is_value(StructureDef::action(ActionDefinition::new(
+            ActionSymbol::from("take-out"),
+            TypedList::from_iter([Variable::from("x").to_typed("physob")]),
+            PreconditionGoalDefinitions::preference(PreferenceGoalDefinition::from_gd(
+                GoalDefinition::not(GoalDefinition::atomic_formula(AtomicFormula::equality(
+                    Term::Variable(Variable::from("x")),
+                    Term::Name(Name::new("B"))
                 )))
+            )),
+            Some(Effects::new(ConditionalEffect::new_primitive_effect(
+                PrimitiveEffect::NotAtomicFormula(AtomicFormula::predicate(
+                    Predicate::from("in"),
+                    vec![Term::Variable(Variable::from("x"))]
+                ))
             )))
-        );
+        ))));
     }
 }

--- a/src/parsers/structure_def.rs
+++ b/src/parsers/structure_def.rs
@@ -13,7 +13,7 @@ use crate::types::StructureDef;
 ///
 /// ```
 /// # use pddl::parsers::{parse_structure_def, preamble::*};
-/// # use pddl::{ActionDefinition, ActionSymbol, AtomicFormula, CEffect, Effects, GoalDefinition, Literal, PEffect, Predicate, Preference, PreferenceGD, PreconditionGoalDefinitions, StructureDef, Term, Variable};
+/// # use pddl::{ActionDefinition, ActionSymbol, AtomicFormula, ConditionalEffect, Effects, GoalDefinition, Literal, PrimitiveEffect, Predicate, Preference, PreferenceGD, PreconditionGoalDefinitions, StructureDef, Term, Variable};
 /// # use pddl::{Name, ToTyped, TypedList};
 /// let input = r#"(:action take-out
 ///                     :parameters (?x - physob)
@@ -39,8 +39,8 @@ use crate::types::StructureDef;
 ///                 )
 ///             )
 ///         )),
-///         Some(Effects::new(CEffect::new_p_effect(
-///             PEffect::NotAtomicFormula(
+///         Some(Effects::new(ConditionalEffect::new_primitive_effect(
+///             PrimitiveEffect::NotAtomicFormula(
 ///                 AtomicFormula::new_predicate(
 ///                     Predicate::from("in"),
 ///                     vec![Term::Variable(Variable::from("x"))]
@@ -72,8 +72,8 @@ impl crate::parsers::Parser for StructureDef {
 mod tests {
     use crate::parsers::preamble::*;
     use crate::{
-        ActionDefinition, ActionSymbol, AtomicFormula, CEffect, Effects, GoalDefinition, Name,
-        PEffect, PreconditionGoalDefinitions, Predicate, PreferenceGD, StructureDef, Term, ToTyped,
+        ActionDefinition, ActionSymbol, AtomicFormula, ConditionalEffect, Effects, GoalDefinition, Name,
+        PrimitiveEffect, PreconditionGoalDefinitions, Predicate, PreferenceGD, StructureDef, Term, ToTyped,
         TypedList, Variable,
     };
 
@@ -99,8 +99,8 @@ mod tests {
                         )
                     ))
                 )),
-                Some(Effects::new(CEffect::new_p_effect(
-                    PEffect::NotAtomicFormula(AtomicFormula::new_predicate(
+                Some(Effects::new(ConditionalEffect::new_primitive_effect(
+                    PrimitiveEffect::NotAtomicFormula(AtomicFormula::new_predicate(
                         Predicate::from("in"),
                         vec![Term::Variable(Variable::from("x"))]
                     ))

--- a/src/parsers/timed_effect.rs
+++ b/src/parsers/timed_effect.rs
@@ -2,7 +2,7 @@
 
 use crate::parsers::{parens, prefix_expr, ParseResult, Span};
 use crate::parsers::{
-    parse_assign_op_t, parse_cond_effect, parse_f_assign_da, parse_f_exp_t, parse_f_head,
+    parse_assign_op_t, parse_effect_condition, parse_f_assign_da, parse_f_exp_t, parse_f_head,
     parse_time_specifier,
 };
 use crate::types::TimedEffect;
@@ -17,13 +17,13 @@ use nom::Parser;
 /// ## Example
 /// ```
 /// # use pddl::parsers::{parse_timed_effect, preamble::*};
-/// # use pddl::{AssignOp, AssignOpT, AtomicFormula, CEffect, ConditionalEffect, EqualityAtomicFormula, FAssignDa, FExpDa, FExpT, FHead, PEffect, Term, TimedEffect, TimeSpecifier};
-/// # use pddl::FExpDa::FExp;
+/// # use pddl::{AssignOp, TimedAssignOperator, AtomicFormula, EffectCondition, EqualityAtomicFormula, DurativeActionFunctionAssignment, DurativeActionFluentExpression, FunctionHead, PrimitiveEffect, Term, TimedEffect, TimedFluentExpression, TimeSpecifier};
+/// # use pddl::DurativeActionFluentExpression::Duration;
 /// assert!(parse_timed_effect("(at start (= x y))").is_value(
 ///     TimedEffect::new_conditional(
 ///         TimeSpecifier::Start,
-///         ConditionalEffect::new(
-///             PEffect::AtomicFormula(AtomicFormula::Equality(
+///         EffectCondition::new(
+///             PrimitiveEffect::AtomicFormula(AtomicFormula::Equality(
 ///                 EqualityAtomicFormula::new(
 ///                     Term::Name("x".into()),
 ///                     Term::Name("y".into()))
@@ -36,19 +36,19 @@ use nom::Parser;
 /// assert!(parse_timed_effect("(at end (assign fun-sym ?duration))").is_value(
 ///     TimedEffect::new_fluent(
 ///         TimeSpecifier::End,
-///         FAssignDa::new(
+///         DurativeActionFunctionAssignment::new(
 ///             AssignOp::Assign,
-///             FHead::Simple("fun-sym".into()),
-///             FExpDa::Duration
+///             FunctionHead::Simple("fun-sym".into()),
+///             DurativeActionFluentExpression::Duration
 ///         )
 ///     )
 /// ));
 ///
 /// assert!(parse_timed_effect("(increase fun-sym #t)").is_value(
 ///     TimedEffect::new_continuous(
-///         AssignOpT::Increase,
-///         FHead::Simple("fun-sym".into()),
-///         FExpT::Now
+///         TimedAssignOperator::Increase,
+///         FunctionHead::Simple("fun-sym".into()),
+///         TimedFluentExpression::Now
 ///     )
 /// ));
 /// ```
@@ -58,7 +58,7 @@ pub fn parse_timed_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Ti
             "at",
             (
                 parse_time_specifier,
-                preceded(multispace1, parse_cond_effect),
+                preceded(multispace1, parse_effect_condition),
             ),
         ),
         TimedEffect::from,
@@ -89,6 +89,12 @@ pub fn parse_timed_effect<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, Ti
     alt((fluent, cond, continuous)).parse(input.into())
 }
 
+/// Alias for [`parse_timed_effect`].
+#[deprecated(since = "0.2.0", note = "Use `parse_timed_effect` instead")]
+pub fn parse_timed_eff<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, TimedEffect> {
+    parse_timed_effect(input)
+}
+
 impl crate::parsers::Parser for TimedEffect {
     type Item = TimedEffect;
 
@@ -103,8 +109,8 @@ mod tests {
     use super::*;
     use crate::parsers::UnwrapValue;
     use crate::{
-        AssignOp, AssignOpT, AtomicFormula, ConditionalEffect, EqualityAtomicFormula, FAssignDa,
-        FExpDa, FExpT, FHead, PEffect, Parser, Term, TimeSpecifier,
+        AssignOp, TimedAssignOperator, AtomicFormula, EffectCondition, EqualityAtomicFormula, DurativeActionFunctionAssignment,
+        DurativeActionFluentExpression, TimedFluentExpression, FunctionHead, PrimitiveEffect, Parser, Term, TimeSpecifier,
     };
 
     #[test]
@@ -118,7 +124,7 @@ mod tests {
         assert!(
             TimedEffect::parse("(at start (= x y))").is_value(TimedEffect::new_conditional(
                 TimeSpecifier::Start,
-                ConditionalEffect::new(PEffect::AtomicFormula(AtomicFormula::Equality(
+                EffectCondition::new(PrimitiveEffect::AtomicFormula(AtomicFormula::Equality(
                     EqualityAtomicFormula::new(Term::Name("x".into()), Term::Name("y".into()))
                 )))
             ))
@@ -128,10 +134,10 @@ mod tests {
             TimedEffect::parse("(at end (assign fun-sym ?duration))").is_value(
                 TimedEffect::new_fluent(
                     TimeSpecifier::End,
-                    FAssignDa::new(
+                    DurativeActionFunctionAssignment::new(
                         AssignOp::Assign,
-                        FHead::Simple("fun-sym".into()),
-                        FExpDa::Duration
+                        FunctionHead::Simple("fun-sym".into()),
+                        DurativeActionFluentExpression::Duration
                     )
                 )
             )
@@ -139,9 +145,9 @@ mod tests {
 
         assert!(
             TimedEffect::parse("(increase fun-sym #t)").is_value(TimedEffect::new_continuous(
-                AssignOpT::Increase,
-                FHead::Simple("fun-sym".into()),
-                FExpT::Now
+                TimedAssignOperator::Increase,
+                FunctionHead::Simple("fun-sym".into()),
+                TimedFluentExpression::Now
             ))
         );
     }

--- a/src/parsers/timed_effect.rs
+++ b/src/parsers/timed_effect.rs
@@ -109,8 +109,9 @@ mod tests {
     use super::*;
     use crate::parsers::UnwrapValue;
     use crate::{
-        AssignOp, TimedAssignOperator, AtomicFormula, EffectCondition, EqualityAtomicFormula, DurativeActionFunctionAssignment,
-        DurativeActionFluentExpression, TimedFluentExpression, FunctionHead, PrimitiveEffect, Parser, Term, TimeSpecifier,
+        AssignOp, AtomicFormula, DurativeActionFluentExpression, DurativeActionFunctionAssignment,
+        EffectCondition, EqualityAtomicFormula, FunctionHead, Parser, PrimitiveEffect, Term,
+        TimeSpecifier, TimedAssignOperator, TimedFluentExpression,
     };
 
     #[test]

--- a/src/parsers/timed_effect.rs
+++ b/src/parsers/timed_effect.rs
@@ -123,7 +123,7 @@ mod tests {
     #[test]
     fn test_parse() {
         assert!(
-            TimedEffect::parse("(at start (= x y))").is_value(TimedEffect::new_conditional(
+            TimedEffect::parse("(at start (= x y))").is_value(TimedEffect::conditional(
                 TimeSpecifier::Start,
                 EffectCondition::new(PrimitiveEffect::AtomicFormula(AtomicFormula::Equality(
                     EqualityAtomicFormula::new(Term::Name("x".into()), Term::Name("y".into()))
@@ -133,7 +133,7 @@ mod tests {
 
         assert!(
             TimedEffect::parse("(at end (assign fun-sym ?duration))").is_value(
-                TimedEffect::new_fluent(
+                TimedEffect::fluent(
                     TimeSpecifier::End,
                     DurativeActionFunctionAssignment::new(
                         AssignOp::Assign,
@@ -145,7 +145,7 @@ mod tests {
         );
 
         assert!(
-            TimedEffect::parse("(increase fun-sym #t)").is_value(TimedEffect::new_continuous(
+            TimedEffect::parse("(increase fun-sym #t)").is_value(TimedEffect::continuous(
                 TimedAssignOperator::Increase,
                 FunctionHead::Simple("fun-sym".into()),
                 TimedFluentExpression::Now

--- a/src/parsers/timed_gd.rs
+++ b/src/parsers/timed_gd.rs
@@ -16,7 +16,7 @@ use nom::Parser;
 /// # use pddl::parsers::{parse_timed_gd, preamble::*};
 /// # use pddl::{AtomicFormula, GoalDefinition, Interval, Term, TimedGoalDefinition, TimeSpecifier};
 /// assert!(parse_timed_gd("(at start (= x y))").is_value(
-///     TimedGoalDefinition::new_at(
+///     TimedGoalDefinition::at(
 ///         TimeSpecifier::Start,
 ///         GoalDefinition::AtomicFormula(
 ///             AtomicFormula::new_equality(
@@ -28,7 +28,7 @@ use nom::Parser;
 /// ));
 ///
 /// assert!(parse_timed_gd("(over all (= x y))").is_value(
-///     TimedGoalDefinition::new_over(
+///     TimedGoalDefinition::over(
 ///         Interval::All,
 ///         GoalDefinition::AtomicFormula(
 ///             AtomicFormula::new_equality(
@@ -80,7 +80,7 @@ mod tests {
     #[test]
     fn test_parse() {
         assert!(TimedGoalDefinition::parse("(at start (= x y))").is_value(
-            TimedGoalDefinition::new_at(
+            TimedGoalDefinition::at(
                 TimeSpecifier::Start,
                 GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
                     Term::Name("x".into()),
@@ -90,7 +90,7 @@ mod tests {
         ));
 
         assert!(
-            parse_timed_gd("(over all (= x y))").is_value(TimedGoalDefinition::new_over(
+            parse_timed_gd("(over all (= x y))").is_value(TimedGoalDefinition::over(
                 Interval::All,
                 GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
                     Term::Name("x".into()),

--- a/src/parsers/timed_gd.rs
+++ b/src/parsers/timed_gd.rs
@@ -79,15 +79,15 @@ mod tests {
 
     #[test]
     fn test_parse() {
-        assert!(
-            TimedGoalDefinition::parse("(at start (= x y))").is_value(TimedGoalDefinition::new_at(
+        assert!(TimedGoalDefinition::parse("(at start (= x y))").is_value(
+            TimedGoalDefinition::new_at(
                 TimeSpecifier::Start,
                 GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
                     Term::Name("x".into()),
                     Term::Name("y".into())
                 ))
-            ))
-        );
+            )
+        ));
 
         assert!(
             parse_timed_gd("(over all (= x y))").is_value(TimedGoalDefinition::new_over(

--- a/src/parsers/timed_gd.rs
+++ b/src/parsers/timed_gd.rs
@@ -2,7 +2,7 @@
 
 use crate::parsers::{parse_gd, parse_interval, parse_time_specifier};
 use crate::parsers::{prefix_expr, ParseResult, Span};
-use crate::types::TimedGD;
+use crate::types::TimedGoalDefinition;
 use nom::branch::alt;
 use nom::character::complete::multispace1;
 use nom::combinator::map;
@@ -14,9 +14,9 @@ use nom::Parser;
 /// ## Examples
 /// ```
 /// # use pddl::parsers::{parse_timed_gd, preamble::*};
-/// # use pddl::{AtomicFormula, GoalDefinition, Interval, Term, TimedGD, TimeSpecifier};
+/// # use pddl::{AtomicFormula, GoalDefinition, Interval, Term, TimedGoalDefinition, TimeSpecifier};
 /// assert!(parse_timed_gd("(at start (= x y))").is_value(
-///     TimedGD::new_at(
+///     TimedGoalDefinition::new_at(
 ///         TimeSpecifier::Start,
 ///         GoalDefinition::AtomicFormula(
 ///             AtomicFormula::new_equality(
@@ -28,7 +28,7 @@ use nom::Parser;
 /// ));
 ///
 /// assert!(parse_timed_gd("(over all (= x y))").is_value(
-///     TimedGD::new_over(
+///     TimedGoalDefinition::new_over(
 ///         Interval::All,
 ///         GoalDefinition::AtomicFormula(
 ///             AtomicFormula::new_equality(
@@ -39,25 +39,25 @@ use nom::Parser;
 ///     )
 /// ));
 /// ```
-pub fn parse_timed_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, TimedGD> {
+pub fn parse_timed_gd<'a, T: Into<Span<'a>>>(input: T) -> ParseResult<'a, TimedGoalDefinition> {
     let at = map(
         prefix_expr(
             "at",
             (parse_time_specifier, preceded(multispace1, parse_gd)),
         ),
-        TimedGD::from,
+        TimedGoalDefinition::from,
     );
 
     let over = map(
         prefix_expr("over", (parse_interval, preceded(multispace1, parse_gd))),
-        TimedGD::from,
+        TimedGoalDefinition::from,
     );
 
     alt((at, over)).parse(input.into())
 }
 
-impl crate::parsers::Parser for TimedGD {
-    type Item = TimedGD;
+impl crate::parsers::Parser for TimedGoalDefinition {
+    type Item = TimedGoalDefinition;
 
     /// See [`parse_timed_gd`].
     fn parse<'a, S: Into<Span<'a>>>(input: S) -> ParseResult<'a, Self::Item> {
@@ -80,7 +80,7 @@ mod tests {
     #[test]
     fn test_parse() {
         assert!(
-            TimedGD::parse("(at start (= x y))").is_value(TimedGD::new_at(
+            TimedGoalDefinition::parse("(at start (= x y))").is_value(TimedGoalDefinition::new_at(
                 TimeSpecifier::Start,
                 GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
                     Term::Name("x".into()),
@@ -90,7 +90,7 @@ mod tests {
         );
 
         assert!(
-            parse_timed_gd("(over all (= x y))").is_value(TimedGD::new_over(
+            parse_timed_gd("(over all (= x y))").is_value(TimedGoalDefinition::new_over(
                 Interval::All,
                 GoalDefinition::AtomicFormula(AtomicFormula::new_equality(
                     Term::Name("x".into()),

--- a/src/parsers/typed_list.rs
+++ b/src/parsers/typed_list.rs
@@ -54,7 +54,7 @@ where
     F: Clone + Parser<Span<'a>, Output = O, Error = ParseError<'a>>,
 {
     // `x*`
-    let implicitly_typed = map(inner.clone(), |o| Typed::new_object(o));
+    let implicitly_typed = map(inner.clone(), |o| Typed::object(o));
     let implicitly_typed_list = space_separated_list0(implicitly_typed);
 
     // `x⁺ - <type>`

--- a/src/pretty_print/atomic_formula.rs
+++ b/src/pretty_print/atomic_formula.rs
@@ -123,8 +123,8 @@ mod tests {
 
     #[test]
     fn predicate_formula_works() {
-        let x = AtomicFormula::new_predicate(
-            Predicate::new_string("at"),
+        let x = AtomicFormula::predicate(
+            Predicate::string("at"),
             vec![
                 Term::new_name(Name::new("B")),
                 Term::new_name(Name::new("home")),
@@ -135,8 +135,8 @@ mod tests {
 
     #[test]
     fn literal_not_works() {
-        let af = AtomicFormula::new_predicate(
-            Predicate::new_string("at"),
+        let af = AtomicFormula::predicate(
+            Predicate::string("at"),
             vec![Term::new_name(Name::new("B"))],
         );
         let x = Literal::<Term>::new_not(af);
@@ -146,8 +146,8 @@ mod tests {
     #[test]
     fn literal_name_atomic_works() {
         use crate::AtomicFormula as NameAtomicFormula;
-        let af = NameAtomicFormula::new_predicate(
-            Predicate::new_string("p"),
+        let af = NameAtomicFormula::predicate(
+            Predicate::string("p"),
             vec![Name::new("x"), Name::new("y")],
         );
         let lit = Literal::<Name>::new(af);
@@ -157,7 +157,7 @@ mod tests {
     #[test]
     fn literal_name_not_atomic_works() {
         use crate::AtomicFormula as NameAtomicFormula;
-        let af = NameAtomicFormula::new_predicate(Predicate::new_string("p"), vec![Name::new("x")]);
+        let af = NameAtomicFormula::predicate(Predicate::string("p"), vec![Name::new("x")]);
         let lit = Literal::<Name>::new_not(af);
         assert_eq!(prettify!(lit, 20), "(not (p x))");
     }
@@ -170,15 +170,14 @@ mod tests {
 
     #[test]
     fn atomic_formula_name_predicate_empty_works() {
-        let pred =
-            AtomicFormula::<Name>::new_predicate(Predicate::new_string("p"), Vec::<Name>::new());
+        let pred = AtomicFormula::<Name>::new_predicate(Predicate::string("p"), Vec::<Name>::new());
         assert_eq!(prettify!(pred, 20), "(p)");
     }
 
     #[test]
     fn atomic_formula_name_predicate_non_empty_works() {
         let pred = AtomicFormula::<Name>::new_predicate(
-            Predicate::new_string("p"),
+            Predicate::string("p"),
             vec![Name::new("x"), Name::new("y")],
         );
         assert_eq!(prettify!(pred, 20), "(p x y)");
@@ -186,8 +185,7 @@ mod tests {
 
     #[test]
     fn atomic_formula_term_empty_args_works() {
-        let pred =
-            AtomicFormula::<Term>::new_predicate(Predicate::new_string("p"), Vec::<Term>::new());
+        let pred = AtomicFormula::<Term>::new_predicate(Predicate::string("p"), Vec::<Term>::new());
         assert_eq!(prettify!(pred, 20), "(p)");
     }
 }

--- a/src/pretty_print/decl.rs
+++ b/src/pretty_print/decl.rs
@@ -2,8 +2,8 @@ use std::ops::Deref;
 
 use crate::pretty_print::{sealed, PrettyRenderer};
 use crate::types::{
-    Constants, Functions, GoalDef, InitElement, InitElements, LengthSpec, MetricSpec, Objects,
-    PredicateDefinitions, Requirements, Types,
+    Constants, Functions, InitElement, InitElements, LengthSpec, MetricSpec, Objects,
+    PredicateDefinitions, ProblemGoalDefinition, Requirements, Types,
 };
 use crate::visitor::{Accept, Visitor};
 use pretty::RcDoc;
@@ -15,7 +15,7 @@ impl sealed::Sealed for PredicateDefinitions {}
 impl sealed::Sealed for Functions {}
 impl sealed::Sealed for Objects {}
 impl sealed::Sealed for InitElements {}
-impl sealed::Sealed for GoalDef {}
+impl sealed::Sealed for ProblemGoalDefinition {}
 impl sealed::Sealed for MetricSpec {}
 impl sealed::Sealed for LengthSpec {}
 impl sealed::Sealed for InitElement {}
@@ -91,8 +91,8 @@ impl Visitor<InitElement, RcDoc<'static>> for PrettyRenderer {
     }
 }
 
-impl Visitor<GoalDef, RcDoc<'static>> for PrettyRenderer {
-    fn visit(&self, value: &GoalDef) -> RcDoc<'static> {
+impl Visitor<ProblemGoalDefinition, RcDoc<'static>> for PrettyRenderer {
+    fn visit(&self, value: &ProblemGoalDefinition) -> RcDoc<'static> {
         value.deref().accept(self)
     }
 }
@@ -138,7 +138,7 @@ mod tests {
     fn metric_spec_works() {
         let ms = crate::MetricSpec::new(
             crate::Optimization::Minimize,
-            crate::MetricFExp::new_total_time(),
+            crate::MetricFluentExpression::new_total_time(),
         );
         assert_eq!(prettify!(ms, 30), "minimize total-time");
     }
@@ -245,7 +245,7 @@ mod tests {
         let gd = crate::GoalDefinition::new_and(Vec::<crate::GoalDefinition>::new());
         let pre_gd =
             crate::PreconditionGoalDefinition::new_preference(crate::PreferenceGD::from_gd(gd));
-        let gdef = GoalDef::new(PreconditionGoalDefinitions::new(vec![pre_gd]));
+        let gdef = ProblemGoalDefinition::new(PreconditionGoalDefinitions::new(vec![pre_gd]));
         assert_eq!(prettify!(gdef, 20), "(and)");
     }
 

--- a/src/pretty_print/decl.rs
+++ b/src/pretty_print/decl.rs
@@ -138,7 +138,7 @@ mod tests {
     fn metric_spec_works() {
         let ms = crate::MetricSpec::new(
             crate::Optimization::Minimize,
-            crate::MetricFluentExpression::new_total_time(),
+            crate::MetricFluentExpression::total_time(),
         );
         assert_eq!(prettify!(ms, 30), "minimize total-time");
     }
@@ -187,12 +187,12 @@ mod tests {
 
     #[test]
     fn init_elements_multi_works() {
-        let lit1 = crate::AtomicFormula::new_predicate(
-            crate::Predicate::new_string("block"),
+        let lit1 = crate::AtomicFormula::predicate(
+            crate::Predicate::string("block"),
             vec![crate::Name::new("a")],
         );
-        let lit2 = crate::AtomicFormula::new_predicate(
-            crate::Predicate::new_string("block"),
+        let lit2 = crate::AtomicFormula::predicate(
+            crate::Predicate::string("block"),
             vec![crate::Name::new("b")],
         );
         let ie = InitElements::new(vec![
@@ -206,8 +206,8 @@ mod tests {
 
     #[test]
     fn init_element_literal_works() {
-        let af = crate::AtomicFormula::new_predicate(
-            crate::Predicate::new_string("block"),
+        let af = crate::AtomicFormula::predicate(
+            crate::Predicate::string("block"),
             vec![crate::Name::new("a")],
         );
         let ie = InitElement::Literal(Literal::new(af));
@@ -216,8 +216,8 @@ mod tests {
 
     #[test]
     fn init_element_at_works() {
-        let af = crate::AtomicFormula::new_predicate(
-            crate::Predicate::new_string("block"),
+        let af = crate::AtomicFormula::predicate(
+            crate::Predicate::string("block"),
             vec![crate::Name::new("a")],
         );
         let ie = InitElement::At(crate::Number::from(10), Literal::new(af));
@@ -242,8 +242,8 @@ mod tests {
 
     #[test]
     fn goal_def_works() {
-        let gd = crate::GoalDefinition::new_and(Vec::<crate::GoalDefinition>::new());
-        let pre_gd = crate::PreconditionGoalDefinition::new_preference(
+        let gd = crate::GoalDefinition::and(Vec::<crate::GoalDefinition>::new());
+        let pre_gd = crate::PreconditionGoalDefinition::preference(
             crate::PreferenceGoalDefinition::from_gd(gd),
         );
         let gdef = ProblemGoalDefinition::new(PreconditionGoalDefinitions::new(vec![pre_gd]));
@@ -266,7 +266,7 @@ mod tests {
     fn predicate_definitions_works() {
         use crate::AtomicFormulaSkeleton;
         let preds = PredicateDefinitions::new(vec![AtomicFormulaSkeleton::new(
-            crate::Predicate::new_string("at"),
+            crate::Predicate::string("at"),
             vec![].into(),
         )]);
         assert_eq!(prettify!(preds, 20), "(at)");

--- a/src/pretty_print/decl.rs
+++ b/src/pretty_print/decl.rs
@@ -243,8 +243,9 @@ mod tests {
     #[test]
     fn goal_def_works() {
         let gd = crate::GoalDefinition::new_and(Vec::<crate::GoalDefinition>::new());
-        let pre_gd =
-            crate::PreconditionGoalDefinition::new_preference(crate::PreferenceGD::from_gd(gd));
+        let pre_gd = crate::PreconditionGoalDefinition::new_preference(
+            crate::PreferenceGoalDefinition::from_gd(gd),
+        );
         let gdef = ProblemGoalDefinition::new(PreconditionGoalDefinitions::new(vec![pre_gd]));
         assert_eq!(prettify!(gdef, 20), "(and)");
     }

--- a/src/pretty_print/domain.rs
+++ b/src/pretty_print/domain.rs
@@ -107,7 +107,7 @@ impl Visitor<Domain, RcDoc<'static>> for PrettyRenderer {
 mod tests {
     use crate::parsers::Parser;
     use crate::pretty_print::Pretty;
-    use crate::types::{ConGD, DomainConstraintsDef};
+    use crate::types::{ConstraintGoalDefinition, DomainConstraintsDef};
 
     #[test]
     fn domain_basic() {
@@ -209,7 +209,7 @@ mod tests {
 
     #[test]
     fn domain_constraints_def_empty_nil() {
-        let dc = DomainConstraintsDef::new(ConGD::default());
+        let dc = DomainConstraintsDef::new(ConstraintGoalDefinition::default());
         let out = dc.pretty(80).to_string();
         assert_eq!(out, "");
     }

--- a/src/pretty_print/effect.rs
+++ b/src/pretty_print/effect.rs
@@ -1,30 +1,30 @@
 use crate::pretty_print::{sealed, PrettyRenderer};
-use crate::types::{CEffect, ConditionalEffect, Effects, ForallCEffect, PEffect, WhenCEffect};
+use crate::types::{ConditionalEffect, EffectCondition, Effects, ForallConditionalEffect, PrimitiveEffect, WhenConditionalEffect};
 use crate::visitor::{Accept, Visitor};
 use pretty::RcDoc;
 
-impl sealed::Sealed for PEffect {}
-impl sealed::Sealed for CEffect {}
-impl sealed::Sealed for ForallCEffect {}
-impl sealed::Sealed for WhenCEffect {}
+impl sealed::Sealed for PrimitiveEffect {}
 impl sealed::Sealed for ConditionalEffect {}
+impl sealed::Sealed for EffectCondition {}
+impl sealed::Sealed for ForallConditionalEffect {}
+impl sealed::Sealed for WhenConditionalEffect {}
 impl sealed::Sealed for Effects {}
 
-impl Visitor<PEffect, RcDoc<'static>> for PrettyRenderer {
-    fn visit(&self, value: &PEffect) -> RcDoc<'static> {
+impl Visitor<PrimitiveEffect, RcDoc<'static>> for PrettyRenderer {
+    fn visit(&self, value: &PrimitiveEffect) -> RcDoc<'static> {
         match value {
-            PEffect::AtomicFormula(af) => af.accept(self),
-            PEffect::NotAtomicFormula(af) => {
+            PrimitiveEffect::AtomicFormula(af) => af.accept(self),
+            PrimitiveEffect::NotAtomicFormula(af) => {
                 RcDoc::text("(not ").append(af.accept(self)).append(")")
             }
-            PEffect::AssignNumericFluent(op, head, exp) => RcDoc::text("(")
+            PrimitiveEffect::AssignNumericFluent(op, head, exp) => RcDoc::text("(")
                 .append(op.accept(self))
                 .append(" ")
                 .append(head.accept(self))
                 .append(" ")
                 .append(exp.accept(self))
                 .append(")"),
-            PEffect::AssignObjectFluent(ft, term) => match term {
+            PrimitiveEffect::AssignObjectFluent(ft, term) => match term {
                 Some(t) => RcDoc::text("(assign ")
                     .append(ft.accept(self))
                     .append(" ")
@@ -36,18 +36,18 @@ impl Visitor<PEffect, RcDoc<'static>> for PrettyRenderer {
     }
 }
 
-impl Visitor<CEffect, RcDoc<'static>> for PrettyRenderer {
-    fn visit(&self, value: &CEffect) -> RcDoc<'static> {
+impl Visitor<ConditionalEffect, RcDoc<'static>> for PrettyRenderer {
+    fn visit(&self, value: &ConditionalEffect) -> RcDoc<'static> {
         match value {
-            CEffect::Effect(pe) => pe.accept(self),
-            CEffect::Forall(fc) => fc.accept(self),
-            CEffect::When(wc) => wc.accept(self),
+            ConditionalEffect::Effect(pe) => pe.accept(self),
+            ConditionalEffect::Forall(fc) => fc.accept(self),
+            ConditionalEffect::When(wc) => wc.accept(self),
         }
     }
 }
 
-impl Visitor<ForallCEffect, RcDoc<'static>> for PrettyRenderer {
-    fn visit(&self, value: &ForallCEffect) -> RcDoc<'static> {
+impl Visitor<ForallConditionalEffect, RcDoc<'static>> for PrettyRenderer {
+    fn visit(&self, value: &ForallConditionalEffect) -> RcDoc<'static> {
         RcDoc::text("(forall (")
             .append(value.variables.accept(self))
             .append(") ")
@@ -56,8 +56,8 @@ impl Visitor<ForallCEffect, RcDoc<'static>> for PrettyRenderer {
     }
 }
 
-impl Visitor<WhenCEffect, RcDoc<'static>> for PrettyRenderer {
-    fn visit(&self, value: &WhenCEffect) -> RcDoc<'static> {
+impl Visitor<WhenConditionalEffect, RcDoc<'static>> for PrettyRenderer {
+    fn visit(&self, value: &WhenConditionalEffect) -> RcDoc<'static> {
         RcDoc::text("(when ")
             .append(value.condition.accept(self))
             .append(" ")
@@ -66,11 +66,11 @@ impl Visitor<WhenCEffect, RcDoc<'static>> for PrettyRenderer {
     }
 }
 
-impl Visitor<ConditionalEffect, RcDoc<'static>> for PrettyRenderer {
-    fn visit(&self, value: &ConditionalEffect) -> RcDoc<'static> {
+impl Visitor<EffectCondition, RcDoc<'static>> for PrettyRenderer {
+    fn visit(&self, value: &EffectCondition) -> RcDoc<'static> {
         match value {
-            ConditionalEffect::Single(pe) => pe.accept(self),
-            ConditionalEffect::All(pes) => {
+            EffectCondition::Single(pe) => pe.accept(self),
+            EffectCondition::All(pes) => {
                 if pes.is_empty() {
                     RcDoc::text("(and)")
                 } else {
@@ -109,7 +109,7 @@ mod tests {
     use crate::pretty_print::prettify;
     use crate::visitor::Accept;
     use crate::{
-        AtomicFormula, ConditionalEffect, FunctionSymbol, GoalDefinition, Name, PEffect, Predicate,
+        AtomicFormula, ConditionalEffect, EffectCondition, FunctionSymbol, GoalDefinition, Name, PrimitiveEffect, Predicate,
         Term,
     };
 
@@ -122,7 +122,7 @@ mod tests {
                 Term::new_name(Name::new("home")),
             ],
         );
-        let pe = PEffect::new(af);
+        let pe = PrimitiveEffect::new(af);
         assert_eq!(prettify!(pe, 30), "(at B home)");
     }
 
@@ -132,16 +132,16 @@ mod tests {
             Predicate::new_string("at"),
             vec![Term::new_name(Name::new("B"))],
         );
-        let pe = PEffect::new_not(af);
+        let pe = PrimitiveEffect::new_not(af);
         assert_eq!(prettify!(pe, 30), "(not (at B))");
     }
 
     #[test]
     fn p_effect_assign() {
-        let pe = PEffect::new_numeric_fluent(
+        let pe = PrimitiveEffect::new_numeric_fluent(
             crate::AssignOp::Assign,
-            crate::FHead::new(FunctionSymbol::from("battery")),
-            crate::FExp::new_number(10),
+            crate::FunctionHead::new(FunctionSymbol::from("battery")),
+            crate::FluentExpression::new_number(10),
         );
         assert_eq!(prettify!(pe, 30), "(assign battery 10)");
     }
@@ -152,8 +152,8 @@ mod tests {
             Predicate::new_string("at"),
             vec![Term::new_name(Name::new("B"))],
         );
-        let pe = PEffect::new(af);
-        let ce = CEffect::new_p_effect(pe);
+        let pe = PrimitiveEffect::new(af);
+        let ce = ConditionalEffect::new_primitive_effect(pe);
         let effects = Effects::new(ce);
         assert_eq!(prettify!(effects, 30), "(and (at B))");
     }
@@ -165,7 +165,7 @@ mod tests {
             FunctionSymbol::from("loc"),
             vec![Term::new_name(Name::new("x"))],
         );
-        let pe = PEffect::new_object_fluent(ft, Some(Term::new_name(Name::new("y"))));
+        let pe = PrimitiveEffect::new_object_fluent(ft, Some(Term::new_name(Name::new("y"))));
         assert_eq!(prettify!(pe, 30), "(assign (loc x) y)");
     }
 
@@ -173,7 +173,7 @@ mod tests {
     fn p_effect_assign_object_fluent_without_term() {
         use crate::{FunctionSymbol, FunctionTerm};
         let ft = FunctionTerm::new(FunctionSymbol::from("loc"), vec![]);
-        let pe = PEffect::new_object_fluent(ft, None);
+        let pe = PrimitiveEffect::new_object_fluent(ft, None);
         assert_eq!(prettify!(pe, 30), "(assign loc)");
     }
 
@@ -185,23 +185,23 @@ mod tests {
             Predicate::new_string("p"),
             vec![Term::new_variable(Variable::from("x"))],
         );
-        let pe = PEffect::new(af);
-        let effects = Effects::new(CEffect::new_p_effect(pe));
-        let ce = CEffect::new_forall(vars, effects);
+        let pe = PrimitiveEffect::new(af);
+        let effects = Effects::new(ConditionalEffect::new_primitive_effect(pe));
+        let ce = ConditionalEffect::new_forall(vars, effects);
         assert_eq!(prettify!(ce, 40), "(forall (?x) (and (p ?x)))");
     }
 
     #[test]
     fn c_effect_when() {
         let cond = GoalDefinition::new_and(Vec::<GoalDefinition>::new());
-        let ce_inner = ConditionalEffect::new_and(Vec::new());
-        let ce = CEffect::new_when(cond, ce_inner);
+        let ce_inner = EffectCondition::new_and(Vec::new());
+        let ce = ConditionalEffect::new_when(cond, ce_inner);
         assert_eq!(prettify!(ce, 30), "(when (and) (and))");
     }
 
     #[test]
     fn conditional_effect_all_empty() {
-        let ce = ConditionalEffect::new_and(Vec::new());
+        let ce = EffectCondition::new_and(Vec::new());
         assert_eq!(prettify!(ce, 20), "(and)");
     }
 
@@ -211,9 +211,9 @@ mod tests {
             Predicate::new_string("at"),
             vec![Term::new_name(Name::new("x"))],
         );
-        let pe1 = PEffect::new(af.clone());
-        let pe2 = PEffect::new(af);
-        let ce = ConditionalEffect::new_and(vec![pe1, pe2]);
+        let pe1 = PrimitiveEffect::new(af.clone());
+        let pe2 = PrimitiveEffect::new(af);
+        let ce = EffectCondition::new_and(vec![pe1, pe2]);
         assert_eq!(prettify!(ce, 30), "(and (at x) (at x))");
     }
 
@@ -227,8 +227,8 @@ mod tests {
             Predicate::new_string("at"),
             vec![Term::new_name(Name::new("y"))],
         );
-        let ce1 = CEffect::new_p_effect(PEffect::new(af1));
-        let ce2 = CEffect::new_p_effect(PEffect::new(af2));
+        let ce1 = ConditionalEffect::new_primitive_effect(PrimitiveEffect::new(af1));
+        let ce2 = ConditionalEffect::new_primitive_effect(PrimitiveEffect::new(af2));
         let effects = Effects::new_and(vec![ce1, ce2]);
         assert_eq!(prettify!(effects, 40), "(and (at x) (at y))");
     }

--- a/src/pretty_print/effect.rs
+++ b/src/pretty_print/effect.rs
@@ -1,5 +1,8 @@
 use crate::pretty_print::{sealed, PrettyRenderer};
-use crate::types::{ConditionalEffect, EffectCondition, Effects, ForallConditionalEffect, PrimitiveEffect, WhenConditionalEffect};
+use crate::types::{
+    ConditionalEffect, EffectCondition, Effects, ForallConditionalEffect, PrimitiveEffect,
+    WhenConditionalEffect,
+};
 use crate::visitor::{Accept, Visitor};
 use pretty::RcDoc;
 
@@ -109,8 +112,8 @@ mod tests {
     use crate::pretty_print::prettify;
     use crate::visitor::Accept;
     use crate::{
-        AtomicFormula, ConditionalEffect, EffectCondition, FunctionSymbol, GoalDefinition, Name, PrimitiveEffect, Predicate,
-        Term,
+        AtomicFormula, ConditionalEffect, EffectCondition, FunctionSymbol, GoalDefinition, Name,
+        Predicate, PrimitiveEffect, Term,
     };
 
     #[test]

--- a/src/pretty_print/effect.rs
+++ b/src/pretty_print/effect.rs
@@ -118,8 +118,8 @@ mod tests {
 
     #[test]
     fn p_effect_atomic() {
-        let af = AtomicFormula::new_predicate(
-            Predicate::new_string("at"),
+        let af = AtomicFormula::predicate(
+            Predicate::string("at"),
             vec![
                 Term::new_name(Name::new("B")),
                 Term::new_name(Name::new("home")),
@@ -131,28 +131,28 @@ mod tests {
 
     #[test]
     fn p_effect_not() {
-        let af = AtomicFormula::new_predicate(
-            Predicate::new_string("at"),
+        let af = AtomicFormula::predicate(
+            Predicate::string("at"),
             vec![Term::new_name(Name::new("B"))],
         );
-        let pe = PrimitiveEffect::new_not(af);
+        let pe = PrimitiveEffect::not(af);
         assert_eq!(prettify!(pe, 30), "(not (at B))");
     }
 
     #[test]
     fn p_effect_assign() {
-        let pe = PrimitiveEffect::new_numeric_fluent(
+        let pe = PrimitiveEffect::numeric_fluent(
             crate::AssignOp::Assign,
             crate::FunctionHead::new(FunctionSymbol::from("battery")),
-            crate::FluentExpression::new_number(10),
+            crate::FluentExpression::number(10),
         );
         assert_eq!(prettify!(pe, 30), "(assign battery 10)");
     }
 
     #[test]
     fn effects_single() {
-        let af = AtomicFormula::new_predicate(
-            Predicate::new_string("at"),
+        let af = AtomicFormula::predicate(
+            Predicate::string("at"),
             vec![Term::new_name(Name::new("B"))],
         );
         let pe = PrimitiveEffect::new(af);
@@ -168,7 +168,7 @@ mod tests {
             FunctionSymbol::from("loc"),
             vec![Term::new_name(Name::new("x"))],
         );
-        let pe = PrimitiveEffect::new_object_fluent(ft, Some(Term::new_name(Name::new("y"))));
+        let pe = PrimitiveEffect::object_fluent(ft, Some(Term::new_name(Name::new("y"))));
         assert_eq!(prettify!(pe, 30), "(assign (loc x) y)");
     }
 
@@ -176,63 +176,63 @@ mod tests {
     fn p_effect_assign_object_fluent_without_term() {
         use crate::{FunctionSymbol, FunctionTerm};
         let ft = FunctionTerm::new(FunctionSymbol::from("loc"), vec![]);
-        let pe = PrimitiveEffect::new_object_fluent(ft, None);
+        let pe = PrimitiveEffect::object_fluent(ft, None);
         assert_eq!(prettify!(pe, 30), "(assign loc)");
     }
 
     #[test]
     fn c_effect_forall() {
         use crate::{ToTyped, Type, TypedVariables, Variable};
-        let vars: TypedVariables = vec![Variable::new_string("x").to_typed(Type::OBJECT)].into();
-        let af = AtomicFormula::new_predicate(
-            Predicate::new_string("p"),
+        let vars: TypedVariables = vec![Variable::string("x").to_typed(Type::OBJECT)].into();
+        let af = AtomicFormula::predicate(
+            Predicate::string("p"),
             vec![Term::new_variable(Variable::from("x"))],
         );
         let pe = PrimitiveEffect::new(af);
         let effects = Effects::new(ConditionalEffect::new_primitive_effect(pe));
-        let ce = ConditionalEffect::new_forall(vars, effects);
+        let ce = ConditionalEffect::forall(vars, effects);
         assert_eq!(prettify!(ce, 40), "(forall (?x) (and (p ?x)))");
     }
 
     #[test]
     fn c_effect_when() {
-        let cond = GoalDefinition::new_and(Vec::<GoalDefinition>::new());
-        let ce_inner = EffectCondition::new_and(Vec::new());
-        let ce = ConditionalEffect::new_when(cond, ce_inner);
+        let cond = GoalDefinition::and(Vec::<GoalDefinition>::new());
+        let ce_inner = EffectCondition::all(Vec::new());
+        let ce = ConditionalEffect::when(cond, ce_inner);
         assert_eq!(prettify!(ce, 30), "(when (and) (and))");
     }
 
     #[test]
     fn conditional_effect_all_empty() {
-        let ce = EffectCondition::new_and(Vec::new());
+        let ce = EffectCondition::all(Vec::new());
         assert_eq!(prettify!(ce, 20), "(and)");
     }
 
     #[test]
     fn conditional_effect_all_non_empty() {
-        let af = AtomicFormula::new_predicate(
-            Predicate::new_string("at"),
+        let af = AtomicFormula::predicate(
+            Predicate::string("at"),
             vec![Term::new_name(Name::new("x"))],
         );
         let pe1 = PrimitiveEffect::new(af.clone());
         let pe2 = PrimitiveEffect::new(af);
-        let ce = EffectCondition::new_and(vec![pe1, pe2]);
+        let ce = EffectCondition::all(vec![pe1, pe2]);
         assert_eq!(prettify!(ce, 30), "(and (at x) (at x))");
     }
 
     #[test]
     fn effects_multi_effect() {
-        let af1 = AtomicFormula::new_predicate(
-            Predicate::new_string("at"),
+        let af1 = AtomicFormula::predicate(
+            Predicate::string("at"),
             vec![Term::new_name(Name::new("x"))],
         );
-        let af2 = AtomicFormula::new_predicate(
-            Predicate::new_string("at"),
+        let af2 = AtomicFormula::predicate(
+            Predicate::string("at"),
             vec![Term::new_name(Name::new("y"))],
         );
         let ce1 = ConditionalEffect::new_primitive_effect(PrimitiveEffect::new(af1));
         let ce2 = ConditionalEffect::new_primitive_effect(PrimitiveEffect::new(af2));
-        let effects = Effects::new_and(vec![ce1, ce2]);
+        let effects = Effects::and(vec![ce1, ce2]);
         assert_eq!(prettify!(effects, 40), "(and (at x) (at y))");
     }
 }

--- a/src/pretty_print/f_exp.rs
+++ b/src/pretty_print/f_exp.rs
@@ -1,31 +1,32 @@
 use crate::pretty_print::{sealed, PrettyRenderer};
 use crate::types::{
-    BinaryComp, BinaryOp, FAssignDa, FComp, FExp, FExpDa, FExpT, FHead, MetricFExp, MultiOp,
+    BinaryComparison, BinaryOp, DurativeActionFluentExpression, DurativeActionFunctionAssignment, FluentComparison,
+    FluentExpression, FunctionHead, MetricFluentExpression, MultiOp, TimedFluentExpression,
 };
 use crate::visitor::{Accept, Visitor};
 use pretty::RcDoc;
 
-impl sealed::Sealed for FExp {}
-impl sealed::Sealed for FHead {}
-impl sealed::Sealed for FComp {}
-impl sealed::Sealed for FExpT {}
-impl sealed::Sealed for FExpDa {}
-impl sealed::Sealed for FAssignDa {}
-impl sealed::Sealed for MetricFExp {}
+impl sealed::Sealed for FluentExpression {}
+impl sealed::Sealed for FunctionHead {}
+impl sealed::Sealed for FluentComparison {}
+impl sealed::Sealed for TimedFluentExpression {}
+impl sealed::Sealed for DurativeActionFluentExpression {}
+impl sealed::Sealed for DurativeActionFunctionAssignment {}
+impl sealed::Sealed for MetricFluentExpression {}
 
-impl Visitor<FExp, RcDoc<'static>> for PrettyRenderer {
-    fn visit(&self, value: &FExp) -> RcDoc<'static> {
+impl Visitor<FluentExpression, RcDoc<'static>> for PrettyRenderer {
+    fn visit(&self, value: &FluentExpression) -> RcDoc<'static> {
         match value {
-            FExp::Number(n) => n.accept(self),
-            FExp::Function(head) => head.accept(self),
-            FExp::Negative(e) => RcDoc::text("(")
+            FluentExpression::Number(n) => n.accept(self),
+            FluentExpression::Function(head) => head.accept(self),
+            FluentExpression::Negative(e) => RcDoc::text("(")
                 .append("-")
                 .append(RcDoc::softline())
                 .append(self.visit(&**e))
                 .nest(4)
                 .group()
                 .append(")"),
-            FExp::BinaryOp(op, a, b) => {
+            FluentExpression::BinaryOp(op, a, b) => {
                 let op_str = match op {
                     BinaryOp::Addition => "+",
                     BinaryOp::Subtraction => "-",
@@ -34,7 +35,7 @@ impl Visitor<FExp, RcDoc<'static>> for PrettyRenderer {
                 };
                 self.sexpr(op_str, [self.visit(&**a), self.visit(&**b)])
             }
-            FExp::MultiOp(op, first, rest) => {
+            FluentExpression::MultiOp(op, first, rest) => {
                 let op_str = match op {
                     MultiOp::Addition => "+",
                     MultiOp::Multiplication => "*",
@@ -48,11 +49,11 @@ impl Visitor<FExp, RcDoc<'static>> for PrettyRenderer {
     }
 }
 
-impl Visitor<FHead, RcDoc<'static>> for PrettyRenderer {
-    fn visit(&self, value: &FHead) -> RcDoc<'static> {
+impl Visitor<FunctionHead, RcDoc<'static>> for PrettyRenderer {
+    fn visit(&self, value: &FunctionHead) -> RcDoc<'static> {
         match value {
-            FHead::Simple(sym) => sym.accept(self),
-            FHead::WithTerms(sym, terms) => RcDoc::text("(")
+            FunctionHead::Simple(sym) => sym.accept(self),
+            FunctionHead::WithTerms(sym, terms) => RcDoc::text("(")
                 .append(sym.accept(self))
                 .append(RcDoc::softline())
                 .append(RcDoc::intersperse(
@@ -66,14 +67,14 @@ impl Visitor<FHead, RcDoc<'static>> for PrettyRenderer {
     }
 }
 
-impl Visitor<FComp, RcDoc<'static>> for PrettyRenderer {
-    fn visit(&self, value: &FComp) -> RcDoc<'static> {
+impl Visitor<FluentComparison, RcDoc<'static>> for PrettyRenderer {
+    fn visit(&self, value: &FluentComparison) -> RcDoc<'static> {
         let op_str = match value.comparison() {
-            BinaryComp::GreaterThan => ">",
-            BinaryComp::LessThan => "<",
-            BinaryComp::Equal => "=",
-            BinaryComp::GreaterOrEqual => ">=",
-            BinaryComp::LessThanOrEqual => "<=",
+            BinaryComparison::GreaterThan => ">",
+            BinaryComparison::LessThan => "<",
+            BinaryComparison::Equal => "=",
+            BinaryComparison::GreaterOrEqual => ">=",
+            BinaryComparison::LessThanOrEqual => "<=",
         };
         self.sexpr(
             op_str,
@@ -82,28 +83,28 @@ impl Visitor<FComp, RcDoc<'static>> for PrettyRenderer {
     }
 }
 
-impl Visitor<FExpT, RcDoc<'static>> for PrettyRenderer {
-    fn visit(&self, value: &FExpT) -> RcDoc<'static> {
+impl Visitor<TimedFluentExpression, RcDoc<'static>> for PrettyRenderer {
+    fn visit(&self, value: &TimedFluentExpression) -> RcDoc<'static> {
         match value {
-            FExpT::Now => RcDoc::text("now"),
-            FExpT::Scaled(e) => self.visit(e),
+            TimedFluentExpression::Now => RcDoc::text("now"),
+            TimedFluentExpression::Scaled(e) => self.visit(e),
         }
     }
 }
 
-impl Visitor<FExpDa, RcDoc<'static>> for PrettyRenderer {
-    fn visit(&self, value: &FExpDa) -> RcDoc<'static> {
+impl Visitor<DurativeActionFluentExpression, RcDoc<'static>> for PrettyRenderer {
+    fn visit(&self, value: &DurativeActionFluentExpression) -> RcDoc<'static> {
         match value {
-            FExpDa::Duration => RcDoc::text("#t"),
-            FExpDa::FExp(e) => self.visit(e),
-            FExpDa::Negative(e) => RcDoc::text("(")
+            DurativeActionFluentExpression::Duration => RcDoc::text("#t"),
+            DurativeActionFluentExpression::FluentExpression(e) => self.visit(e),
+            DurativeActionFluentExpression::Negative(e) => RcDoc::text("(")
                 .append("-")
                 .append(RcDoc::softline())
                 .append(self.visit(&**e))
                 .nest(4)
                 .group()
                 .append(")"),
-            FExpDa::BinaryOp(op, a, b) => {
+            DurativeActionFluentExpression::BinaryOp(op, a, b) => {
                 let op_str = match op {
                     BinaryOp::Addition => "+",
                     BinaryOp::Subtraction => "-",
@@ -112,7 +113,7 @@ impl Visitor<FExpDa, RcDoc<'static>> for PrettyRenderer {
                 };
                 self.sexpr(op_str, [self.visit(&**a), self.visit(&**b)])
             }
-            FExpDa::MultiOp(op, first, rest) => {
+            DurativeActionFluentExpression::MultiOp(op, first, rest) => {
                 let op_str = match op {
                     MultiOp::Addition => "+",
                     MultiOp::Multiplication => "*",
@@ -122,15 +123,15 @@ impl Visitor<FExpDa, RcDoc<'static>> for PrettyRenderer {
                     std::iter::once(self.visit(&**first)).chain(rest.iter().map(|e| self.visit(e))),
                 )
             }
-            FExpDa::Assign(op, head, expr) => {
+            DurativeActionFluentExpression::Assign(op, head, expr) => {
                 self.sexpr(op.as_str(), [self.visit(head), self.visit(&**expr)])
             }
         }
     }
 }
 
-impl Visitor<FAssignDa, RcDoc<'static>> for PrettyRenderer {
-    fn visit(&self, value: &FAssignDa) -> RcDoc<'static> {
+impl Visitor<DurativeActionFunctionAssignment, RcDoc<'static>> for PrettyRenderer {
+    fn visit(&self, value: &DurativeActionFunctionAssignment) -> RcDoc<'static> {
         self.sexpr(
             value.operation().as_str(),
             [
@@ -141,11 +142,11 @@ impl Visitor<FAssignDa, RcDoc<'static>> for PrettyRenderer {
     }
 }
 
-impl Visitor<MetricFExp, RcDoc<'static>> for PrettyRenderer {
-    fn visit(&self, value: &MetricFExp) -> RcDoc<'static> {
+impl Visitor<MetricFluentExpression, RcDoc<'static>> for PrettyRenderer {
+    fn visit(&self, value: &MetricFluentExpression) -> RcDoc<'static> {
         match value {
-            MetricFExp::Number(n) => n.accept(self),
-            MetricFExp::Function(sym, names) => {
+            MetricFluentExpression::Number(n) => n.accept(self),
+            MetricFluentExpression::Function(sym, names) => {
                 if names.is_empty() {
                     sym.accept(self)
                 } else {
@@ -161,22 +162,22 @@ impl Visitor<MetricFExp, RcDoc<'static>> for PrettyRenderer {
                         .append(")")
                 }
             }
-            MetricFExp::TotalTime => RcDoc::text("total-time"),
-            MetricFExp::IsViolated(pref) => RcDoc::text("(")
+            MetricFluentExpression::TotalTime => RcDoc::text("total-time"),
+            MetricFluentExpression::IsViolated(pref) => RcDoc::text("(")
                 .append("is-violated")
                 .append(RcDoc::softline())
                 .append(pref.accept(self))
                 .nest(4)
                 .group()
                 .append(")"),
-            MetricFExp::Negative(e) => RcDoc::text("(")
+            MetricFluentExpression::Negative(e) => RcDoc::text("(")
                 .append("-")
                 .append(RcDoc::softline())
                 .append(self.visit(&**e))
                 .nest(4)
                 .group()
                 .append(")"),
-            MetricFExp::BinaryOp(op, a, b) => {
+            MetricFluentExpression::BinaryOp(op, a, b) => {
                 let op_str = match op {
                     BinaryOp::Addition => "+",
                     BinaryOp::Subtraction => "-",
@@ -185,7 +186,7 @@ impl Visitor<MetricFExp, RcDoc<'static>> for PrettyRenderer {
                 };
                 self.sexpr(op_str, [self.visit(&**a), self.visit(&**b)])
             }
-            MetricFExp::MultiOp(op, first, rest) => {
+            MetricFluentExpression::MultiOp(op, first, rest) => {
                 let op_str = match op {
                     MultiOp::Addition => "+",
                     MultiOp::Multiplication => "*",
@@ -205,284 +206,284 @@ mod tests {
     use crate::pretty_print::prettify;
     use crate::visitor::Accept;
     use crate::{
-        AssignOp, BinaryComp, BinaryOp, FunctionSymbol, MultiOp, Name, Number, PreferenceName,
-        Variable,
+        AssignOp, BinaryComparison, BinaryOp, FunctionSymbol, MultiOp, Name, Number,
+        PreferenceName, Variable,
     };
 
     #[test]
     fn fexp_number_works() {
-        let n = FExp::new_number(Number::from(42));
+        let n = FluentExpression::new_number(Number::from(42));
         assert_eq!(prettify!(n, 10), "42");
     }
 
     #[test]
     fn fexp_simple_function_works() {
-        let head = FHead::Simple(FunctionSymbol::from("fuel"));
-        let e = FExp::new_function(head);
+        let head = FunctionHead::Simple(FunctionSymbol::from("fuel"));
+        let e = FluentExpression::new_function(head);
         assert_eq!(prettify!(e, 10), "fuel");
     }
 
     #[test]
     fn fexp_function_with_terms_works() {
-        let head = FHead::WithTerms(
+        let head = FunctionHead::WithTerms(
             FunctionSymbol::from("fuel"),
             vec![crate::Term::new_variable(Variable::from("r"))],
         );
-        let e = FExp::new_function(head);
+        let e = FluentExpression::new_function(head);
         assert_eq!(prettify!(e, 20), "(fuel ?r)");
     }
 
     #[test]
     fn fexp_negative_works() {
-        let inner = FExp::new_number(Number::from(5));
-        let e = FExp::new_negative(inner);
+        let inner = FluentExpression::new_number(Number::from(5));
+        let e = FluentExpression::new_negative(inner);
         assert_eq!(prettify!(e, 10), "(- 5)");
     }
 
     #[test]
     fn fexp_binary_op_works() {
-        let a = FExp::new_number(Number::from(3));
-        let b = FExp::new_number(Number::from(4));
-        let e = FExp::new_binary_op(BinaryOp::Addition, a, b);
+        let a = FluentExpression::new_number(Number::from(3));
+        let b = FluentExpression::new_number(Number::from(4));
+        let e = FluentExpression::new_binary_op(BinaryOp::Addition, a, b);
         assert_eq!(prettify!(e, 10), "(+ 3 4)");
     }
 
     #[test]
     fn fcomp_works() {
-        let a = FExp::new_number(Number::from(3));
-        let b = FExp::new_number(Number::from(4));
-        let fc = FComp::new(BinaryComp::GreaterThan, a, b);
+        let a = FluentExpression::new_number(Number::from(3));
+        let b = FluentExpression::new_number(Number::from(4));
+        let fc = FluentComparison::new(BinaryComparison::GreaterThan, a, b);
         assert_eq!(prettify!(fc, 10), "(> 3 4)");
     }
 
     #[test]
     fn fexp_t_now_works() {
-        let e = FExpT::Now;
+        let e = TimedFluentExpression::Now;
         assert_eq!(prettify!(e, 10), "now");
     }
 
     #[test]
     fn fexp_t_scaled_works() {
-        let inner = FExp::new_number(Number::from(2));
-        let e = FExpT::Scaled(inner);
+        let inner = FluentExpression::new_number(Number::from(2));
+        let e = TimedFluentExpression::Scaled(inner);
         assert_eq!(prettify!(e, 10), "2");
     }
 
     #[test]
     fn fexp_da_duration_works() {
-        let e = FExpDa::new_duration();
+        let e = DurativeActionFluentExpression::new_duration();
         assert_eq!(prettify!(e, 10), "#t");
     }
 
     #[test]
     fn fexp_da_fexp_works() {
-        let inner = FExp::new_number(Number::from(10));
-        let e = FExpDa::new_f_exp(inner);
+        let inner = FluentExpression::new_number(Number::from(10));
+        let e = DurativeActionFluentExpression::new_f_exp(inner);
         assert_eq!(prettify!(e, 10), "10");
     }
 
     #[test]
     fn f_assign_da_works() {
-        let head = FHead::Simple(FunctionSymbol::from("fuel"));
-        let expr = FExpDa::new_f_exp(FExp::new_number(Number::from(5)));
-        let assign = FAssignDa::new(AssignOp::Assign, head, expr);
+        let head = FunctionHead::Simple(FunctionSymbol::from("fuel"));
+        let expr = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(Number::from(5)));
+        let assign = DurativeActionFunctionAssignment::new(AssignOp::Assign, head, expr);
         assert_eq!(prettify!(assign, 20), "(assign fuel 5)");
     }
 
     #[test]
     fn metric_fexp_number_works() {
-        let m = MetricFExp::new_number(Number::from(10));
+        let m = MetricFluentExpression::new_number(Number::from(10));
         assert_eq!(prettify!(m, 10), "10");
     }
 
     #[test]
     fn metric_fexp_total_time_works() {
-        let m = MetricFExp::new_total_time();
+        let m = MetricFluentExpression::new_total_time();
         assert_eq!(prettify!(m, 10), "total-time");
     }
 
     #[test]
     fn metric_fexp_function_works() {
-        let m = MetricFExp::new_function(FunctionSymbol::from("fuel"), vec![Name::new("r")]);
+        let m = MetricFluentExpression::new_function(FunctionSymbol::from("fuel"), vec![Name::new("r")]);
         assert_eq!(prettify!(m, 20), "(fuel r)");
     }
 
     #[test]
     fn metric_fexp_is_violated_works() {
-        let m = MetricFExp::new_is_violated(PreferenceName::new_string("p1"));
+        let m = MetricFluentExpression::new_is_violated(PreferenceName::new_string("p1"));
         assert_eq!(prettify!(m, 20), "(is-violated p1)");
     }
 
     #[test]
     fn fexp_multi_op_addition_works() {
-        let a = FExp::new_number(Number::from(1));
-        let b = FExp::new_number(Number::from(2));
-        let c = FExp::new_number(Number::from(3));
-        let e = FExp::new_multi_op(MultiOp::Addition, a, [b, c]);
+        let a = FluentExpression::new_number(Number::from(1));
+        let b = FluentExpression::new_number(Number::from(2));
+        let c = FluentExpression::new_number(Number::from(3));
+        let e = FluentExpression::new_multi_op(MultiOp::Addition, a, [b, c]);
         assert_eq!(prettify!(e, 20), "(+ 1 2 3)");
     }
 
     #[test]
     fn fexp_multi_op_multiplication_works() {
-        let a = FExp::new_number(Number::from(2));
-        let b = FExp::new_number(Number::from(3));
-        let c = FExp::new_number(Number::from(4));
-        let e = FExp::new_multi_op(MultiOp::Multiplication, a, [b, c]);
+        let a = FluentExpression::new_number(Number::from(2));
+        let b = FluentExpression::new_number(Number::from(3));
+        let c = FluentExpression::new_number(Number::from(4));
+        let e = FluentExpression::new_multi_op(MultiOp::Multiplication, a, [b, c]);
         assert_eq!(prettify!(e, 20), "(* 2 3 4)");
     }
 
     #[test]
     fn fexp_binary_op_subtraction_works() {
-        let a = FExp::new_number(Number::from(5));
-        let b = FExp::new_number(Number::from(3));
-        let e = FExp::new_binary_op(BinaryOp::Subtraction, a, b);
+        let a = FluentExpression::new_number(Number::from(5));
+        let b = FluentExpression::new_number(Number::from(3));
+        let e = FluentExpression::new_binary_op(BinaryOp::Subtraction, a, b);
         assert_eq!(prettify!(e, 10), "(- 5 3)");
     }
 
     #[test]
     fn fexp_binary_op_division_works() {
-        let a = FExp::new_number(Number::from(10));
-        let b = FExp::new_number(Number::from(2));
-        let e = FExp::new_binary_op(BinaryOp::Division, a, b);
+        let a = FluentExpression::new_number(Number::from(10));
+        let b = FluentExpression::new_number(Number::from(2));
+        let e = FluentExpression::new_binary_op(BinaryOp::Division, a, b);
         assert_eq!(prettify!(e, 10), "(/ 10 2)");
     }
 
     #[test]
     fn fexp_binary_op_multiplication_works() {
-        let a = FExp::new_number(Number::from(3));
-        let b = FExp::new_number(Number::from(4));
-        let e = FExp::new_binary_op(BinaryOp::Multiplication, a, b);
+        let a = FluentExpression::new_number(Number::from(3));
+        let b = FluentExpression::new_number(Number::from(4));
+        let e = FluentExpression::new_binary_op(BinaryOp::Multiplication, a, b);
         assert_eq!(prettify!(e, 10), "(* 3 4)");
     }
 
     #[test]
     fn fexp_da_negative_works() {
-        let inner = FExpDa::new_f_exp(FExp::new_number(Number::from(5)));
-        let e = FExpDa::new_negative(inner);
+        let inner = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(Number::from(5)));
+        let e = DurativeActionFluentExpression::new_negative(inner);
         assert_eq!(prettify!(e, 10), "(- 5)");
     }
 
     #[test]
     fn fexp_da_binary_op_subtraction_works() {
-        let a = FExpDa::new_f_exp(FExp::new_number(Number::from(5)));
-        let b = FExpDa::new_f_exp(FExp::new_number(Number::from(3)));
-        let e = FExpDa::new_binary_op(BinaryOp::Subtraction, a, b);
+        let a = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(Number::from(5)));
+        let b = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(Number::from(3)));
+        let e = DurativeActionFluentExpression::new_binary_op(BinaryOp::Subtraction, a, b);
         assert_eq!(prettify!(e, 10), "(- 5 3)");
     }
 
     #[test]
     fn fexp_da_binary_op_division_works() {
-        let a = FExpDa::new_f_exp(FExp::new_number(Number::from(10)));
-        let b = FExpDa::new_f_exp(FExp::new_number(Number::from(2)));
-        let e = FExpDa::new_binary_op(BinaryOp::Division, a, b);
+        let a = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(Number::from(10)));
+        let b = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(Number::from(2)));
+        let e = DurativeActionFluentExpression::new_binary_op(BinaryOp::Division, a, b);
         assert_eq!(prettify!(e, 10), "(/ 10 2)");
     }
 
     #[test]
     fn fexp_da_binary_op_multiplication_works() {
-        let a = FExpDa::new_f_exp(FExp::new_number(Number::from(3)));
-        let b = FExpDa::new_f_exp(FExp::new_number(Number::from(4)));
-        let e = FExpDa::new_binary_op(BinaryOp::Multiplication, a, b);
+        let a = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(Number::from(3)));
+        let b = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(Number::from(4)));
+        let e = DurativeActionFluentExpression::new_binary_op(BinaryOp::Multiplication, a, b);
         assert_eq!(prettify!(e, 10), "(* 3 4)");
     }
 
     #[test]
     fn fexp_da_multi_op_addition_works() {
-        let a = FExpDa::new_f_exp(FExp::new_number(Number::from(1)));
-        let b = FExpDa::new_f_exp(FExp::new_number(Number::from(2)));
-        let c = FExpDa::new_f_exp(FExp::new_number(Number::from(3)));
-        let e = FExpDa::new_multi_op(MultiOp::Addition, a, [b, c]);
+        let a = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(Number::from(1)));
+        let b = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(Number::from(2)));
+        let c = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(Number::from(3)));
+        let e = DurativeActionFluentExpression::new_multi_op(MultiOp::Addition, a, [b, c]);
         assert_eq!(prettify!(e, 20), "(+ 1 2 3)");
     }
 
     #[test]
     fn fexp_da_multi_op_multiplication_works() {
-        let a = FExpDa::new_f_exp(FExp::new_number(Number::from(2)));
-        let b = FExpDa::new_f_exp(FExp::new_number(Number::from(3)));
-        let c = FExpDa::new_f_exp(FExp::new_number(Number::from(4)));
-        let e = FExpDa::new_multi_op(MultiOp::Multiplication, a, [b, c]);
+        let a = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(Number::from(2)));
+        let b = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(Number::from(3)));
+        let c = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(Number::from(4)));
+        let e = DurativeActionFluentExpression::new_multi_op(MultiOp::Multiplication, a, [b, c]);
         assert_eq!(prettify!(e, 20), "(* 2 3 4)");
     }
 
     #[test]
     fn fexp_da_assign_works() {
-        use crate::FHead;
-        let head = FHead::Simple(FunctionSymbol::from("x"));
-        let expr = FExpDa::new_f_exp(FExp::new_number(Number::from(10)));
-        let e = FExpDa::Assign(AssignOp::Increase, head, Box::new(expr));
+        use crate::FunctionHead;
+        let head = FunctionHead::Simple(FunctionSymbol::from("x"));
+        let expr = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(Number::from(10)));
+        let e = DurativeActionFluentExpression::Assign(AssignOp::Increase, head, Box::new(expr));
         assert_eq!(prettify!(e, 20), "(increase x 10)");
     }
 
     #[test]
     fn fcomp_less_than_works() {
-        let a = FExp::new_number(Number::from(3));
-        let b = FExp::new_number(Number::from(4));
-        let fc = FComp::new(BinaryComp::LessThan, a, b);
+        let a = FluentExpression::new_number(Number::from(3));
+        let b = FluentExpression::new_number(Number::from(4));
+        let fc = FluentComparison::new(BinaryComparison::LessThan, a, b);
         assert_eq!(prettify!(fc, 10), "(< 3 4)");
     }
 
     #[test]
     fn fcomp_equal_works() {
-        let a = FExp::new_number(Number::from(3));
-        let b = FExp::new_number(Number::from(4));
-        let fc = FComp::new(BinaryComp::Equal, a, b);
+        let a = FluentExpression::new_number(Number::from(3));
+        let b = FluentExpression::new_number(Number::from(4));
+        let fc = FluentComparison::new(BinaryComparison::Equal, a, b);
         assert_eq!(prettify!(fc, 10), "(= 3 4)");
     }
 
     #[test]
     fn fcomp_greater_or_equal_works() {
-        let a = FExp::new_number(Number::from(3));
-        let b = FExp::new_number(Number::from(4));
-        let fc = FComp::new(BinaryComp::GreaterOrEqual, a, b);
+        let a = FluentExpression::new_number(Number::from(3));
+        let b = FluentExpression::new_number(Number::from(4));
+        let fc = FluentComparison::new(BinaryComparison::GreaterOrEqual, a, b);
         assert_eq!(prettify!(fc, 10), "(>= 3 4)");
     }
 
     #[test]
     fn fcomp_less_than_or_equal_works() {
-        let a = FExp::new_number(Number::from(3));
-        let b = FExp::new_number(Number::from(4));
-        let fc = FComp::new(BinaryComp::LessThanOrEqual, a, b);
+        let a = FluentExpression::new_number(Number::from(3));
+        let b = FluentExpression::new_number(Number::from(4));
+        let fc = FluentComparison::new(BinaryComparison::LessThanOrEqual, a, b);
         assert_eq!(prettify!(fc, 10), "(<= 3 4)");
     }
 
     #[test]
     fn metric_fexp_negative_works() {
-        let inner = MetricFExp::new_number(Number::from(5));
-        let m = MetricFExp::new_negative(inner);
+        let inner = MetricFluentExpression::new_number(Number::from(5));
+        let m = MetricFluentExpression::new_negative(inner);
         assert_eq!(prettify!(m, 10), "(- 5)");
     }
 
     #[test]
     fn metric_fexp_binary_op_subtraction_works() {
-        let a = MetricFExp::new_number(Number::from(5));
-        let b = MetricFExp::new_number(Number::from(3));
-        let m = MetricFExp::new_binary_op(BinaryOp::Subtraction, a, b);
+        let a = MetricFluentExpression::new_number(Number::from(5));
+        let b = MetricFluentExpression::new_number(Number::from(3));
+        let m = MetricFluentExpression::new_binary_op(BinaryOp::Subtraction, a, b);
         assert_eq!(prettify!(m, 10), "(- 5 3)");
     }
 
     #[test]
     fn metric_fexp_binary_op_multiplication_works() {
-        let a = MetricFExp::new_number(Number::from(3));
-        let b = MetricFExp::new_number(Number::from(4));
-        let m = MetricFExp::new_binary_op(BinaryOp::Multiplication, a, b);
+        let a = MetricFluentExpression::new_number(Number::from(3));
+        let b = MetricFluentExpression::new_number(Number::from(4));
+        let m = MetricFluentExpression::new_binary_op(BinaryOp::Multiplication, a, b);
         assert_eq!(prettify!(m, 10), "(* 3 4)");
     }
 
     #[test]
     fn metric_fexp_multi_op_addition_works() {
-        let a = MetricFExp::new_number(Number::from(1));
-        let b = MetricFExp::new_number(Number::from(2));
-        let c = MetricFExp::new_number(Number::from(3));
-        let m = MetricFExp::new_multi_op(MultiOp::Addition, a, [b, c]);
+        let a = MetricFluentExpression::new_number(Number::from(1));
+        let b = MetricFluentExpression::new_number(Number::from(2));
+        let c = MetricFluentExpression::new_number(Number::from(3));
+        let m = MetricFluentExpression::new_multi_op(MultiOp::Addition, a, [b, c]);
         assert_eq!(prettify!(m, 20), "(+ 1 2 3)");
     }
 
     #[test]
     fn metric_fexp_multi_op_multiplication_works() {
-        let a = MetricFExp::new_number(Number::from(2));
-        let b = MetricFExp::new_number(Number::from(3));
-        let c = MetricFExp::new_number(Number::from(4));
-        let m = MetricFExp::new_multi_op(MultiOp::Multiplication, a, [b, c]);
+        let a = MetricFluentExpression::new_number(Number::from(2));
+        let b = MetricFluentExpression::new_number(Number::from(3));
+        let c = MetricFluentExpression::new_number(Number::from(4));
+        let m = MetricFluentExpression::new_multi_op(MultiOp::Multiplication, a, [b, c]);
         assert_eq!(prettify!(m, 20), "(* 2 3 4)");
     }
 }

--- a/src/pretty_print/f_exp.rs
+++ b/src/pretty_print/f_exp.rs
@@ -1,7 +1,8 @@
 use crate::pretty_print::{sealed, PrettyRenderer};
 use crate::types::{
-    BinaryComparison, BinaryOp, DurativeActionFluentExpression, DurativeActionFunctionAssignment, FluentComparison,
-    FluentExpression, FunctionHead, MetricFluentExpression, MultiOp, TimedFluentExpression,
+    BinaryComparison, BinaryOp, DurativeActionFluentExpression, DurativeActionFunctionAssignment,
+    FluentComparison, FluentExpression, FunctionHead, MetricFluentExpression, MultiOp,
+    TimedFluentExpression,
 };
 use crate::visitor::{Accept, Visitor};
 use pretty::RcDoc;
@@ -285,7 +286,9 @@ mod tests {
     #[test]
     fn f_assign_da_works() {
         let head = FunctionHead::Simple(FunctionSymbol::from("fuel"));
-        let expr = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(Number::from(5)));
+        let expr = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(
+            Number::from(5),
+        ));
         let assign = DurativeActionFunctionAssignment::new(AssignOp::Assign, head, expr);
         assert_eq!(prettify!(assign, 20), "(assign fuel 5)");
     }
@@ -304,7 +307,10 @@ mod tests {
 
     #[test]
     fn metric_fexp_function_works() {
-        let m = MetricFluentExpression::new_function(FunctionSymbol::from("fuel"), vec![Name::new("r")]);
+        let m = MetricFluentExpression::new_function(
+            FunctionSymbol::from("fuel"),
+            vec![Name::new("r")],
+        );
         assert_eq!(prettify!(m, 20), "(fuel r)");
     }
 
@@ -358,49 +364,75 @@ mod tests {
 
     #[test]
     fn fexp_da_negative_works() {
-        let inner = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(Number::from(5)));
+        let inner = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(
+            Number::from(5),
+        ));
         let e = DurativeActionFluentExpression::new_negative(inner);
         assert_eq!(prettify!(e, 10), "(- 5)");
     }
 
     #[test]
     fn fexp_da_binary_op_subtraction_works() {
-        let a = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(Number::from(5)));
-        let b = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(Number::from(3)));
+        let a = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(
+            Number::from(5),
+        ));
+        let b = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(
+            Number::from(3),
+        ));
         let e = DurativeActionFluentExpression::new_binary_op(BinaryOp::Subtraction, a, b);
         assert_eq!(prettify!(e, 10), "(- 5 3)");
     }
 
     #[test]
     fn fexp_da_binary_op_division_works() {
-        let a = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(Number::from(10)));
-        let b = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(Number::from(2)));
+        let a = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(
+            Number::from(10),
+        ));
+        let b = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(
+            Number::from(2),
+        ));
         let e = DurativeActionFluentExpression::new_binary_op(BinaryOp::Division, a, b);
         assert_eq!(prettify!(e, 10), "(/ 10 2)");
     }
 
     #[test]
     fn fexp_da_binary_op_multiplication_works() {
-        let a = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(Number::from(3)));
-        let b = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(Number::from(4)));
+        let a = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(
+            Number::from(3),
+        ));
+        let b = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(
+            Number::from(4),
+        ));
         let e = DurativeActionFluentExpression::new_binary_op(BinaryOp::Multiplication, a, b);
         assert_eq!(prettify!(e, 10), "(* 3 4)");
     }
 
     #[test]
     fn fexp_da_multi_op_addition_works() {
-        let a = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(Number::from(1)));
-        let b = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(Number::from(2)));
-        let c = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(Number::from(3)));
+        let a = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(
+            Number::from(1),
+        ));
+        let b = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(
+            Number::from(2),
+        ));
+        let c = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(
+            Number::from(3),
+        ));
         let e = DurativeActionFluentExpression::new_multi_op(MultiOp::Addition, a, [b, c]);
         assert_eq!(prettify!(e, 20), "(+ 1 2 3)");
     }
 
     #[test]
     fn fexp_da_multi_op_multiplication_works() {
-        let a = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(Number::from(2)));
-        let b = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(Number::from(3)));
-        let c = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(Number::from(4)));
+        let a = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(
+            Number::from(2),
+        ));
+        let b = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(
+            Number::from(3),
+        ));
+        let c = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(
+            Number::from(4),
+        ));
         let e = DurativeActionFluentExpression::new_multi_op(MultiOp::Multiplication, a, [b, c]);
         assert_eq!(prettify!(e, 20), "(* 2 3 4)");
     }
@@ -409,7 +441,9 @@ mod tests {
     fn fexp_da_assign_works() {
         use crate::FunctionHead;
         let head = FunctionHead::Simple(FunctionSymbol::from("x"));
-        let expr = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(Number::from(10)));
+        let expr = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(
+            Number::from(10),
+        ));
         let e = DurativeActionFluentExpression::Assign(AssignOp::Increase, head, Box::new(expr));
         assert_eq!(prettify!(e, 20), "(increase x 10)");
     }

--- a/src/pretty_print/f_exp.rs
+++ b/src/pretty_print/f_exp.rs
@@ -213,14 +213,14 @@ mod tests {
 
     #[test]
     fn fexp_number_works() {
-        let n = FluentExpression::new_number(Number::from(42));
+        let n = FluentExpression::number(Number::from(42));
         assert_eq!(prettify!(n, 10), "42");
     }
 
     #[test]
     fn fexp_simple_function_works() {
         let head = FunctionHead::Simple(FunctionSymbol::from("fuel"));
-        let e = FluentExpression::new_function(head);
+        let e = FluentExpression::function(head);
         assert_eq!(prettify!(e, 10), "fuel");
     }
 
@@ -230,29 +230,29 @@ mod tests {
             FunctionSymbol::from("fuel"),
             vec![crate::Term::new_variable(Variable::from("r"))],
         );
-        let e = FluentExpression::new_function(head);
+        let e = FluentExpression::function(head);
         assert_eq!(prettify!(e, 20), "(fuel ?r)");
     }
 
     #[test]
     fn fexp_negative_works() {
-        let inner = FluentExpression::new_number(Number::from(5));
-        let e = FluentExpression::new_negative(inner);
+        let inner = FluentExpression::number(Number::from(5));
+        let e = FluentExpression::negative(inner);
         assert_eq!(prettify!(e, 10), "(- 5)");
     }
 
     #[test]
     fn fexp_binary_op_works() {
-        let a = FluentExpression::new_number(Number::from(3));
-        let b = FluentExpression::new_number(Number::from(4));
-        let e = FluentExpression::new_binary_op(BinaryOp::Addition, a, b);
+        let a = FluentExpression::number(Number::from(3));
+        let b = FluentExpression::number(Number::from(4));
+        let e = FluentExpression::binary_op(BinaryOp::Addition, a, b);
         assert_eq!(prettify!(e, 10), "(+ 3 4)");
     }
 
     #[test]
     fn fcomp_works() {
-        let a = FluentExpression::new_number(Number::from(3));
-        let b = FluentExpression::new_number(Number::from(4));
+        let a = FluentExpression::number(Number::from(3));
+        let b = FluentExpression::number(Number::from(4));
         let fc = FluentComparison::new(BinaryComparison::GreaterThan, a, b);
         assert_eq!(prettify!(fc, 10), "(> 3 4)");
     }
@@ -265,28 +265,28 @@ mod tests {
 
     #[test]
     fn fexp_t_scaled_works() {
-        let inner = FluentExpression::new_number(Number::from(2));
+        let inner = FluentExpression::number(Number::from(2));
         let e = TimedFluentExpression::Scaled(inner);
         assert_eq!(prettify!(e, 10), "2");
     }
 
     #[test]
     fn fexp_da_duration_works() {
-        let e = DurativeActionFluentExpression::new_duration();
+        let e = DurativeActionFluentExpression::duration();
         assert_eq!(prettify!(e, 10), "#t");
     }
 
     #[test]
     fn fexp_da_fexp_works() {
-        let inner = FluentExpression::new_number(Number::from(10));
-        let e = DurativeActionFluentExpression::new_f_exp(inner);
+        let inner = FluentExpression::number(Number::from(10));
+        let e = DurativeActionFluentExpression::fluent_expression(inner);
         assert_eq!(prettify!(e, 10), "10");
     }
 
     #[test]
     fn f_assign_da_works() {
         let head = FunctionHead::Simple(FunctionSymbol::from("fuel"));
-        let expr = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(
+        let expr = DurativeActionFluentExpression::fluent_expression(FluentExpression::number(
             Number::from(5),
         ));
         let assign = DurativeActionFunctionAssignment::new(AssignOp::Assign, head, expr);
@@ -295,145 +295,143 @@ mod tests {
 
     #[test]
     fn metric_fexp_number_works() {
-        let m = MetricFluentExpression::new_number(Number::from(10));
+        let m = MetricFluentExpression::number(Number::from(10));
         assert_eq!(prettify!(m, 10), "10");
     }
 
     #[test]
     fn metric_fexp_total_time_works() {
-        let m = MetricFluentExpression::new_total_time();
+        let m = MetricFluentExpression::total_time();
         assert_eq!(prettify!(m, 10), "total-time");
     }
 
     #[test]
     fn metric_fexp_function_works() {
-        let m = MetricFluentExpression::new_function(
-            FunctionSymbol::from("fuel"),
-            vec![Name::new("r")],
-        );
+        let m =
+            MetricFluentExpression::function(FunctionSymbol::from("fuel"), vec![Name::new("r")]);
         assert_eq!(prettify!(m, 20), "(fuel r)");
     }
 
     #[test]
     fn metric_fexp_is_violated_works() {
-        let m = MetricFluentExpression::new_is_violated(PreferenceName::new_string("p1"));
+        let m = MetricFluentExpression::is_violated(PreferenceName::string("p1"));
         assert_eq!(prettify!(m, 20), "(is-violated p1)");
     }
 
     #[test]
     fn fexp_multi_op_addition_works() {
-        let a = FluentExpression::new_number(Number::from(1));
-        let b = FluentExpression::new_number(Number::from(2));
-        let c = FluentExpression::new_number(Number::from(3));
-        let e = FluentExpression::new_multi_op(MultiOp::Addition, a, [b, c]);
+        let a = FluentExpression::number(Number::from(1));
+        let b = FluentExpression::number(Number::from(2));
+        let c = FluentExpression::number(Number::from(3));
+        let e = FluentExpression::multi_op(MultiOp::Addition, a, [b, c]);
         assert_eq!(prettify!(e, 20), "(+ 1 2 3)");
     }
 
     #[test]
     fn fexp_multi_op_multiplication_works() {
-        let a = FluentExpression::new_number(Number::from(2));
-        let b = FluentExpression::new_number(Number::from(3));
-        let c = FluentExpression::new_number(Number::from(4));
-        let e = FluentExpression::new_multi_op(MultiOp::Multiplication, a, [b, c]);
+        let a = FluentExpression::number(Number::from(2));
+        let b = FluentExpression::number(Number::from(3));
+        let c = FluentExpression::number(Number::from(4));
+        let e = FluentExpression::multi_op(MultiOp::Multiplication, a, [b, c]);
         assert_eq!(prettify!(e, 20), "(* 2 3 4)");
     }
 
     #[test]
     fn fexp_binary_op_subtraction_works() {
-        let a = FluentExpression::new_number(Number::from(5));
-        let b = FluentExpression::new_number(Number::from(3));
-        let e = FluentExpression::new_binary_op(BinaryOp::Subtraction, a, b);
+        let a = FluentExpression::number(Number::from(5));
+        let b = FluentExpression::number(Number::from(3));
+        let e = FluentExpression::binary_op(BinaryOp::Subtraction, a, b);
         assert_eq!(prettify!(e, 10), "(- 5 3)");
     }
 
     #[test]
     fn fexp_binary_op_division_works() {
-        let a = FluentExpression::new_number(Number::from(10));
-        let b = FluentExpression::new_number(Number::from(2));
-        let e = FluentExpression::new_binary_op(BinaryOp::Division, a, b);
+        let a = FluentExpression::number(Number::from(10));
+        let b = FluentExpression::number(Number::from(2));
+        let e = FluentExpression::binary_op(BinaryOp::Division, a, b);
         assert_eq!(prettify!(e, 10), "(/ 10 2)");
     }
 
     #[test]
     fn fexp_binary_op_multiplication_works() {
-        let a = FluentExpression::new_number(Number::from(3));
-        let b = FluentExpression::new_number(Number::from(4));
-        let e = FluentExpression::new_binary_op(BinaryOp::Multiplication, a, b);
+        let a = FluentExpression::number(Number::from(3));
+        let b = FluentExpression::number(Number::from(4));
+        let e = FluentExpression::binary_op(BinaryOp::Multiplication, a, b);
         assert_eq!(prettify!(e, 10), "(* 3 4)");
     }
 
     #[test]
     fn fexp_da_negative_works() {
-        let inner = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(
+        let inner = DurativeActionFluentExpression::fluent_expression(FluentExpression::number(
             Number::from(5),
         ));
-        let e = DurativeActionFluentExpression::new_negative(inner);
+        let e = DurativeActionFluentExpression::negative(inner);
         assert_eq!(prettify!(e, 10), "(- 5)");
     }
 
     #[test]
     fn fexp_da_binary_op_subtraction_works() {
-        let a = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(
+        let a = DurativeActionFluentExpression::fluent_expression(FluentExpression::number(
             Number::from(5),
         ));
-        let b = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(
+        let b = DurativeActionFluentExpression::fluent_expression(FluentExpression::number(
             Number::from(3),
         ));
-        let e = DurativeActionFluentExpression::new_binary_op(BinaryOp::Subtraction, a, b);
+        let e = DurativeActionFluentExpression::binary_op(BinaryOp::Subtraction, a, b);
         assert_eq!(prettify!(e, 10), "(- 5 3)");
     }
 
     #[test]
     fn fexp_da_binary_op_division_works() {
-        let a = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(
+        let a = DurativeActionFluentExpression::fluent_expression(FluentExpression::number(
             Number::from(10),
         ));
-        let b = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(
+        let b = DurativeActionFluentExpression::fluent_expression(FluentExpression::number(
             Number::from(2),
         ));
-        let e = DurativeActionFluentExpression::new_binary_op(BinaryOp::Division, a, b);
+        let e = DurativeActionFluentExpression::binary_op(BinaryOp::Division, a, b);
         assert_eq!(prettify!(e, 10), "(/ 10 2)");
     }
 
     #[test]
     fn fexp_da_binary_op_multiplication_works() {
-        let a = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(
+        let a = DurativeActionFluentExpression::fluent_expression(FluentExpression::number(
             Number::from(3),
         ));
-        let b = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(
+        let b = DurativeActionFluentExpression::fluent_expression(FluentExpression::number(
             Number::from(4),
         ));
-        let e = DurativeActionFluentExpression::new_binary_op(BinaryOp::Multiplication, a, b);
+        let e = DurativeActionFluentExpression::binary_op(BinaryOp::Multiplication, a, b);
         assert_eq!(prettify!(e, 10), "(* 3 4)");
     }
 
     #[test]
     fn fexp_da_multi_op_addition_works() {
-        let a = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(
+        let a = DurativeActionFluentExpression::fluent_expression(FluentExpression::number(
             Number::from(1),
         ));
-        let b = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(
+        let b = DurativeActionFluentExpression::fluent_expression(FluentExpression::number(
             Number::from(2),
         ));
-        let c = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(
+        let c = DurativeActionFluentExpression::fluent_expression(FluentExpression::number(
             Number::from(3),
         ));
-        let e = DurativeActionFluentExpression::new_multi_op(MultiOp::Addition, a, [b, c]);
+        let e = DurativeActionFluentExpression::multi_op(MultiOp::Addition, a, [b, c]);
         assert_eq!(prettify!(e, 20), "(+ 1 2 3)");
     }
 
     #[test]
     fn fexp_da_multi_op_multiplication_works() {
-        let a = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(
+        let a = DurativeActionFluentExpression::fluent_expression(FluentExpression::number(
             Number::from(2),
         ));
-        let b = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(
+        let b = DurativeActionFluentExpression::fluent_expression(FluentExpression::number(
             Number::from(3),
         ));
-        let c = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(
+        let c = DurativeActionFluentExpression::fluent_expression(FluentExpression::number(
             Number::from(4),
         ));
-        let e = DurativeActionFluentExpression::new_multi_op(MultiOp::Multiplication, a, [b, c]);
+        let e = DurativeActionFluentExpression::multi_op(MultiOp::Multiplication, a, [b, c]);
         assert_eq!(prettify!(e, 20), "(* 2 3 4)");
     }
 
@@ -441,7 +439,7 @@ mod tests {
     fn fexp_da_assign_works() {
         use crate::FunctionHead;
         let head = FunctionHead::Simple(FunctionSymbol::from("x"));
-        let expr = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(
+        let expr = DurativeActionFluentExpression::fluent_expression(FluentExpression::number(
             Number::from(10),
         ));
         let e = DurativeActionFluentExpression::Assign(AssignOp::Increase, head, Box::new(expr));
@@ -450,74 +448,74 @@ mod tests {
 
     #[test]
     fn fcomp_less_than_works() {
-        let a = FluentExpression::new_number(Number::from(3));
-        let b = FluentExpression::new_number(Number::from(4));
+        let a = FluentExpression::number(Number::from(3));
+        let b = FluentExpression::number(Number::from(4));
         let fc = FluentComparison::new(BinaryComparison::LessThan, a, b);
         assert_eq!(prettify!(fc, 10), "(< 3 4)");
     }
 
     #[test]
     fn fcomp_equal_works() {
-        let a = FluentExpression::new_number(Number::from(3));
-        let b = FluentExpression::new_number(Number::from(4));
+        let a = FluentExpression::number(Number::from(3));
+        let b = FluentExpression::number(Number::from(4));
         let fc = FluentComparison::new(BinaryComparison::Equal, a, b);
         assert_eq!(prettify!(fc, 10), "(= 3 4)");
     }
 
     #[test]
     fn fcomp_greater_or_equal_works() {
-        let a = FluentExpression::new_number(Number::from(3));
-        let b = FluentExpression::new_number(Number::from(4));
+        let a = FluentExpression::number(Number::from(3));
+        let b = FluentExpression::number(Number::from(4));
         let fc = FluentComparison::new(BinaryComparison::GreaterOrEqual, a, b);
         assert_eq!(prettify!(fc, 10), "(>= 3 4)");
     }
 
     #[test]
     fn fcomp_less_than_or_equal_works() {
-        let a = FluentExpression::new_number(Number::from(3));
-        let b = FluentExpression::new_number(Number::from(4));
+        let a = FluentExpression::number(Number::from(3));
+        let b = FluentExpression::number(Number::from(4));
         let fc = FluentComparison::new(BinaryComparison::LessThanOrEqual, a, b);
         assert_eq!(prettify!(fc, 10), "(<= 3 4)");
     }
 
     #[test]
     fn metric_fexp_negative_works() {
-        let inner = MetricFluentExpression::new_number(Number::from(5));
-        let m = MetricFluentExpression::new_negative(inner);
+        let inner = MetricFluentExpression::number(Number::from(5));
+        let m = MetricFluentExpression::negative(inner);
         assert_eq!(prettify!(m, 10), "(- 5)");
     }
 
     #[test]
     fn metric_fexp_binary_op_subtraction_works() {
-        let a = MetricFluentExpression::new_number(Number::from(5));
-        let b = MetricFluentExpression::new_number(Number::from(3));
-        let m = MetricFluentExpression::new_binary_op(BinaryOp::Subtraction, a, b);
+        let a = MetricFluentExpression::number(Number::from(5));
+        let b = MetricFluentExpression::number(Number::from(3));
+        let m = MetricFluentExpression::binary_op(BinaryOp::Subtraction, a, b);
         assert_eq!(prettify!(m, 10), "(- 5 3)");
     }
 
     #[test]
     fn metric_fexp_binary_op_multiplication_works() {
-        let a = MetricFluentExpression::new_number(Number::from(3));
-        let b = MetricFluentExpression::new_number(Number::from(4));
-        let m = MetricFluentExpression::new_binary_op(BinaryOp::Multiplication, a, b);
+        let a = MetricFluentExpression::number(Number::from(3));
+        let b = MetricFluentExpression::number(Number::from(4));
+        let m = MetricFluentExpression::binary_op(BinaryOp::Multiplication, a, b);
         assert_eq!(prettify!(m, 10), "(* 3 4)");
     }
 
     #[test]
     fn metric_fexp_multi_op_addition_works() {
-        let a = MetricFluentExpression::new_number(Number::from(1));
-        let b = MetricFluentExpression::new_number(Number::from(2));
-        let c = MetricFluentExpression::new_number(Number::from(3));
-        let m = MetricFluentExpression::new_multi_op(MultiOp::Addition, a, [b, c]);
+        let a = MetricFluentExpression::number(Number::from(1));
+        let b = MetricFluentExpression::number(Number::from(2));
+        let c = MetricFluentExpression::number(Number::from(3));
+        let m = MetricFluentExpression::multi_op(MultiOp::Addition, a, [b, c]);
         assert_eq!(prettify!(m, 20), "(+ 1 2 3)");
     }
 
     #[test]
     fn metric_fexp_multi_op_multiplication_works() {
-        let a = MetricFluentExpression::new_number(Number::from(2));
-        let b = MetricFluentExpression::new_number(Number::from(3));
-        let c = MetricFluentExpression::new_number(Number::from(4));
-        let m = MetricFluentExpression::new_multi_op(MultiOp::Multiplication, a, [b, c]);
+        let a = MetricFluentExpression::number(Number::from(2));
+        let b = MetricFluentExpression::number(Number::from(3));
+        let c = MetricFluentExpression::number(Number::from(4));
+        let m = MetricFluentExpression::multi_op(MultiOp::Multiplication, a, [b, c]);
         assert_eq!(prettify!(m, 20), "(* 2 3 4)");
     }
 }

--- a/src/pretty_print/gd.rs
+++ b/src/pretty_print/gd.rs
@@ -1,7 +1,9 @@
 use crate::pretty_print::{sealed, PrettyRenderer};
 use crate::types::{
-    ConstraintGoalDefinition, ConstraintGoalDefinitionInner, GoalDefinition, PreconditionGoalDefinition, PreconditionGoalDefinitions,
-    PreferenceConstraintGoalDefinition, PreferenceConstraintGoalDefinitions, Preference, PreferenceGD,
+    ConstraintGoalDefinition, ConstraintGoalDefinitionInner, GoalDefinition,
+    PreconditionGoalDefinition, PreconditionGoalDefinitions, Preference,
+    PreferenceConstraintGoalDefinition, PreferenceConstraintGoalDefinitions,
+    PreferenceGoalDefinition,
 };
 use crate::visitor::{Accept, Visitor};
 use pretty::RcDoc;
@@ -9,7 +11,7 @@ use pretty::RcDoc;
 impl sealed::Sealed for GoalDefinition {}
 impl sealed::Sealed for PreconditionGoalDefinition {}
 impl sealed::Sealed for PreconditionGoalDefinitions {}
-impl sealed::Sealed for PreferenceGD {}
+impl sealed::Sealed for PreferenceGoalDefinition {}
 impl sealed::Sealed for Preference {}
 impl sealed::Sealed for PreferenceConstraintGoalDefinition {}
 impl sealed::Sealed for PreferenceConstraintGoalDefinitions {}
@@ -85,11 +87,11 @@ impl Visitor<PreconditionGoalDefinitions, RcDoc<'static>> for PrettyRenderer {
     }
 }
 
-impl Visitor<PreferenceGD, RcDoc<'static>> for PrettyRenderer {
-    fn visit(&self, value: &PreferenceGD) -> RcDoc<'static> {
+impl Visitor<PreferenceGoalDefinition, RcDoc<'static>> for PrettyRenderer {
+    fn visit(&self, value: &PreferenceGoalDefinition) -> RcDoc<'static> {
         match value {
-            PreferenceGD::Goal(gd) => self.visit(gd),
-            PreferenceGD::Preference(pref) => self.visit(pref),
+            PreferenceGoalDefinition::Goal(gd) => self.visit(gd),
+            PreferenceGoalDefinition::Preference(pref) => self.visit(pref),
         }
     }
 }
@@ -153,11 +155,17 @@ impl Visitor<ConstraintGoalDefinition, RcDoc<'static>> for PrettyRenderer {
                     self.visit(&**body),
                 ],
             ),
-            ConstraintGoalDefinition::AtEnd(gd) => self.sexpr("at", [RcDoc::text("end"), self.visit(gd)]),
+            ConstraintGoalDefinition::AtEnd(gd) => {
+                self.sexpr("at", [RcDoc::text("end"), self.visit(gd)])
+            }
             ConstraintGoalDefinition::Always(gd) => self.sexpr("always", [self.visit(gd)]),
             ConstraintGoalDefinition::Sometime(gd) => self.sexpr("sometime", [self.visit(gd)]),
-            ConstraintGoalDefinition::Within(n, gd) => self.sexpr("within", [n.accept(self), self.visit(gd)]),
-            ConstraintGoalDefinition::AtMostOnce(gd) => self.sexpr("at-most-once", [self.visit(gd)]),
+            ConstraintGoalDefinition::Within(n, gd) => {
+                self.sexpr("within", [n.accept(self), self.visit(gd)])
+            }
+            ConstraintGoalDefinition::AtMostOnce(gd) => {
+                self.sexpr("at-most-once", [self.visit(gd)])
+            }
             ConstraintGoalDefinition::SometimeAfter(a, b) => {
                 self.sexpr("sometime-after", [self.visit(a), self.visit(b)])
             }
@@ -172,7 +180,9 @@ impl Visitor<ConstraintGoalDefinition, RcDoc<'static>> for PrettyRenderer {
                 "hold-during",
                 [s.accept(self), e.accept(self), self.visit(gd)],
             ),
-            ConstraintGoalDefinition::HoldAfter(n, gd) => self.sexpr("hold-after", [n.accept(self), self.visit(gd)]),
+            ConstraintGoalDefinition::HoldAfter(n, gd) => {
+                self.sexpr("hold-after", [n.accept(self), self.visit(gd)])
+            }
         }
     }
 }
@@ -192,8 +202,8 @@ mod tests {
     use crate::pretty_print::prettify;
     use crate::visitor::Accept;
     use crate::{
-        AtomicFormula, BinaryComparison, FluentComparison, FluentExpression, Literal, Name, Number, Predicate, Term,
-        Variable,
+        AtomicFormula, BinaryComparison, FluentComparison, FluentExpression, Literal, Name, Number,
+        Predicate, Term, Variable,
     };
 
     fn make_simple_gd() -> GoalDefinition {
@@ -292,7 +302,7 @@ mod tests {
     #[test]
     fn preference_gd_goal_works() {
         let gd = make_simple_gd();
-        let pgd = PreferenceGD::from_gd(gd);
+        let pgd = PreferenceGoalDefinition::from_gd(gd);
         assert_eq!(prettify!(pgd, 40), "(at ?r loc1)");
     }
 
@@ -301,7 +311,7 @@ mod tests {
         use crate::PreferenceName;
         let gd = make_simple_gd();
         let pref = Preference::new(Some(PreferenceName::new_string("p1")), gd);
-        let pgd = PreferenceGD::from_preference(pref);
+        let pgd = PreferenceGoalDefinition::from_preference(pref);
         assert_eq!(prettify!(pgd, 40), "(preference p1 (at ?r loc1))");
     }
 
@@ -346,7 +356,10 @@ mod tests {
     fn con_gd_sometime_after_works() {
         let gd1 = make_simple_gd();
         let gd2 = make_simple_gd();
-        let con = ConstraintGoalDefinition::new_sometime_after(ConstraintGoalDefinitionInner::new_goal(gd1), ConstraintGoalDefinitionInner::new_goal(gd2));
+        let con = ConstraintGoalDefinition::new_sometime_after(
+            ConstraintGoalDefinitionInner::new_goal(gd1),
+            ConstraintGoalDefinitionInner::new_goal(gd2),
+        );
         assert_eq!(
             prettify!(con, 40),
             "(sometime-after (at ?r loc1) (at ?r\n        loc1))"
@@ -357,7 +370,8 @@ mod tests {
     fn con_gd_hold_during_works() {
         let gd = make_simple_gd();
         let con2 = ConstraintGoalDefinitionInner::new_goal(gd);
-        let con = ConstraintGoalDefinition::new_hold_during(Number::from(5), Number::from(15), con2);
+        let con =
+            ConstraintGoalDefinition::new_hold_during(Number::from(5), Number::from(15), con2);
         assert_eq!(prettify!(con, 40), "(hold-during 5 15 (at ?r loc1))");
     }
 
@@ -398,9 +412,9 @@ mod tests {
 
     #[test]
     fn precondition_goal_definition_preference_works() {
-        use crate::PreferenceGD;
+        use crate::PreferenceGoalDefinition;
         let gd = make_simple_gd();
-        let pref_gd = PreferenceGD::from_gd(gd);
+        let pref_gd = PreferenceGoalDefinition::from_gd(gd);
         let pre_gd = PreconditionGoalDefinition::new_preference(pref_gd);
         assert_eq!(prettify!(pre_gd, 40), "(at ?r loc1)");
     }
@@ -426,7 +440,8 @@ mod tests {
     #[test]
     fn precondition_goal_definitions_single_works() {
         let gd = make_simple_gd();
-        let pre_gd = PreconditionGoalDefinition::new_preference(PreferenceGD::from_gd(gd));
+        let pre_gd =
+            PreconditionGoalDefinition::new_preference(PreferenceGoalDefinition::from_gd(gd));
         let pgds = PreconditionGoalDefinitions::new(vec![pre_gd]);
         assert_eq!(prettify!(pgds, 40), "(at ?r loc1)");
     }
@@ -436,8 +451,8 @@ mod tests {
         let gd1 = make_simple_gd();
         let gd2 = make_simple_gd();
         let pgds = PreconditionGoalDefinitions::new(vec![
-            PreconditionGoalDefinition::new_preference(PreferenceGD::from_gd(gd1)),
-            PreconditionGoalDefinition::new_preference(PreferenceGD::from_gd(gd2)),
+            PreconditionGoalDefinition::new_preference(PreferenceGoalDefinition::from_gd(gd1)),
+            PreconditionGoalDefinition::new_preference(PreferenceGoalDefinition::from_gd(gd2)),
         ]);
         assert_eq!(prettify!(pgds, 40), "(and (at ?r loc1) (at ?r loc1))");
     }
@@ -447,9 +462,11 @@ mod tests {
         use crate::{ToTyped, Type, TypedVariables, Variable};
         let vars: TypedVariables = vec![Variable::new_string("x").to_typed(Type::OBJECT)].into();
         let _inner = ConstraintGoalDefinition::new_and(Vec::new());
-        let pgds = PreferenceConstraintGoalDefinitions::new(vec![PreferenceConstraintGoalDefinition::new_goal(ConstraintGoalDefinition::new_always(
-            ConstraintGoalDefinitionInner::new_goal(make_simple_gd()),
-        ))]);
+        let pgds = PreferenceConstraintGoalDefinitions::new(vec![
+            PreferenceConstraintGoalDefinition::new_goal(ConstraintGoalDefinition::new_always(
+                ConstraintGoalDefinitionInner::new_goal(make_simple_gd()),
+            )),
+        ]);
         let pgd = PreferenceConstraintGoalDefinition::new_forall(vars, pgds);
         assert_eq!(prettify!(pgd, 40), "(forall (?x) (always (at ?r loc1)))");
     }
@@ -459,7 +476,10 @@ mod tests {
         use crate::PreferenceName;
         let gd = make_simple_gd();
         let con = ConstraintGoalDefinition::new_at_end(gd);
-        let pcgd = PreferenceConstraintGoalDefinition::new_preference(Some(PreferenceName::new_string("p1")), con);
+        let pcgd = PreferenceConstraintGoalDefinition::new_preference(
+            Some(PreferenceName::new_string("p1")),
+            con,
+        );
         assert_eq!(prettify!(pcgd, 40), "(preference p1 (at end (at ?r loc1)))");
     }
 
@@ -503,7 +523,10 @@ mod tests {
     fn con_gd_sometime_before_works() {
         let gd1 = make_simple_gd();
         let gd2 = make_simple_gd();
-        let con = ConstraintGoalDefinition::new_sometime_before(ConstraintGoalDefinitionInner::new_goal(gd1), ConstraintGoalDefinitionInner::new_goal(gd2));
+        let con = ConstraintGoalDefinition::new_sometime_before(
+            ConstraintGoalDefinitionInner::new_goal(gd1),
+            ConstraintGoalDefinitionInner::new_goal(gd2),
+        );
         assert_eq!(
             prettify!(con, 40),
             "(sometime-before (at ?r loc1) (at ?r\n        loc1))"

--- a/src/pretty_print/gd.rs
+++ b/src/pretty_print/gd.rs
@@ -207,14 +207,14 @@ mod tests {
     };
 
     fn make_simple_gd() -> GoalDefinition {
-        let af: AtomicFormula<Term> = AtomicFormula::new_predicate(
-            Predicate::new_string("at"),
+        let af: AtomicFormula<Term> = AtomicFormula::predicate(
+            Predicate::string("at"),
             vec![
                 Term::new_variable(Variable::from("r")),
                 Term::new_name(Name::new("loc1")),
             ],
         );
-        GoalDefinition::new_atomic_formula(af)
+        GoalDefinition::atomic_formula(af)
     }
 
     #[test]
@@ -225,77 +225,77 @@ mod tests {
 
     #[test]
     fn goal_and_works() {
-        let af: AtomicFormula<Term> = AtomicFormula::new_predicate(
-            Predicate::new_string("at"),
+        let af: AtomicFormula<Term> = AtomicFormula::predicate(
+            Predicate::string("at"),
             vec![
                 Term::new_variable(Variable::from("r")),
                 Term::new_name(Name::new("loc1")),
             ],
         );
-        let gd = GoalDefinition::new_and([
-            GoalDefinition::new_atomic_formula(af.clone()),
-            GoalDefinition::new_atomic_formula(af),
+        let gd = GoalDefinition::and([
+            GoalDefinition::atomic_formula(af.clone()),
+            GoalDefinition::atomic_formula(af),
         ]);
         assert_eq!(prettify!(gd, 40), "(and (at ?r loc1) (at ?r loc1))");
     }
 
     #[test]
     fn goal_and_empty_works() {
-        let gd = GoalDefinition::new_and(Vec::<GoalDefinition>::new());
+        let gd = GoalDefinition::and(Vec::<GoalDefinition>::new());
         assert_eq!(prettify!(gd, 40), "(and)");
     }
 
     #[test]
     fn goal_or_works() {
-        let af: AtomicFormula<Term> = AtomicFormula::new_predicate(
-            Predicate::new_string("at"),
+        let af: AtomicFormula<Term> = AtomicFormula::predicate(
+            Predicate::string("at"),
             vec![
                 Term::new_variable(Variable::from("r")),
                 Term::new_name(Name::new("loc1")),
             ],
         );
-        let gd = GoalDefinition::new_or([
-            GoalDefinition::new_atomic_formula(af.clone()),
-            GoalDefinition::new_atomic_formula(af),
+        let gd = GoalDefinition::or([
+            GoalDefinition::atomic_formula(af.clone()),
+            GoalDefinition::atomic_formula(af),
         ]);
         assert_eq!(prettify!(gd, 40), "(or (at ?r loc1) (at ?r loc1))");
     }
 
     #[test]
     fn goal_not_works() {
-        let af: AtomicFormula<Term> = AtomicFormula::new_predicate(
-            Predicate::new_string("at"),
+        let af: AtomicFormula<Term> = AtomicFormula::predicate(
+            Predicate::string("at"),
             vec![
                 Term::new_variable(Variable::from("r")),
                 Term::new_name(Name::new("loc1")),
             ],
         );
-        let gd = GoalDefinition::new_not(GoalDefinition::new_atomic_formula(af));
+        let gd = GoalDefinition::not(GoalDefinition::atomic_formula(af));
         assert_eq!(prettify!(gd, 40), "(not (at ?r loc1))");
     }
 
     #[test]
     fn goal_imply_works() {
-        let af: AtomicFormula<Term> = AtomicFormula::new_predicate(
-            Predicate::new_string("at"),
+        let af: AtomicFormula<Term> = AtomicFormula::predicate(
+            Predicate::string("at"),
             vec![
                 Term::new_variable(Variable::from("r")),
                 Term::new_name(Name::new("loc1")),
             ],
         );
-        let gd = GoalDefinition::new_imply(
-            GoalDefinition::new_atomic_formula(af.clone()),
-            GoalDefinition::new_atomic_formula(af),
+        let gd = GoalDefinition::imply(
+            GoalDefinition::atomic_formula(af.clone()),
+            GoalDefinition::atomic_formula(af),
         );
         assert_eq!(prettify!(gd, 40), "(imply (at ?r loc1) (at ?r loc1))");
     }
 
     #[test]
     fn goal_fcomp_works() {
-        let a = FluentExpression::new_number(crate::Number::from(3));
-        let b = FluentExpression::new_number(crate::Number::from(4));
+        let a = FluentExpression::number(crate::Number::from(3));
+        let b = FluentExpression::number(crate::Number::from(4));
         let fc = FluentComparison::new(BinaryComparison::GreaterThan, a, b);
-        let gd = GoalDefinition::new_f_comp(fc);
+        let gd = GoalDefinition::fluent_comparison(fc);
         assert_eq!(prettify!(gd, 10), "(> 3 4)");
     }
 
@@ -310,7 +310,7 @@ mod tests {
     fn preference_gd_preference_works() {
         use crate::PreferenceName;
         let gd = make_simple_gd();
-        let pref = Preference::new(Some(PreferenceName::new_string("p1")), gd);
+        let pref = Preference::new(Some(PreferenceName::string("p1")), gd);
         let pgd = PreferenceGoalDefinition::from_preference(pref);
         assert_eq!(prettify!(pgd, 40), "(preference p1 (at ?r loc1))");
     }
@@ -325,30 +325,30 @@ mod tests {
     #[test]
     fn con_gd_and_works() {
         let gd = make_simple_gd();
-        let con = ConstraintGoalDefinition::new_and([ConstraintGoalDefinition::new_at_end(gd)]);
+        let con = ConstraintGoalDefinition::and([ConstraintGoalDefinition::at_end(gd)]);
         assert_eq!(prettify!(con, 40), "(and (at end (at ?r loc1)))");
     }
 
     #[test]
     fn con_gd_at_end_works() {
         let gd = make_simple_gd();
-        let con = ConstraintGoalDefinition::new_at_end(gd);
+        let con = ConstraintGoalDefinition::at_end(gd);
         assert_eq!(prettify!(con, 40), "(at end (at ?r loc1))");
     }
 
     #[test]
     fn con_gd_always_works() {
         let gd = make_simple_gd();
-        let con2 = ConstraintGoalDefinitionInner::new_goal(gd);
-        let con = ConstraintGoalDefinition::new_always(con2);
+        let con2 = ConstraintGoalDefinitionInner::goal(gd);
+        let con = ConstraintGoalDefinition::always(con2);
         assert_eq!(prettify!(con, 40), "(always (at ?r loc1))");
     }
 
     #[test]
     fn con_gd_within_works() {
         let gd = make_simple_gd();
-        let con2 = ConstraintGoalDefinitionInner::new_goal(gd);
-        let con = ConstraintGoalDefinition::new_within(Number::from(10), con2);
+        let con2 = ConstraintGoalDefinitionInner::goal(gd);
+        let con = ConstraintGoalDefinition::within(Number::from(10), con2);
         assert_eq!(prettify!(con, 40), "(within 10 (at ?r loc1))");
     }
 
@@ -356,9 +356,9 @@ mod tests {
     fn con_gd_sometime_after_works() {
         let gd1 = make_simple_gd();
         let gd2 = make_simple_gd();
-        let con = ConstraintGoalDefinition::new_sometime_after(
-            ConstraintGoalDefinitionInner::new_goal(gd1),
-            ConstraintGoalDefinitionInner::new_goal(gd2),
+        let con = ConstraintGoalDefinition::sometime_after(
+            ConstraintGoalDefinitionInner::goal(gd1),
+            ConstraintGoalDefinitionInner::goal(gd2),
         );
         assert_eq!(
             prettify!(con, 40),
@@ -369,44 +369,43 @@ mod tests {
     #[test]
     fn con_gd_hold_during_works() {
         let gd = make_simple_gd();
-        let con2 = ConstraintGoalDefinitionInner::new_goal(gd);
-        let con =
-            ConstraintGoalDefinition::new_hold_during(Number::from(5), Number::from(15), con2);
+        let con2 = ConstraintGoalDefinitionInner::goal(gd);
+        let con = ConstraintGoalDefinition::hold_during(Number::from(5), Number::from(15), con2);
         assert_eq!(prettify!(con, 40), "(hold-during 5 15 (at ?r loc1))");
     }
 
     #[test]
     fn goal_literal_works() {
-        let af: AtomicFormula<Term> = AtomicFormula::new_predicate(
-            Predicate::new_string("at"),
+        let af: AtomicFormula<Term> = AtomicFormula::predicate(
+            Predicate::string("at"),
             vec![Term::new_name(Name::new("x"))],
         );
         let lit = Literal::new(af);
-        let gd = GoalDefinition::new_literal(lit);
+        let gd = GoalDefinition::literal(lit);
         assert_eq!(prettify!(gd, 20), "(at x)");
     }
 
     #[test]
     fn goal_or_empty_works() {
-        let gd = GoalDefinition::new_or(Vec::<GoalDefinition>::new());
+        let gd = GoalDefinition::or(Vec::<GoalDefinition>::new());
         assert_eq!(prettify!(gd, 20), "(or)");
     }
 
     #[test]
     fn goal_exists_works() {
         use crate::{ToTyped, Type, TypedVariables, Variable};
-        let vars: TypedVariables = vec![Variable::new_string("x").to_typed(Type::OBJECT)].into();
+        let vars: TypedVariables = vec![Variable::string("x").to_typed(Type::OBJECT)].into();
         let inner = make_simple_gd();
-        let gd = GoalDefinition::new_exists(vars, inner);
+        let gd = GoalDefinition::exists(vars, inner);
         assert_eq!(prettify!(gd, 40), "(exists (?x) (at ?r loc1))");
     }
 
     #[test]
     fn goal_forall_works() {
         use crate::{ToTyped, Type, TypedVariables, Variable};
-        let vars: TypedVariables = vec![Variable::new_string("x").to_typed(Type::OBJECT)].into();
+        let vars: TypedVariables = vec![Variable::string("x").to_typed(Type::OBJECT)].into();
         let inner = make_simple_gd();
-        let gd = GoalDefinition::new_forall(vars, inner);
+        let gd = GoalDefinition::forall(vars, inner);
         assert_eq!(prettify!(gd, 40), "(forall (?x) (at ?r loc1))");
     }
 
@@ -415,16 +414,16 @@ mod tests {
         use crate::PreferenceGoalDefinition;
         let gd = make_simple_gd();
         let pref_gd = PreferenceGoalDefinition::from_gd(gd);
-        let pre_gd = PreconditionGoalDefinition::new_preference(pref_gd);
+        let pre_gd = PreconditionGoalDefinition::preference(pref_gd);
         assert_eq!(prettify!(pre_gd, 40), "(at ?r loc1)");
     }
 
     #[test]
     fn precondition_goal_definition_forall_works() {
         use crate::{ToTyped, Type, TypedVariables, Variable};
-        let vars: TypedVariables = vec![Variable::new_string("x").to_typed(Type::OBJECT)].into();
+        let vars: TypedVariables = vec![Variable::string("x").to_typed(Type::OBJECT)].into();
         let inner = PreconditionGoalDefinitions::default();
-        let pre_gd = PreconditionGoalDefinition::new_forall(vars, inner);
+        let pre_gd = PreconditionGoalDefinition::forall(vars, inner);
         // The visitor renders as "forall (?x)" with the body being empty PreconditionGoalDefinitions rendering as (and)
         let out = prettify!(pre_gd, 40);
         assert!(out.contains("forall"));
@@ -440,8 +439,7 @@ mod tests {
     #[test]
     fn precondition_goal_definitions_single_works() {
         let gd = make_simple_gd();
-        let pre_gd =
-            PreconditionGoalDefinition::new_preference(PreferenceGoalDefinition::from_gd(gd));
+        let pre_gd = PreconditionGoalDefinition::preference(PreferenceGoalDefinition::from_gd(gd));
         let pgds = PreconditionGoalDefinitions::new(vec![pre_gd]);
         assert_eq!(prettify!(pgds, 40), "(at ?r loc1)");
     }
@@ -451,8 +449,8 @@ mod tests {
         let gd1 = make_simple_gd();
         let gd2 = make_simple_gd();
         let pgds = PreconditionGoalDefinitions::new(vec![
-            PreconditionGoalDefinition::new_preference(PreferenceGoalDefinition::from_gd(gd1)),
-            PreconditionGoalDefinition::new_preference(PreferenceGoalDefinition::from_gd(gd2)),
+            PreconditionGoalDefinition::preference(PreferenceGoalDefinition::from_gd(gd1)),
+            PreconditionGoalDefinition::preference(PreferenceGoalDefinition::from_gd(gd2)),
         ]);
         assert_eq!(prettify!(pgds, 40), "(and (at ?r loc1) (at ?r loc1))");
     }
@@ -460,14 +458,14 @@ mod tests {
     #[test]
     fn pref_con_gd_forall_works() {
         use crate::{ToTyped, Type, TypedVariables, Variable};
-        let vars: TypedVariables = vec![Variable::new_string("x").to_typed(Type::OBJECT)].into();
-        let _inner = ConstraintGoalDefinition::new_and(Vec::new());
+        let vars: TypedVariables = vec![Variable::string("x").to_typed(Type::OBJECT)].into();
+        let _inner = ConstraintGoalDefinition::and(Vec::new());
         let pgds = PreferenceConstraintGoalDefinitions::new(vec![
-            PreferenceConstraintGoalDefinition::new_goal(ConstraintGoalDefinition::new_always(
-                ConstraintGoalDefinitionInner::new_goal(make_simple_gd()),
+            PreferenceConstraintGoalDefinition::goal(ConstraintGoalDefinition::always(
+                ConstraintGoalDefinitionInner::goal(make_simple_gd()),
             )),
         ]);
-        let pgd = PreferenceConstraintGoalDefinition::new_forall(vars, pgds);
+        let pgd = PreferenceConstraintGoalDefinition::forall(vars, pgds);
         assert_eq!(prettify!(pgd, 40), "(forall (?x) (always (at ?r loc1)))");
     }
 
@@ -475,19 +473,17 @@ mod tests {
     fn pref_con_gd_preference_with_name_works() {
         use crate::PreferenceName;
         let gd = make_simple_gd();
-        let con = ConstraintGoalDefinition::new_at_end(gd);
-        let pcgd = PreferenceConstraintGoalDefinition::new_preference(
-            Some(PreferenceName::new_string("p1")),
-            con,
-        );
+        let con = ConstraintGoalDefinition::at_end(gd);
+        let pcgd =
+            PreferenceConstraintGoalDefinition::preference(Some(PreferenceName::string("p1")), con);
         assert_eq!(prettify!(pcgd, 40), "(preference p1 (at end (at ?r loc1)))");
     }
 
     #[test]
     fn pref_con_gd_preference_no_name_works() {
         let gd = make_simple_gd();
-        let con = ConstraintGoalDefinition::new_at_end(gd);
-        let pcgd = PreferenceConstraintGoalDefinition::new_preference(None, con);
+        let con = ConstraintGoalDefinition::at_end(gd);
+        let pcgd = PreferenceConstraintGoalDefinition::preference(None, con);
         assert_eq!(prettify!(pcgd, 40), "(preference (at end (at ?r loc1)))");
     }
 
@@ -496,8 +492,8 @@ mod tests {
         let gd1 = make_simple_gd();
         let gd2 = make_simple_gd();
         let pgds = PreferenceConstraintGoalDefinitions::new(vec![
-            PreferenceConstraintGoalDefinition::new_goal(ConstraintGoalDefinition::new_at_end(gd1)),
-            PreferenceConstraintGoalDefinition::new_goal(ConstraintGoalDefinition::new_at_end(gd2)),
+            PreferenceConstraintGoalDefinition::goal(ConstraintGoalDefinition::at_end(gd1)),
+            PreferenceConstraintGoalDefinition::goal(ConstraintGoalDefinition::at_end(gd2)),
         ]);
         let out = prettify!(pgds, 40);
         assert!(out.contains("(at end"));
@@ -506,16 +502,16 @@ mod tests {
     #[test]
     fn con_gd_sometime_works() {
         let gd = make_simple_gd();
-        let con2 = ConstraintGoalDefinitionInner::new_goal(gd);
-        let con = ConstraintGoalDefinition::new_sometime(con2);
+        let con2 = ConstraintGoalDefinitionInner::goal(gd);
+        let con = ConstraintGoalDefinition::sometime(con2);
         assert_eq!(prettify!(con, 40), "(sometime (at ?r loc1))");
     }
 
     #[test]
     fn con_gd_at_most_once_works() {
         let gd = make_simple_gd();
-        let con2 = ConstraintGoalDefinitionInner::new_goal(gd);
-        let con = ConstraintGoalDefinition::new_at_most_once(con2);
+        let con2 = ConstraintGoalDefinitionInner::goal(gd);
+        let con = ConstraintGoalDefinition::at_most_once(con2);
         assert_eq!(prettify!(con, 40), "(at-most-once (at ?r loc1))");
     }
 
@@ -523,9 +519,9 @@ mod tests {
     fn con_gd_sometime_before_works() {
         let gd1 = make_simple_gd();
         let gd2 = make_simple_gd();
-        let con = ConstraintGoalDefinition::new_sometime_before(
-            ConstraintGoalDefinitionInner::new_goal(gd1),
-            ConstraintGoalDefinitionInner::new_goal(gd2),
+        let con = ConstraintGoalDefinition::sometime_before(
+            ConstraintGoalDefinitionInner::goal(gd1),
+            ConstraintGoalDefinitionInner::goal(gd2),
         );
         assert_eq!(
             prettify!(con, 40),
@@ -537,10 +533,10 @@ mod tests {
     fn con_gd_always_within_works() {
         let gd1 = make_simple_gd();
         let gd2 = make_simple_gd();
-        let con = ConstraintGoalDefinition::new_always_within(
+        let con = ConstraintGoalDefinition::always_within(
             Number::from(10),
-            ConstraintGoalDefinitionInner::new_goal(gd1),
-            ConstraintGoalDefinitionInner::new_goal(gd2),
+            ConstraintGoalDefinitionInner::goal(gd1),
+            ConstraintGoalDefinitionInner::goal(gd2),
         );
         assert_eq!(
             prettify!(con, 40),
@@ -551,25 +547,25 @@ mod tests {
     #[test]
     fn con_gd_hold_after_works() {
         let gd = make_simple_gd();
-        let con2 = ConstraintGoalDefinitionInner::new_goal(gd);
-        let con = ConstraintGoalDefinition::new_hold_after(Number::from(15), con2);
+        let con2 = ConstraintGoalDefinitionInner::goal(gd);
+        let con = ConstraintGoalDefinition::hold_after(Number::from(15), con2);
         assert_eq!(prettify!(con, 40), "(hold-after 15 (at ?r loc1))");
     }
 
     #[test]
     fn con_gd_forall_works() {
         use crate::{ToTyped, Type, TypedVariables, Variable};
-        let vars: TypedVariables = vec![Variable::new_string("x").to_typed(Type::OBJECT)].into();
-        let inner = ConstraintGoalDefinition::new_at_end(make_simple_gd());
-        let con = ConstraintGoalDefinition::new_forall(vars, inner);
+        let vars: TypedVariables = vec![Variable::string("x").to_typed(Type::OBJECT)].into();
+        let inner = ConstraintGoalDefinition::at_end(make_simple_gd());
+        let con = ConstraintGoalDefinition::forall(vars, inner);
         assert_eq!(prettify!(con, 40), "(forall (?x) (at end (at ?r loc1)))");
     }
 
     #[test]
     fn con2_gd_nested_works() {
         let gd = make_simple_gd();
-        let con = ConstraintGoalDefinition::new_at_end(gd);
-        let con2 = ConstraintGoalDefinitionInner::new_nested(con);
+        let con = ConstraintGoalDefinition::at_end(gd);
+        let con2 = ConstraintGoalDefinitionInner::nested(con);
         assert_eq!(prettify!(con2, 40), "(at end (at ?r loc1))");
     }
 }

--- a/src/pretty_print/gd.rs
+++ b/src/pretty_print/gd.rs
@@ -1,7 +1,7 @@
 use crate::pretty_print::{sealed, PrettyRenderer};
 use crate::types::{
-    Con2GD, ConGD, GoalDefinition, PreconditionGoalDefinition, PreconditionGoalDefinitions,
-    PrefConGD, PrefConGDs, Preference, PreferenceGD,
+    ConstraintGoalDefinition, ConstraintGoalDefinitionInner, GoalDefinition, PreconditionGoalDefinition, PreconditionGoalDefinitions,
+    PreferenceConstraintGoalDefinition, PreferenceConstraintGoalDefinitions, Preference, PreferenceGD,
 };
 use crate::visitor::{Accept, Visitor};
 use pretty::RcDoc;
@@ -11,10 +11,10 @@ impl sealed::Sealed for PreconditionGoalDefinition {}
 impl sealed::Sealed for PreconditionGoalDefinitions {}
 impl sealed::Sealed for PreferenceGD {}
 impl sealed::Sealed for Preference {}
-impl sealed::Sealed for PrefConGD {}
-impl sealed::Sealed for PrefConGDs {}
-impl sealed::Sealed for ConGD {}
-impl sealed::Sealed for Con2GD {}
+impl sealed::Sealed for PreferenceConstraintGoalDefinition {}
+impl sealed::Sealed for PreferenceConstraintGoalDefinitions {}
+impl sealed::Sealed for ConstraintGoalDefinition {}
+impl sealed::Sealed for ConstraintGoalDefinitionInner {}
 
 impl Visitor<GoalDefinition, RcDoc<'static>> for PrettyRenderer {
     fn visit(&self, value: &GoalDefinition) -> RcDoc<'static> {
@@ -53,7 +53,7 @@ impl Visitor<GoalDefinition, RcDoc<'static>> for PrettyRenderer {
                     self.visit(&**body),
                 ],
             ),
-            GoalDefinition::FComp(fc) => fc.accept(self),
+            GoalDefinition::FluentComparison(fc) => fc.accept(self),
         }
     }
 }
@@ -108,18 +108,18 @@ impl Visitor<Preference, RcDoc<'static>> for PrettyRenderer {
     }
 }
 
-impl Visitor<PrefConGD, RcDoc<'static>> for PrettyRenderer {
-    fn visit(&self, value: &PrefConGD) -> RcDoc<'static> {
+impl Visitor<PreferenceConstraintGoalDefinition, RcDoc<'static>> for PrettyRenderer {
+    fn visit(&self, value: &PreferenceConstraintGoalDefinition) -> RcDoc<'static> {
         match value {
-            PrefConGD::Goal(gd) => self.visit(gd),
-            PrefConGD::Forall(vars, gds) => self.sexpr(
+            PreferenceConstraintGoalDefinition::Goal(gd) => self.visit(gd),
+            PreferenceConstraintGoalDefinition::Forall(vars, gds) => self.sexpr(
                 "forall",
                 [
                     RcDoc::text("(").append(vars.accept(self)).append(")"),
                     RcDoc::intersperse(gds.iter().map(|gd| self.visit(gd)), RcDoc::softline()),
                 ],
             ),
-            PrefConGD::Preference(name, gd) => {
+            PreferenceConstraintGoalDefinition::Preference(name, gd) => {
                 let children: Vec<RcDoc<'static>> = match name {
                     Some(n) => vec![n.accept(self), self.visit(gd)],
                     None => vec![self.visit(gd)],
@@ -130,58 +130,58 @@ impl Visitor<PrefConGD, RcDoc<'static>> for PrettyRenderer {
     }
 }
 
-impl Visitor<PrefConGDs, RcDoc<'static>> for PrettyRenderer {
-    fn visit(&self, value: &PrefConGDs) -> RcDoc<'static> {
+impl Visitor<PreferenceConstraintGoalDefinitions, RcDoc<'static>> for PrettyRenderer {
+    fn visit(&self, value: &PreferenceConstraintGoalDefinitions) -> RcDoc<'static> {
         RcDoc::intersperse(value.iter().map(|gd| self.visit(gd)), RcDoc::softline())
     }
 }
 
-impl Visitor<ConGD, RcDoc<'static>> for PrettyRenderer {
-    fn visit(&self, value: &ConGD) -> RcDoc<'static> {
+impl Visitor<ConstraintGoalDefinition, RcDoc<'static>> for PrettyRenderer {
+    fn visit(&self, value: &ConstraintGoalDefinition) -> RcDoc<'static> {
         match value {
-            ConGD::And(items) => {
+            ConstraintGoalDefinition::And(items) => {
                 if items.is_empty() {
                     RcDoc::text("(and)")
                 } else {
                     self.sexpr("and", items.iter().map(|gd| self.visit(gd)))
                 }
             }
-            ConGD::Forall(vars, body) => self.sexpr(
+            ConstraintGoalDefinition::Forall(vars, body) => self.sexpr(
                 "forall",
                 [
                     RcDoc::text("(").append(vars.accept(self)).append(")"),
                     self.visit(&**body),
                 ],
             ),
-            ConGD::AtEnd(gd) => self.sexpr("at", [RcDoc::text("end"), self.visit(gd)]),
-            ConGD::Always(gd) => self.sexpr("always", [self.visit(gd)]),
-            ConGD::Sometime(gd) => self.sexpr("sometime", [self.visit(gd)]),
-            ConGD::Within(n, gd) => self.sexpr("within", [n.accept(self), self.visit(gd)]),
-            ConGD::AtMostOnce(gd) => self.sexpr("at-most-once", [self.visit(gd)]),
-            ConGD::SometimeAfter(a, b) => {
+            ConstraintGoalDefinition::AtEnd(gd) => self.sexpr("at", [RcDoc::text("end"), self.visit(gd)]),
+            ConstraintGoalDefinition::Always(gd) => self.sexpr("always", [self.visit(gd)]),
+            ConstraintGoalDefinition::Sometime(gd) => self.sexpr("sometime", [self.visit(gd)]),
+            ConstraintGoalDefinition::Within(n, gd) => self.sexpr("within", [n.accept(self), self.visit(gd)]),
+            ConstraintGoalDefinition::AtMostOnce(gd) => self.sexpr("at-most-once", [self.visit(gd)]),
+            ConstraintGoalDefinition::SometimeAfter(a, b) => {
                 self.sexpr("sometime-after", [self.visit(a), self.visit(b)])
             }
-            ConGD::SometimeBefore(a, b) => {
+            ConstraintGoalDefinition::SometimeBefore(a, b) => {
                 self.sexpr("sometime-before", [self.visit(a), self.visit(b)])
             }
-            ConGD::AlwaysWithin(n, a, b) => self.sexpr(
+            ConstraintGoalDefinition::AlwaysWithin(n, a, b) => self.sexpr(
                 "always-within",
                 [n.accept(self), self.visit(a), self.visit(b)],
             ),
-            ConGD::HoldDuring(s, e, gd) => self.sexpr(
+            ConstraintGoalDefinition::HoldDuring(s, e, gd) => self.sexpr(
                 "hold-during",
                 [s.accept(self), e.accept(self), self.visit(gd)],
             ),
-            ConGD::HoldAfter(n, gd) => self.sexpr("hold-after", [n.accept(self), self.visit(gd)]),
+            ConstraintGoalDefinition::HoldAfter(n, gd) => self.sexpr("hold-after", [n.accept(self), self.visit(gd)]),
         }
     }
 }
 
-impl Visitor<Con2GD, RcDoc<'static>> for PrettyRenderer {
-    fn visit(&self, value: &Con2GD) -> RcDoc<'static> {
+impl Visitor<ConstraintGoalDefinitionInner, RcDoc<'static>> for PrettyRenderer {
+    fn visit(&self, value: &ConstraintGoalDefinitionInner) -> RcDoc<'static> {
         match value {
-            Con2GD::Goal(gd) => self.visit(gd),
-            Con2GD::Nested(gd) => self.visit(&**gd),
+            ConstraintGoalDefinitionInner::Goal(gd) => self.visit(gd),
+            ConstraintGoalDefinitionInner::Nested(gd) => self.visit(&**gd),
         }
     }
 }
@@ -192,7 +192,8 @@ mod tests {
     use crate::pretty_print::prettify;
     use crate::visitor::Accept;
     use crate::{
-        AtomicFormula, BinaryComp, FComp, FExp, Literal, Name, Number, Predicate, Term, Variable,
+        AtomicFormula, BinaryComparison, FluentComparison, FluentExpression, Literal, Name, Number, Predicate, Term,
+        Variable,
     };
 
     fn make_simple_gd() -> GoalDefinition {
@@ -281,9 +282,9 @@ mod tests {
 
     #[test]
     fn goal_fcomp_works() {
-        let a = FExp::new_number(crate::Number::from(3));
-        let b = FExp::new_number(crate::Number::from(4));
-        let fc = FComp::new(BinaryComp::GreaterThan, a, b);
+        let a = FluentExpression::new_number(crate::Number::from(3));
+        let b = FluentExpression::new_number(crate::Number::from(4));
+        let fc = FluentComparison::new(BinaryComparison::GreaterThan, a, b);
         let gd = GoalDefinition::new_f_comp(fc);
         assert_eq!(prettify!(gd, 10), "(> 3 4)");
     }
@@ -314,30 +315,30 @@ mod tests {
     #[test]
     fn con_gd_and_works() {
         let gd = make_simple_gd();
-        let con = ConGD::new_and([ConGD::new_at_end(gd)]);
+        let con = ConstraintGoalDefinition::new_and([ConstraintGoalDefinition::new_at_end(gd)]);
         assert_eq!(prettify!(con, 40), "(and (at end (at ?r loc1)))");
     }
 
     #[test]
     fn con_gd_at_end_works() {
         let gd = make_simple_gd();
-        let con = ConGD::new_at_end(gd);
+        let con = ConstraintGoalDefinition::new_at_end(gd);
         assert_eq!(prettify!(con, 40), "(at end (at ?r loc1))");
     }
 
     #[test]
     fn con_gd_always_works() {
         let gd = make_simple_gd();
-        let con2 = Con2GD::new_goal(gd);
-        let con = ConGD::new_always(con2);
+        let con2 = ConstraintGoalDefinitionInner::new_goal(gd);
+        let con = ConstraintGoalDefinition::new_always(con2);
         assert_eq!(prettify!(con, 40), "(always (at ?r loc1))");
     }
 
     #[test]
     fn con_gd_within_works() {
         let gd = make_simple_gd();
-        let con2 = Con2GD::new_goal(gd);
-        let con = ConGD::new_within(Number::from(10), con2);
+        let con2 = ConstraintGoalDefinitionInner::new_goal(gd);
+        let con = ConstraintGoalDefinition::new_within(Number::from(10), con2);
         assert_eq!(prettify!(con, 40), "(within 10 (at ?r loc1))");
     }
 
@@ -345,7 +346,7 @@ mod tests {
     fn con_gd_sometime_after_works() {
         let gd1 = make_simple_gd();
         let gd2 = make_simple_gd();
-        let con = ConGD::new_sometime_after(Con2GD::new_goal(gd1), Con2GD::new_goal(gd2));
+        let con = ConstraintGoalDefinition::new_sometime_after(ConstraintGoalDefinitionInner::new_goal(gd1), ConstraintGoalDefinitionInner::new_goal(gd2));
         assert_eq!(
             prettify!(con, 40),
             "(sometime-after (at ?r loc1) (at ?r\n        loc1))"
@@ -355,8 +356,8 @@ mod tests {
     #[test]
     fn con_gd_hold_during_works() {
         let gd = make_simple_gd();
-        let con2 = Con2GD::new_goal(gd);
-        let con = ConGD::new_hold_during(Number::from(5), Number::from(15), con2);
+        let con2 = ConstraintGoalDefinitionInner::new_goal(gd);
+        let con = ConstraintGoalDefinition::new_hold_during(Number::from(5), Number::from(15), con2);
         assert_eq!(prettify!(con, 40), "(hold-during 5 15 (at ?r loc1))");
     }
 
@@ -445,11 +446,11 @@ mod tests {
     fn pref_con_gd_forall_works() {
         use crate::{ToTyped, Type, TypedVariables, Variable};
         let vars: TypedVariables = vec![Variable::new_string("x").to_typed(Type::OBJECT)].into();
-        let _inner = ConGD::new_and(Vec::new());
-        let pgds = PrefConGDs::new(vec![PrefConGD::new_goal(ConGD::new_always(
-            Con2GD::new_goal(make_simple_gd()),
+        let _inner = ConstraintGoalDefinition::new_and(Vec::new());
+        let pgds = PreferenceConstraintGoalDefinitions::new(vec![PreferenceConstraintGoalDefinition::new_goal(ConstraintGoalDefinition::new_always(
+            ConstraintGoalDefinitionInner::new_goal(make_simple_gd()),
         ))]);
-        let pgd = PrefConGD::new_forall(vars, pgds);
+        let pgd = PreferenceConstraintGoalDefinition::new_forall(vars, pgds);
         assert_eq!(prettify!(pgd, 40), "(forall (?x) (always (at ?r loc1)))");
     }
 
@@ -457,16 +458,16 @@ mod tests {
     fn pref_con_gd_preference_with_name_works() {
         use crate::PreferenceName;
         let gd = make_simple_gd();
-        let con = ConGD::new_at_end(gd);
-        let pcgd = PrefConGD::new_preference(Some(PreferenceName::new_string("p1")), con);
+        let con = ConstraintGoalDefinition::new_at_end(gd);
+        let pcgd = PreferenceConstraintGoalDefinition::new_preference(Some(PreferenceName::new_string("p1")), con);
         assert_eq!(prettify!(pcgd, 40), "(preference p1 (at end (at ?r loc1)))");
     }
 
     #[test]
     fn pref_con_gd_preference_no_name_works() {
         let gd = make_simple_gd();
-        let con = ConGD::new_at_end(gd);
-        let pcgd = PrefConGD::new_preference(None, con);
+        let con = ConstraintGoalDefinition::new_at_end(gd);
+        let pcgd = PreferenceConstraintGoalDefinition::new_preference(None, con);
         assert_eq!(prettify!(pcgd, 40), "(preference (at end (at ?r loc1)))");
     }
 
@@ -474,9 +475,9 @@ mod tests {
     fn pref_con_gds_multi_works() {
         let gd1 = make_simple_gd();
         let gd2 = make_simple_gd();
-        let pgds = PrefConGDs::new(vec![
-            PrefConGD::new_goal(ConGD::new_at_end(gd1)),
-            PrefConGD::new_goal(ConGD::new_at_end(gd2)),
+        let pgds = PreferenceConstraintGoalDefinitions::new(vec![
+            PreferenceConstraintGoalDefinition::new_goal(ConstraintGoalDefinition::new_at_end(gd1)),
+            PreferenceConstraintGoalDefinition::new_goal(ConstraintGoalDefinition::new_at_end(gd2)),
         ]);
         let out = prettify!(pgds, 40);
         assert!(out.contains("(at end"));
@@ -485,16 +486,16 @@ mod tests {
     #[test]
     fn con_gd_sometime_works() {
         let gd = make_simple_gd();
-        let con2 = Con2GD::new_goal(gd);
-        let con = ConGD::new_sometime(con2);
+        let con2 = ConstraintGoalDefinitionInner::new_goal(gd);
+        let con = ConstraintGoalDefinition::new_sometime(con2);
         assert_eq!(prettify!(con, 40), "(sometime (at ?r loc1))");
     }
 
     #[test]
     fn con_gd_at_most_once_works() {
         let gd = make_simple_gd();
-        let con2 = Con2GD::new_goal(gd);
-        let con = ConGD::new_at_most_once(con2);
+        let con2 = ConstraintGoalDefinitionInner::new_goal(gd);
+        let con = ConstraintGoalDefinition::new_at_most_once(con2);
         assert_eq!(prettify!(con, 40), "(at-most-once (at ?r loc1))");
     }
 
@@ -502,7 +503,7 @@ mod tests {
     fn con_gd_sometime_before_works() {
         let gd1 = make_simple_gd();
         let gd2 = make_simple_gd();
-        let con = ConGD::new_sometime_before(Con2GD::new_goal(gd1), Con2GD::new_goal(gd2));
+        let con = ConstraintGoalDefinition::new_sometime_before(ConstraintGoalDefinitionInner::new_goal(gd1), ConstraintGoalDefinitionInner::new_goal(gd2));
         assert_eq!(
             prettify!(con, 40),
             "(sometime-before (at ?r loc1) (at ?r\n        loc1))"
@@ -513,10 +514,10 @@ mod tests {
     fn con_gd_always_within_works() {
         let gd1 = make_simple_gd();
         let gd2 = make_simple_gd();
-        let con = ConGD::new_always_within(
+        let con = ConstraintGoalDefinition::new_always_within(
             Number::from(10),
-            Con2GD::new_goal(gd1),
-            Con2GD::new_goal(gd2),
+            ConstraintGoalDefinitionInner::new_goal(gd1),
+            ConstraintGoalDefinitionInner::new_goal(gd2),
         );
         assert_eq!(
             prettify!(con, 40),
@@ -527,8 +528,8 @@ mod tests {
     #[test]
     fn con_gd_hold_after_works() {
         let gd = make_simple_gd();
-        let con2 = Con2GD::new_goal(gd);
-        let con = ConGD::new_hold_after(Number::from(15), con2);
+        let con2 = ConstraintGoalDefinitionInner::new_goal(gd);
+        let con = ConstraintGoalDefinition::new_hold_after(Number::from(15), con2);
         assert_eq!(prettify!(con, 40), "(hold-after 15 (at ?r loc1))");
     }
 
@@ -536,16 +537,16 @@ mod tests {
     fn con_gd_forall_works() {
         use crate::{ToTyped, Type, TypedVariables, Variable};
         let vars: TypedVariables = vec![Variable::new_string("x").to_typed(Type::OBJECT)].into();
-        let inner = ConGD::new_at_end(make_simple_gd());
-        let con = ConGD::new_forall(vars, inner);
+        let inner = ConstraintGoalDefinition::new_at_end(make_simple_gd());
+        let con = ConstraintGoalDefinition::new_forall(vars, inner);
         assert_eq!(prettify!(con, 40), "(forall (?x) (at end (at ?r loc1)))");
     }
 
     #[test]
     fn con2_gd_nested_works() {
         let gd = make_simple_gd();
-        let con = ConGD::new_at_end(gd);
-        let con2 = Con2GD::new_nested(con);
+        let con = ConstraintGoalDefinition::new_at_end(gd);
+        let con2 = ConstraintGoalDefinitionInner::new_nested(con);
         assert_eq!(prettify!(con2, 40), "(at end (at ?r loc1))");
     }
 }

--- a/src/pretty_print/ops.rs
+++ b/src/pretty_print/ops.rs
@@ -1,16 +1,16 @@
 use crate::pretty_print::{sealed, PrettyRenderer};
 use crate::types::{
-    AssignOp, AssignOpT, BinaryComp, BinaryOp, DOp, Interval, MultiOp, Optimization, Requirement,
-    TimeSpecifier,
+    AssignOp, BinaryComparison, BinaryOp, DurationOperator, Interval, MultiOp, Optimization,
+    Requirement, TimeSpecifier, TimedAssignOperator,
 };
 use crate::visitor::Visitor;
 use pretty::RcDoc;
 
 impl sealed::Sealed for AssignOp {}
-impl sealed::Sealed for AssignOpT {}
+impl sealed::Sealed for TimedAssignOperator {}
 impl sealed::Sealed for BinaryOp {}
-impl sealed::Sealed for BinaryComp {}
-impl sealed::Sealed for DOp {}
+impl sealed::Sealed for BinaryComparison {}
+impl sealed::Sealed for DurationOperator {}
 impl sealed::Sealed for MultiOp {}
 impl sealed::Sealed for Optimization {}
 impl sealed::Sealed for Interval {}
@@ -23,8 +23,8 @@ impl Visitor<AssignOp, RcDoc<'static>> for PrettyRenderer {
     }
 }
 
-impl Visitor<AssignOpT, RcDoc<'static>> for PrettyRenderer {
-    fn visit(&self, value: &AssignOpT) -> RcDoc<'static> {
+impl Visitor<TimedAssignOperator, RcDoc<'static>> for PrettyRenderer {
+    fn visit(&self, value: &TimedAssignOperator) -> RcDoc<'static> {
         RcDoc::text(value.to_string())
     }
 }
@@ -35,14 +35,14 @@ impl Visitor<BinaryOp, RcDoc<'static>> for PrettyRenderer {
     }
 }
 
-impl Visitor<BinaryComp, RcDoc<'static>> for PrettyRenderer {
-    fn visit(&self, value: &BinaryComp) -> RcDoc<'static> {
+impl Visitor<BinaryComparison, RcDoc<'static>> for PrettyRenderer {
+    fn visit(&self, value: &BinaryComparison) -> RcDoc<'static> {
         RcDoc::text(value.to_string())
     }
 }
 
-impl Visitor<DOp, RcDoc<'static>> for PrettyRenderer {
-    fn visit(&self, value: &DOp) -> RcDoc<'static> {
+impl Visitor<DurationOperator, RcDoc<'static>> for PrettyRenderer {
+    fn visit(&self, value: &DurationOperator) -> RcDoc<'static> {
         RcDoc::text(value.to_string())
     }
 }
@@ -110,24 +110,24 @@ mod tests {
 
     #[test]
     fn assign_op_t_works() {
-        assert_eq!(prettify!(AssignOpT::Increase, 10), "increase");
-        assert_eq!(prettify!(AssignOpT::Decrease, 10), "decrease");
+        assert_eq!(prettify!(TimedAssignOperator::Increase, 10), "increase");
+        assert_eq!(prettify!(TimedAssignOperator::Decrease, 10), "decrease");
     }
 
     #[test]
     fn binary_comp_all_variants() {
-        assert_eq!(prettify!(BinaryComp::GreaterThan, 10), ">");
-        assert_eq!(prettify!(BinaryComp::LessThan, 10), "<");
-        assert_eq!(prettify!(BinaryComp::Equal, 10), "=");
-        assert_eq!(prettify!(BinaryComp::GreaterOrEqual, 10), ">=");
-        assert_eq!(prettify!(BinaryComp::LessThanOrEqual, 10), "<=");
+        assert_eq!(prettify!(BinaryComparison::GreaterThan, 10), ">");
+        assert_eq!(prettify!(BinaryComparison::LessThan, 10), "<");
+        assert_eq!(prettify!(BinaryComparison::Equal, 10), "=");
+        assert_eq!(prettify!(BinaryComparison::GreaterOrEqual, 10), ">=");
+        assert_eq!(prettify!(BinaryComparison::LessThanOrEqual, 10), "<=");
     }
 
     #[test]
     fn d_op_all_variants() {
-        assert_eq!(prettify!(DOp::Equal, 10), "=");
-        assert_eq!(prettify!(DOp::GreaterOrEqual, 10), ">=");
-        assert_eq!(prettify!(DOp::LessThanOrEqual, 10), "<=");
+        assert_eq!(prettify!(DurationOperator::Equal, 10), "=");
+        assert_eq!(prettify!(DurationOperator::GreaterOrEqual, 10), ">=");
+        assert_eq!(prettify!(DurationOperator::LessThanOrEqual, 10), "<=");
     }
 
     #[test]

--- a/src/pretty_print/problem.rs
+++ b/src/pretty_print/problem.rs
@@ -79,7 +79,7 @@ impl Visitor<Problem, RcDoc<'static>> for PrettyRenderer {
 mod tests {
     use crate::parsers::Parser;
     use crate::pretty_print::Pretty;
-    use crate::types::{PrefConGDs, ProblemConstraintsDef};
+    use crate::types::{PreferenceConstraintGoalDefinitions, ProblemConstraintsDef};
 
     #[test]
     fn problem_basic() {
@@ -165,7 +165,7 @@ mod tests {
 
     #[test]
     fn problem_constraints_def_empty_nil() {
-        let dc = ProblemConstraintsDef::new(PrefConGDs::new(Vec::new()));
+        let dc = ProblemConstraintsDef::new(PreferenceConstraintGoalDefinitions::new(Vec::new()));
         let out = dc.pretty(80).to_string();
         assert_eq!(out, "");
     }

--- a/src/pretty_print/timed.rs
+++ b/src/pretty_print/timed.rs
@@ -183,8 +183,10 @@ mod tests {
 
     #[test]
     fn simple_duration_constraint_op() {
-        let sdc =
-            SimpleDurationConstraint::new_op(DurationOperator::Equal, DurationValue::new_number(10));
+        let sdc = SimpleDurationConstraint::new_op(
+            DurationOperator::Equal,
+            DurationValue::new_number(10),
+        );
         assert_eq!(prettify!(sdc, 30), "(= ?duration 10)");
     }
 
@@ -197,24 +199,30 @@ mod tests {
 
     #[test]
     fn simple_duration_constraint_at() {
-        let inner =
-            SimpleDurationConstraint::new_op(DurationOperator::Equal, DurationValue::new_number(10));
+        let inner = SimpleDurationConstraint::new_op(
+            DurationOperator::Equal,
+            DurationValue::new_number(10),
+        );
         let sdc = SimpleDurationConstraint::new_at(crate::TimeSpecifier::Start, inner);
         assert_eq!(prettify!(sdc, 30), "(at start (= ?duration 10))");
     }
 
     #[test]
     fn duration_constraint_single() {
-        let sdc =
-            SimpleDurationConstraint::new_op(DurationOperator::Equal, DurationValue::new_number(10));
+        let sdc = SimpleDurationConstraint::new_op(
+            DurationOperator::Equal,
+            DurationValue::new_number(10),
+        );
         let dc = DurationConstraint::new(sdc);
         assert_eq!(prettify!(dc, 30), "(= ?duration 10)");
     }
 
     #[test]
     fn duration_constraint_all() {
-        let sdc1 =
-            SimpleDurationConstraint::new_op(DurationOperator::Equal, DurationValue::new_number(10));
+        let sdc1 = SimpleDurationConstraint::new_op(
+            DurationOperator::Equal,
+            DurationValue::new_number(10),
+        );
         let sdc2 = SimpleDurationConstraint::new_op(
             DurationOperator::GreaterOrEqual,
             DurationValue::new_number(5),
@@ -254,7 +262,10 @@ mod tests {
         use crate::PreferenceName;
         let gd = crate::GoalDefinition::new_and(Vec::<crate::GoalDefinition>::new());
         let tgd = TimedGoalDefinition::new_at(crate::TimeSpecifier::Start, gd);
-        let ptgd = PreferenceTimedGoalDefinition::new_preference(Some(PreferenceName::new_string("p1")), tgd);
+        let ptgd = PreferenceTimedGoalDefinition::new_preference(
+            Some(PreferenceName::new_string("p1")),
+            tgd,
+        );
         assert_eq!(prettify!(ptgd, 40), "(preference p1 (at start (and)))");
     }
 
@@ -276,9 +287,14 @@ mod tests {
 
     #[test]
     fn timed_effect_numeric_fluent() {
-        use crate::{AssignOp, FluentExpression, DurativeActionFluentExpression, FunctionHead, FunctionSymbol, Number, DurativeActionFunctionAssignment};
+        use crate::{
+            AssignOp, DurativeActionFluentExpression, DurativeActionFunctionAssignment,
+            FluentExpression, FunctionHead, FunctionSymbol, Number,
+        };
         let head = FunctionHead::Simple(FunctionSymbol::from("x"));
-        let expr = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(Number::from(5)));
+        let expr = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(
+            Number::from(5),
+        ));
         let fassign = DurativeActionFunctionAssignment::new(AssignOp::Increase, head, expr);
         let te = TimedEffect::new_fluent(crate::TimeSpecifier::End, fassign);
         assert_eq!(prettify!(te, 30), "(at end (increase x 5))");
@@ -286,10 +302,17 @@ mod tests {
 
     #[test]
     fn timed_effect_continuous() {
-        use crate::{TimedAssignOperator, FluentExpression, FunctionHead, FunctionSymbol, Number, TimedFluentExpression};
+        use crate::{
+            FluentExpression, FunctionHead, FunctionSymbol, Number, TimedAssignOperator,
+            TimedFluentExpression,
+        };
         let head = FunctionHead::Simple(FunctionSymbol::from("x"));
         let exp = FluentExpression::new_number(Number::from(1));
-        let te = TimedEffect::new_continuous(TimedAssignOperator::Increase, head, TimedFluentExpression::Scaled(exp));
+        let te = TimedEffect::new_continuous(
+            TimedAssignOperator::Increase,
+            head,
+            TimedFluentExpression::Scaled(exp),
+        );
         assert_eq!(prettify!(te, 30), "(increase x 1)");
     }
 
@@ -365,10 +388,9 @@ mod tests {
         let ce = EffectCondition::new_and(Vec::new());
         let te = TimedEffect::new_conditional(crate::TimeSpecifier::Start, ce);
         let dae = DurativeActionEffect::new_when(
-            DurativeActionGoalDefinition::new_timed(PreferenceTimedGoalDefinition::new_required(TimedGoalDefinition::new_at(
-                crate::TimeSpecifier::Start,
-                gd,
-            ))),
+            DurativeActionGoalDefinition::new_timed(PreferenceTimedGoalDefinition::new_required(
+                TimedGoalDefinition::new_at(crate::TimeSpecifier::Start, gd),
+            )),
             te,
         );
         assert_eq!(prettify!(dae, 40), "(at (at start (and)) (at start (and)))");

--- a/src/pretty_print/timed.rs
+++ b/src/pretty_print/timed.rs
@@ -1,7 +1,7 @@
 use crate::pretty_print::{sealed, PrettyRenderer};
 use crate::types::{
     DurationConstraint, DurationValue, DurativeActionEffect, DurativeActionGoalDefinition,
-    PrefTimedGD, SimpleDurationConstraint, TimedEffect, TimedGD,
+    PreferenceTimedGoalDefinition, SimpleDurationConstraint, TimedEffect, TimedGoalDefinition,
 };
 use crate::visitor::{Accept, Visitor};
 use pretty::RcDoc;
@@ -9,8 +9,8 @@ use pretty::RcDoc;
 impl sealed::Sealed for DurationValue {}
 impl sealed::Sealed for SimpleDurationConstraint {}
 impl sealed::Sealed for DurationConstraint {}
-impl sealed::Sealed for TimedGD {}
-impl sealed::Sealed for PrefTimedGD {}
+impl sealed::Sealed for TimedGoalDefinition {}
+impl sealed::Sealed for PreferenceTimedGoalDefinition {}
 impl sealed::Sealed for TimedEffect {}
 impl sealed::Sealed for DurativeActionEffect {}
 impl sealed::Sealed for DurativeActionGoalDefinition {}
@@ -19,7 +19,7 @@ impl Visitor<DurationValue, RcDoc<'static>> for PrettyRenderer {
     fn visit(&self, value: &DurationValue) -> RcDoc<'static> {
         match value {
             DurationValue::Number(n) => n.accept(self),
-            DurationValue::FExp(e) => e.accept(self),
+            DurationValue::FluentExpression(e) => e.accept(self),
         }
     }
 }
@@ -61,15 +61,15 @@ impl Visitor<DurationConstraint, RcDoc<'static>> for PrettyRenderer {
     }
 }
 
-impl Visitor<TimedGD, RcDoc<'static>> for PrettyRenderer {
-    fn visit(&self, value: &TimedGD) -> RcDoc<'static> {
+impl Visitor<TimedGoalDefinition, RcDoc<'static>> for PrettyRenderer {
+    fn visit(&self, value: &TimedGoalDefinition) -> RcDoc<'static> {
         match value {
-            TimedGD::At(ts, gd) => RcDoc::text("(at ")
+            TimedGoalDefinition::At(ts, gd) => RcDoc::text("(at ")
                 .append(ts.accept(self))
                 .append(" ")
                 .append(gd.accept(self))
                 .append(")"),
-            TimedGD::Over(interval, gd) => RcDoc::text("(over ")
+            TimedGoalDefinition::Over(interval, gd) => RcDoc::text("(over ")
                 .append(interval.accept(self))
                 .append(" ")
                 .append(gd.accept(self))
@@ -78,11 +78,11 @@ impl Visitor<TimedGD, RcDoc<'static>> for PrettyRenderer {
     }
 }
 
-impl Visitor<PrefTimedGD, RcDoc<'static>> for PrettyRenderer {
-    fn visit(&self, value: &PrefTimedGD) -> RcDoc<'static> {
+impl Visitor<PreferenceTimedGoalDefinition, RcDoc<'static>> for PrettyRenderer {
+    fn visit(&self, value: &PreferenceTimedGoalDefinition) -> RcDoc<'static> {
         match value {
-            PrefTimedGD::Required(tgd) => tgd.accept(self),
-            PrefTimedGD::Preference(name, tgd) => {
+            PreferenceTimedGoalDefinition::Required(tgd) => tgd.accept(self),
+            PreferenceTimedGoalDefinition::Preference(name, tgd) => {
                 let children: Vec<RcDoc<'static>> = match name {
                     Some(n) => vec![n.accept(self), self.visit(tgd)],
                     None => vec![self.visit(tgd)],
@@ -173,6 +173,7 @@ mod tests {
     use super::*;
     use crate::pretty_print::prettify;
     use crate::visitor::Accept;
+    use crate::{DurationOperator, PreferenceTimedGoalDefinition};
 
     #[test]
     fn duration_value_number() {
@@ -183,13 +184,13 @@ mod tests {
     #[test]
     fn simple_duration_constraint_op() {
         let sdc =
-            SimpleDurationConstraint::new_op(crate::DOp::Equal, DurationValue::new_number(10));
+            SimpleDurationConstraint::new_op(DurationOperator::Equal, DurationValue::new_number(10));
         assert_eq!(prettify!(sdc, 30), "(= ?duration 10)");
     }
 
     #[test]
     fn duration_value_fexp() {
-        let exp = crate::FExp::new_number(crate::Number::from(5));
+        let exp = crate::FluentExpression::new_number(crate::Number::from(5));
         let dv = DurationValue::new_f_exp(exp);
         assert_eq!(prettify!(dv, 20), "5");
     }
@@ -197,7 +198,7 @@ mod tests {
     #[test]
     fn simple_duration_constraint_at() {
         let inner =
-            SimpleDurationConstraint::new_op(crate::DOp::Equal, DurationValue::new_number(10));
+            SimpleDurationConstraint::new_op(DurationOperator::Equal, DurationValue::new_number(10));
         let sdc = SimpleDurationConstraint::new_at(crate::TimeSpecifier::Start, inner);
         assert_eq!(prettify!(sdc, 30), "(at start (= ?duration 10))");
     }
@@ -205,7 +206,7 @@ mod tests {
     #[test]
     fn duration_constraint_single() {
         let sdc =
-            SimpleDurationConstraint::new_op(crate::DOp::Equal, DurationValue::new_number(10));
+            SimpleDurationConstraint::new_op(DurationOperator::Equal, DurationValue::new_number(10));
         let dc = DurationConstraint::new(sdc);
         assert_eq!(prettify!(dc, 30), "(= ?duration 10)");
     }
@@ -213,9 +214,9 @@ mod tests {
     #[test]
     fn duration_constraint_all() {
         let sdc1 =
-            SimpleDurationConstraint::new_op(crate::DOp::Equal, DurationValue::new_number(10));
+            SimpleDurationConstraint::new_op(DurationOperator::Equal, DurationValue::new_number(10));
         let sdc2 = SimpleDurationConstraint::new_op(
-            crate::DOp::GreaterOrEqual,
+            DurationOperator::GreaterOrEqual,
             DurationValue::new_number(5),
         );
         let dc = DurationConstraint::new_all([sdc1, sdc2]);
@@ -228,7 +229,7 @@ mod tests {
     #[test]
     fn timed_gd_at() {
         let gd = crate::GoalDefinition::new_and(Vec::<crate::GoalDefinition>::new());
-        let tgd = TimedGD::new_at(crate::TimeSpecifier::Start, gd);
+        let tgd = TimedGoalDefinition::new_at(crate::TimeSpecifier::Start, gd);
         assert_eq!(prettify!(tgd, 30), "(at start (and))");
     }
 
@@ -236,15 +237,15 @@ mod tests {
     fn timed_gd_over() {
         use crate::Interval;
         let gd = crate::GoalDefinition::new_and(Vec::<crate::GoalDefinition>::new());
-        let tgd = TimedGD::new_over(Interval::All, gd);
+        let tgd = TimedGoalDefinition::new_over(Interval::All, gd);
         assert_eq!(prettify!(tgd, 30), "(over all (and))");
     }
 
     #[test]
     fn pref_timed_gd_required() {
         let gd = crate::GoalDefinition::new_and(Vec::<crate::GoalDefinition>::new());
-        let tgd = TimedGD::new_at(crate::TimeSpecifier::Start, gd);
-        let ptgd = PrefTimedGD::new_required(tgd);
+        let tgd = TimedGoalDefinition::new_at(crate::TimeSpecifier::Start, gd);
+        let ptgd = PreferenceTimedGoalDefinition::new_required(tgd);
         assert_eq!(prettify!(ptgd, 30), "(at start (and))");
     }
 
@@ -252,51 +253,51 @@ mod tests {
     fn pref_timed_gd_preference_with_name() {
         use crate::PreferenceName;
         let gd = crate::GoalDefinition::new_and(Vec::<crate::GoalDefinition>::new());
-        let tgd = TimedGD::new_at(crate::TimeSpecifier::Start, gd);
-        let ptgd = PrefTimedGD::new_preference(Some(PreferenceName::new_string("p1")), tgd);
+        let tgd = TimedGoalDefinition::new_at(crate::TimeSpecifier::Start, gd);
+        let ptgd = PreferenceTimedGoalDefinition::new_preference(Some(PreferenceName::new_string("p1")), tgd);
         assert_eq!(prettify!(ptgd, 40), "(preference p1 (at start (and)))");
     }
 
     #[test]
     fn pref_timed_gd_preference_no_name() {
         let gd = crate::GoalDefinition::new_and(Vec::<crate::GoalDefinition>::new());
-        let tgd = TimedGD::new_at(crate::TimeSpecifier::Start, gd);
-        let ptgd = PrefTimedGD::new_preference(None, tgd);
+        let tgd = TimedGoalDefinition::new_at(crate::TimeSpecifier::Start, gd);
+        let ptgd = PreferenceTimedGoalDefinition::new_preference(None, tgd);
         assert_eq!(prettify!(ptgd, 40), "(preference (at start (and)))");
     }
 
     #[test]
     fn timed_effect_conditional() {
-        use crate::ConditionalEffect;
-        let ce = ConditionalEffect::new_and(Vec::new());
+        use crate::EffectCondition;
+        let ce = EffectCondition::new_and(Vec::new());
         let te = TimedEffect::new_conditional(crate::TimeSpecifier::Start, ce);
         assert_eq!(prettify!(te, 30), "(at start (and))");
     }
 
     #[test]
     fn timed_effect_numeric_fluent() {
-        use crate::{AssignOp, FExp, FExpDa, FHead, FunctionSymbol, Number};
-        let head = FHead::Simple(FunctionSymbol::from("x"));
-        let expr = FExpDa::new_f_exp(FExp::new_number(Number::from(5)));
-        let fassign = crate::FAssignDa::new(AssignOp::Increase, head, expr);
+        use crate::{AssignOp, FluentExpression, DurativeActionFluentExpression, FunctionHead, FunctionSymbol, Number, DurativeActionFunctionAssignment};
+        let head = FunctionHead::Simple(FunctionSymbol::from("x"));
+        let expr = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(Number::from(5)));
+        let fassign = DurativeActionFunctionAssignment::new(AssignOp::Increase, head, expr);
         let te = TimedEffect::new_fluent(crate::TimeSpecifier::End, fassign);
         assert_eq!(prettify!(te, 30), "(at end (increase x 5))");
     }
 
     #[test]
     fn timed_effect_continuous() {
-        use crate::{AssignOpT, FExp, FHead, FunctionSymbol, Number};
-        let head = FHead::Simple(FunctionSymbol::from("x"));
-        let exp = FExp::new_number(Number::from(1));
-        let te = TimedEffect::new_continuous(AssignOpT::Increase, head, crate::FExpT::Scaled(exp));
+        use crate::{TimedAssignOperator, FluentExpression, FunctionHead, FunctionSymbol, Number, TimedFluentExpression};
+        let head = FunctionHead::Simple(FunctionSymbol::from("x"));
+        let exp = FluentExpression::new_number(Number::from(1));
+        let te = TimedEffect::new_continuous(TimedAssignOperator::Increase, head, TimedFluentExpression::Scaled(exp));
         assert_eq!(prettify!(te, 30), "(increase x 1)");
     }
 
     #[test]
     fn durative_action_goal_timed() {
         let gd = crate::GoalDefinition::new_and(Vec::<crate::GoalDefinition>::new());
-        let tgd = TimedGD::new_at(crate::TimeSpecifier::Start, gd);
-        let ptgd = PrefTimedGD::new_required(tgd);
+        let tgd = TimedGoalDefinition::new_at(crate::TimeSpecifier::Start, gd);
+        let ptgd = PreferenceTimedGoalDefinition::new_required(tgd);
         let dagd = DurativeActionGoalDefinition::new_timed(ptgd);
         assert_eq!(prettify!(dagd, 30), "(at start (and))");
     }
@@ -310,8 +311,8 @@ mod tests {
     #[test]
     fn durative_action_goal_and_non_empty() {
         let gd = crate::GoalDefinition::new_and(Vec::<crate::GoalDefinition>::new());
-        let tgd = TimedGD::new_at(crate::TimeSpecifier::Start, gd);
-        let ptgd = PrefTimedGD::new_required(tgd);
+        let tgd = TimedGoalDefinition::new_at(crate::TimeSpecifier::Start, gd);
+        let ptgd = PreferenceTimedGoalDefinition::new_required(tgd);
         let dagd =
             DurativeActionGoalDefinition::new_and([DurativeActionGoalDefinition::new_timed(ptgd)]);
         assert_eq!(prettify!(dagd, 40), "(and (at start (and)))");
@@ -328,8 +329,8 @@ mod tests {
 
     #[test]
     fn durative_action_effect_timed() {
-        use crate::ConditionalEffect;
-        let ce = ConditionalEffect::new_and(Vec::new());
+        use crate::EffectCondition;
+        let ce = EffectCondition::new_and(Vec::new());
         let te = TimedEffect::new_conditional(crate::TimeSpecifier::Start, ce);
         let dae = DurativeActionEffect::new_timed(te);
         assert_eq!(prettify!(dae, 30), "(at start (and))");
@@ -337,8 +338,8 @@ mod tests {
 
     #[test]
     fn durative_action_effect_all() {
-        use crate::ConditionalEffect;
-        let ce = ConditionalEffect::new_and(Vec::new());
+        use crate::EffectCondition;
+        let ce = EffectCondition::new_and(Vec::new());
         let te = TimedEffect::new_conditional(crate::TimeSpecifier::Start, ce);
         let dae = DurativeActionEffect::new_and([DurativeActionEffect::new_timed(te)]);
         assert_eq!(prettify!(dae, 40), "(and (at start (and)))");
@@ -346,9 +347,9 @@ mod tests {
 
     #[test]
     fn durative_action_effect_forall() {
-        use crate::{ConditionalEffect, ToTyped, Type, TypedVariables, Variable};
+        use crate::{EffectCondition, ToTyped, Type, TypedVariables, Variable};
         let vars: TypedVariables = vec![Variable::new_string("x").to_typed(Type::OBJECT)].into();
-        let ce = ConditionalEffect::new_and(Vec::new());
+        let ce = EffectCondition::new_and(Vec::new());
         let inner = DurativeActionEffect::new_timed(TimedEffect::new_conditional(
             crate::TimeSpecifier::Start,
             ce,
@@ -359,12 +360,12 @@ mod tests {
 
     #[test]
     fn durative_action_effect_when() {
-        use crate::{ConditionalEffect, GoalDefinition};
+        use crate::{EffectCondition, GoalDefinition};
         let gd = GoalDefinition::new_and(Vec::<GoalDefinition>::new());
-        let ce = ConditionalEffect::new_and(Vec::new());
+        let ce = EffectCondition::new_and(Vec::new());
         let te = TimedEffect::new_conditional(crate::TimeSpecifier::Start, ce);
         let dae = DurativeActionEffect::new_when(
-            DurativeActionGoalDefinition::new_timed(PrefTimedGD::new_required(TimedGD::new_at(
+            DurativeActionGoalDefinition::new_timed(PreferenceTimedGoalDefinition::new_required(TimedGoalDefinition::new_at(
                 crate::TimeSpecifier::Start,
                 gd,
             ))),

--- a/src/pretty_print/timed.rs
+++ b/src/pretty_print/timed.rs
@@ -177,57 +177,46 @@ mod tests {
 
     #[test]
     fn duration_value_number() {
-        let dv = DurationValue::new_number(10);
+        let dv = DurationValue::number(10);
         assert_eq!(prettify!(dv, 20), "10");
     }
 
     #[test]
     fn simple_duration_constraint_op() {
-        let sdc = SimpleDurationConstraint::new_op(
-            DurationOperator::Equal,
-            DurationValue::new_number(10),
-        );
+        let sdc = SimpleDurationConstraint::op(DurationOperator::Equal, DurationValue::number(10));
         assert_eq!(prettify!(sdc, 30), "(= ?duration 10)");
     }
 
     #[test]
     fn duration_value_fexp() {
-        let exp = crate::FluentExpression::new_number(crate::Number::from(5));
-        let dv = DurationValue::new_f_exp(exp);
+        let exp = crate::FluentExpression::number(crate::Number::from(5));
+        let dv = DurationValue::fluent_expression(exp);
         assert_eq!(prettify!(dv, 20), "5");
     }
 
     #[test]
     fn simple_duration_constraint_at() {
-        let inner = SimpleDurationConstraint::new_op(
-            DurationOperator::Equal,
-            DurationValue::new_number(10),
-        );
-        let sdc = SimpleDurationConstraint::new_at(crate::TimeSpecifier::Start, inner);
+        let inner =
+            SimpleDurationConstraint::op(DurationOperator::Equal, DurationValue::number(10));
+        let sdc = SimpleDurationConstraint::at(crate::TimeSpecifier::Start, inner);
         assert_eq!(prettify!(sdc, 30), "(at start (= ?duration 10))");
     }
 
     #[test]
     fn duration_constraint_single() {
-        let sdc = SimpleDurationConstraint::new_op(
-            DurationOperator::Equal,
-            DurationValue::new_number(10),
-        );
+        let sdc = SimpleDurationConstraint::op(DurationOperator::Equal, DurationValue::number(10));
         let dc = DurationConstraint::new(sdc);
         assert_eq!(prettify!(dc, 30), "(= ?duration 10)");
     }
 
     #[test]
     fn duration_constraint_all() {
-        let sdc1 = SimpleDurationConstraint::new_op(
-            DurationOperator::Equal,
-            DurationValue::new_number(10),
-        );
-        let sdc2 = SimpleDurationConstraint::new_op(
+        let sdc1 = SimpleDurationConstraint::op(DurationOperator::Equal, DurationValue::number(10));
+        let sdc2 = SimpleDurationConstraint::op(
             DurationOperator::GreaterOrEqual,
-            DurationValue::new_number(5),
+            DurationValue::number(5),
         );
-        let dc = DurationConstraint::new_all([sdc1, sdc2]);
+        let dc = DurationConstraint::all([sdc1, sdc2]);
         let out = prettify!(dc, 30);
         assert!(out.starts_with("(and"));
         assert!(out.contains("(= ?duration 10)"));
@@ -236,52 +225,50 @@ mod tests {
 
     #[test]
     fn timed_gd_at() {
-        let gd = crate::GoalDefinition::new_and(Vec::<crate::GoalDefinition>::new());
-        let tgd = TimedGoalDefinition::new_at(crate::TimeSpecifier::Start, gd);
+        let gd = crate::GoalDefinition::and(Vec::<crate::GoalDefinition>::new());
+        let tgd = TimedGoalDefinition::at(crate::TimeSpecifier::Start, gd);
         assert_eq!(prettify!(tgd, 30), "(at start (and))");
     }
 
     #[test]
     fn timed_gd_over() {
         use crate::Interval;
-        let gd = crate::GoalDefinition::new_and(Vec::<crate::GoalDefinition>::new());
-        let tgd = TimedGoalDefinition::new_over(Interval::All, gd);
+        let gd = crate::GoalDefinition::and(Vec::<crate::GoalDefinition>::new());
+        let tgd = TimedGoalDefinition::over(Interval::All, gd);
         assert_eq!(prettify!(tgd, 30), "(over all (and))");
     }
 
     #[test]
     fn pref_timed_gd_required() {
-        let gd = crate::GoalDefinition::new_and(Vec::<crate::GoalDefinition>::new());
-        let tgd = TimedGoalDefinition::new_at(crate::TimeSpecifier::Start, gd);
-        let ptgd = PreferenceTimedGoalDefinition::new_required(tgd);
+        let gd = crate::GoalDefinition::and(Vec::<crate::GoalDefinition>::new());
+        let tgd = TimedGoalDefinition::at(crate::TimeSpecifier::Start, gd);
+        let ptgd = PreferenceTimedGoalDefinition::required(tgd);
         assert_eq!(prettify!(ptgd, 30), "(at start (and))");
     }
 
     #[test]
     fn pref_timed_gd_preference_with_name() {
         use crate::PreferenceName;
-        let gd = crate::GoalDefinition::new_and(Vec::<crate::GoalDefinition>::new());
-        let tgd = TimedGoalDefinition::new_at(crate::TimeSpecifier::Start, gd);
-        let ptgd = PreferenceTimedGoalDefinition::new_preference(
-            Some(PreferenceName::new_string("p1")),
-            tgd,
-        );
+        let gd = crate::GoalDefinition::and(Vec::<crate::GoalDefinition>::new());
+        let tgd = TimedGoalDefinition::at(crate::TimeSpecifier::Start, gd);
+        let ptgd =
+            PreferenceTimedGoalDefinition::preference(Some(PreferenceName::string("p1")), tgd);
         assert_eq!(prettify!(ptgd, 40), "(preference p1 (at start (and)))");
     }
 
     #[test]
     fn pref_timed_gd_preference_no_name() {
-        let gd = crate::GoalDefinition::new_and(Vec::<crate::GoalDefinition>::new());
-        let tgd = TimedGoalDefinition::new_at(crate::TimeSpecifier::Start, gd);
-        let ptgd = PreferenceTimedGoalDefinition::new_preference(None, tgd);
+        let gd = crate::GoalDefinition::and(Vec::<crate::GoalDefinition>::new());
+        let tgd = TimedGoalDefinition::at(crate::TimeSpecifier::Start, gd);
+        let ptgd = PreferenceTimedGoalDefinition::preference(None, tgd);
         assert_eq!(prettify!(ptgd, 40), "(preference (at start (and)))");
     }
 
     #[test]
     fn timed_effect_conditional() {
         use crate::EffectCondition;
-        let ce = EffectCondition::new_and(Vec::new());
-        let te = TimedEffect::new_conditional(crate::TimeSpecifier::Start, ce);
+        let ce = EffectCondition::all(Vec::new());
+        let te = TimedEffect::conditional(crate::TimeSpecifier::Start, ce);
         assert_eq!(prettify!(te, 30), "(at start (and))");
     }
 
@@ -292,11 +279,11 @@ mod tests {
             FluentExpression, FunctionHead, FunctionSymbol, Number,
         };
         let head = FunctionHead::Simple(FunctionSymbol::from("x"));
-        let expr = DurativeActionFluentExpression::new_f_exp(FluentExpression::new_number(
+        let expr = DurativeActionFluentExpression::fluent_expression(FluentExpression::number(
             Number::from(5),
         ));
         let fassign = DurativeActionFunctionAssignment::new(AssignOp::Increase, head, expr);
-        let te = TimedEffect::new_fluent(crate::TimeSpecifier::End, fassign);
+        let te = TimedEffect::fluent(crate::TimeSpecifier::End, fassign);
         assert_eq!(prettify!(te, 30), "(at end (increase x 5))");
     }
 
@@ -307,8 +294,8 @@ mod tests {
             TimedFluentExpression,
         };
         let head = FunctionHead::Simple(FunctionSymbol::from("x"));
-        let exp = FluentExpression::new_number(Number::from(1));
-        let te = TimedEffect::new_continuous(
+        let exp = FluentExpression::number(Number::from(1));
+        let te = TimedEffect::continuous(
             TimedAssignOperator::Increase,
             head,
             TimedFluentExpression::Scaled(exp),
@@ -318,78 +305,75 @@ mod tests {
 
     #[test]
     fn durative_action_goal_timed() {
-        let gd = crate::GoalDefinition::new_and(Vec::<crate::GoalDefinition>::new());
-        let tgd = TimedGoalDefinition::new_at(crate::TimeSpecifier::Start, gd);
-        let ptgd = PreferenceTimedGoalDefinition::new_required(tgd);
-        let dagd = DurativeActionGoalDefinition::new_timed(ptgd);
+        let gd = crate::GoalDefinition::and(Vec::<crate::GoalDefinition>::new());
+        let tgd = TimedGoalDefinition::at(crate::TimeSpecifier::Start, gd);
+        let ptgd = PreferenceTimedGoalDefinition::required(tgd);
+        let dagd = DurativeActionGoalDefinition::timed(ptgd);
         assert_eq!(prettify!(dagd, 30), "(at start (and))");
     }
 
     #[test]
     fn durative_action_goal_and_empty() {
-        let dagd = DurativeActionGoalDefinition::new_and(Vec::new());
+        let dagd = DurativeActionGoalDefinition::and(Vec::new());
         assert_eq!(prettify!(dagd, 30), "(and)");
     }
 
     #[test]
     fn durative_action_goal_and_non_empty() {
-        let gd = crate::GoalDefinition::new_and(Vec::<crate::GoalDefinition>::new());
-        let tgd = TimedGoalDefinition::new_at(crate::TimeSpecifier::Start, gd);
-        let ptgd = PreferenceTimedGoalDefinition::new_required(tgd);
-        let dagd =
-            DurativeActionGoalDefinition::new_and([DurativeActionGoalDefinition::new_timed(ptgd)]);
+        let gd = crate::GoalDefinition::and(Vec::<crate::GoalDefinition>::new());
+        let tgd = TimedGoalDefinition::at(crate::TimeSpecifier::Start, gd);
+        let ptgd = PreferenceTimedGoalDefinition::required(tgd);
+        let dagd = DurativeActionGoalDefinition::and([DurativeActionGoalDefinition::timed(ptgd)]);
         assert_eq!(prettify!(dagd, 40), "(and (at start (and)))");
     }
 
     #[test]
     fn durative_action_goal_forall() {
         use crate::{ToTyped, Type, TypedVariables, Variable};
-        let vars: TypedVariables = vec![Variable::new_string("x").to_typed(Type::OBJECT)].into();
-        let inner = DurativeActionGoalDefinition::new_and(Vec::new());
-        let dagd = DurativeActionGoalDefinition::new_forall(vars, inner);
+        let vars: TypedVariables = vec![Variable::string("x").to_typed(Type::OBJECT)].into();
+        let inner = DurativeActionGoalDefinition::and(Vec::new());
+        let dagd = DurativeActionGoalDefinition::forall(vars, inner);
         assert_eq!(prettify!(dagd, 40), "(forall (?x) (and))");
     }
 
     #[test]
     fn durative_action_effect_timed() {
         use crate::EffectCondition;
-        let ce = EffectCondition::new_and(Vec::new());
-        let te = TimedEffect::new_conditional(crate::TimeSpecifier::Start, ce);
-        let dae = DurativeActionEffect::new_timed(te);
+        let ce = EffectCondition::all(Vec::new());
+        let te = TimedEffect::conditional(crate::TimeSpecifier::Start, ce);
+        let dae = DurativeActionEffect::timed(te);
         assert_eq!(prettify!(dae, 30), "(at start (and))");
     }
 
     #[test]
     fn durative_action_effect_all() {
         use crate::EffectCondition;
-        let ce = EffectCondition::new_and(Vec::new());
-        let te = TimedEffect::new_conditional(crate::TimeSpecifier::Start, ce);
-        let dae = DurativeActionEffect::new_and([DurativeActionEffect::new_timed(te)]);
+        let ce = EffectCondition::all(Vec::new());
+        let te = TimedEffect::conditional(crate::TimeSpecifier::Start, ce);
+        let dae = DurativeActionEffect::and([DurativeActionEffect::timed(te)]);
         assert_eq!(prettify!(dae, 40), "(and (at start (and)))");
     }
 
     #[test]
     fn durative_action_effect_forall() {
         use crate::{EffectCondition, ToTyped, Type, TypedVariables, Variable};
-        let vars: TypedVariables = vec![Variable::new_string("x").to_typed(Type::OBJECT)].into();
-        let ce = EffectCondition::new_and(Vec::new());
-        let inner = DurativeActionEffect::new_timed(TimedEffect::new_conditional(
-            crate::TimeSpecifier::Start,
-            ce,
-        ));
-        let dae = DurativeActionEffect::new_forall(vars, inner);
+        let vars: TypedVariables = vec![Variable::string("x").to_typed(Type::OBJECT)].into();
+        let ce = EffectCondition::all(Vec::new());
+        let inner =
+            DurativeActionEffect::timed(TimedEffect::conditional(crate::TimeSpecifier::Start, ce));
+        let dae = DurativeActionEffect::forall(vars, inner);
         assert_eq!(prettify!(dae, 40), "(forall (?x) (at start (and)))");
     }
 
     #[test]
     fn durative_action_effect_when() {
         use crate::{EffectCondition, GoalDefinition};
-        let gd = GoalDefinition::new_and(Vec::<GoalDefinition>::new());
-        let ce = EffectCondition::new_and(Vec::new());
-        let te = TimedEffect::new_conditional(crate::TimeSpecifier::Start, ce);
-        let dae = DurativeActionEffect::new_when(
-            DurativeActionGoalDefinition::new_timed(PreferenceTimedGoalDefinition::new_required(
-                TimedGoalDefinition::new_at(crate::TimeSpecifier::Start, gd),
+        let gd = GoalDefinition::and(Vec::<GoalDefinition>::new());
+        let ce = EffectCondition::all(Vec::new());
+        let te = TimedEffect::conditional(crate::TimeSpecifier::Start, ce);
+        let dae = DurativeActionEffect::when(
+            DurativeActionGoalDefinition::timed(PreferenceTimedGoalDefinition::required(
+                TimedGoalDefinition::at(crate::TimeSpecifier::Start, gd),
             )),
             te,
         );

--- a/src/pretty_print/typed_list.rs
+++ b/src/pretty_print/typed_list.rs
@@ -135,7 +135,7 @@ mod tests {
 
     #[test]
     fn typed_explicit() {
-        let x = Name::new("x").to_typed(Type::new_exactly("letter"));
+        let x = Name::new("x").to_typed(Type::exactly("letter"));
         assert_eq!(prettify!(x, 20), "x - letter");
     }
 
@@ -152,9 +152,9 @@ mod tests {
     #[test]
     fn typed_list_same_type() {
         let list = TypedList::from_iter([
-            Name::new("x").to_typed(Type::new_exactly("letter")),
-            Name::new("y").to_typed(Type::new_exactly("letter")),
-            Name::new("z").to_typed(Type::new_exactly("letter")),
+            Name::new("x").to_typed(Type::exactly("letter")),
+            Name::new("y").to_typed(Type::exactly("letter")),
+            Name::new("z").to_typed(Type::exactly("letter")),
         ]);
         assert_eq!(prettify!(list, 30), "x y z - letter");
     }
@@ -162,9 +162,9 @@ mod tests {
     #[test]
     fn typed_list_interleaved() {
         let list = TypedList::from_iter([
-            Name::new("x").to_typed(Type::new_exactly("letter")),
-            Name::new("y").to_typed(Type::new_exactly("car")),
-            Name::new("z").to_typed(Type::new_exactly("letter")),
+            Name::new("x").to_typed(Type::exactly("letter")),
+            Name::new("y").to_typed(Type::exactly("car")),
+            Name::new("z").to_typed(Type::exactly("letter")),
         ]);
         assert_eq!(prettify!(list, 30), "x - letter y - car z - letter");
     }
@@ -172,7 +172,7 @@ mod tests {
     #[test]
     fn typed_list_object_at_end() {
         let list = TypedList::from_iter([
-            Name::new("x").to_typed(Type::new_exactly("letter")),
+            Name::new("x").to_typed(Type::exactly("letter")),
             Name::new("y").to_typed(Type::OBJECT),
             Name::new("z").to_typed(Type::OBJECT),
         ]);
@@ -182,9 +182,9 @@ mod tests {
     #[test]
     fn typed_list_object_at_start() {
         let list = TypedList::from_iter([
-            Variable::new_string("x").to_typed(Type::OBJECT),
-            Variable::new_string("y").to_typed(Type::OBJECT),
-            Variable::new_string("z").to_typed(Type::new_exactly("letter")),
+            Variable::string("x").to_typed(Type::OBJECT),
+            Variable::string("y").to_typed(Type::OBJECT),
+            Variable::string("z").to_typed(Type::exactly("letter")),
         ]);
         assert_eq!(prettify!(list, 30), "?x ?y - object ?z - letter");
     }
@@ -207,7 +207,7 @@ mod tests {
         use crate::{FunctionSymbol, FunctionTyped};
         let ft = FunctionTyped::new(
             FunctionSymbol::from("loc"),
-            crate::FunctionType::new(crate::Type::new_exactly("location")),
+            crate::FunctionType::new(crate::Type::exactly("location")),
         );
         assert_eq!(prettify!(ft, 20), "loc - location");
     }
@@ -245,7 +245,7 @@ mod tests {
             ),
             FunctionTyped::new(
                 AtomicFunctionSkeleton::new(FunctionSymbol::from("y"), vec![].into()),
-                crate::FunctionType::new(crate::Type::new_exactly("location")),
+                crate::FunctionType::new(crate::Type::exactly("location")),
             ),
         ]);
         assert_eq!(prettify!(list, 30), "(x) - number (y) - location");
@@ -257,7 +257,7 @@ mod tests {
         let list = crate::FunctionTypedList::new(vec![
             FunctionTyped::new(
                 AtomicFunctionSkeleton::new(FunctionSymbol::from("x"), vec![].into()),
-                crate::FunctionType::new(crate::Type::new_exactly("location")),
+                crate::FunctionType::new(crate::Type::exactly("location")),
             ),
             FunctionTyped::new(
                 AtomicFunctionSkeleton::new(FunctionSymbol::from("y"), vec![].into()),
@@ -277,7 +277,7 @@ mod tests {
             ),
             FunctionTyped::new(
                 AtomicFunctionSkeleton::new(FunctionSymbol::from("y"), vec![].into()),
-                crate::FunctionType::new(crate::Type::new_exactly("location")),
+                crate::FunctionType::new(crate::Type::exactly("location")),
             ),
         ]);
         assert_eq!(prettify!(list, 30), "(x) - number (y) - location");

--- a/src/types/action_symbols.rs
+++ b/src/types/action_symbols.rs
@@ -17,8 +17,14 @@ impl ActionSymbol {
     }
 
     #[inline(always)]
-    pub fn new_string(name: &str) -> Self {
+    #[doc(alias = "new_string")]
+    pub fn string(name: &str) -> Self {
         Self(Name::new(name))
+    }
+
+    #[inline(always)]
+    pub fn new_string(name: &str) -> Self {
+        Self::string(name)
     }
 
     #[inline(always)]

--- a/src/types/assign_op.rs
+++ b/src/types/assign_op.rs
@@ -6,7 +6,7 @@ use std::fmt::{Display, Formatter};
 /// An assignment operation.
 ///
 /// ## Usage
-/// Used by [`PEffect`](crate::PEffect), [`TimedEffect`](crate::TimedEffect) and
+/// Used by [`PrimitiveEffect`](crate::PrimitiveEffect), [`TimedEffect`](crate::TimedEffect) and
 /// [`FAssignDa`](crate::FAssignDa).
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum AssignOp {

--- a/src/types/assign_op_t.rs
+++ b/src/types/assign_op_t.rs
@@ -1,4 +1,4 @@
-//! Contains the timed effect assignment operation type [`AssignOpT`].
+//! Contains the timed effect assignment operation type [`TimedAssignOperator`].
 
 use std::fmt::{Display, Formatter};
 
@@ -6,8 +6,9 @@ use std::fmt::{Display, Formatter};
 ///
 /// ## Usage
 /// Used by [`TimedEffect`](crate::TimedEffect).
+#[doc(alias("assign-op-t"))]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum AssignOpT {
+pub enum TimedAssignOperator {
     Increase,
     Decrease,
 }
@@ -17,16 +18,16 @@ pub mod names {
     pub const DECREASE: &str = "decrease";
 }
 
-impl Display for AssignOpT {
+impl Display for TimedAssignOperator {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            AssignOpT::Increase => write!(f, "{}", names::INCREASE),
-            AssignOpT::Decrease => write!(f, "{}", names::DECREASE),
+            TimedAssignOperator::Increase => write!(f, "{}", names::INCREASE),
+            TimedAssignOperator::Decrease => write!(f, "{}", names::DECREASE),
         }
     }
 }
 
-impl TryFrom<&str> for AssignOpT {
+impl TryFrom<&str> for TimedAssignOperator {
     type Error = ParseError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
@@ -43,3 +44,7 @@ pub enum ParseError {
     #[error("Invalid operation")]
     InvalidOperation,
 }
+
+/// Alias for [`TimedAssignOperator`]; matches BNF `<assign-op-t>`.
+#[deprecated(since = "0.2.0", note = "Use `TimedAssignOperator` instead")]
+pub type AssignOpT = TimedAssignOperator;

--- a/src/types/atomic_formula.rs
+++ b/src/types/atomic_formula.rs
@@ -7,7 +7,7 @@ use std::ops::Deref;
 ///
 /// ## Usage
 /// Used by [`Literal`](crate::Literal), [`GoalDefinition`](crate::GoalDefinition) and
-/// [`PEffect`](crate::PEffect).
+/// [`PrimitiveEffect`](crate::PrimitiveEffect).
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum AtomicFormula<T> {
     Equality(EqualityAtomicFormula<T>),

--- a/src/types/atomic_formula.rs
+++ b/src/types/atomic_formula.rs
@@ -15,15 +15,25 @@ pub enum AtomicFormula<T> {
 }
 
 impl<T> AtomicFormula<T> {
-    pub const fn new_equality(first: T, second: T) -> Self {
+    #[doc(alias = "new_equality")]
+    pub const fn equality(first: T, second: T) -> Self {
         Self::Equality(EqualityAtomicFormula::new(first, second))
     }
 
-    pub fn new_predicate<V: IntoIterator<Item = T>>(predicate: Predicate, values: V) -> Self {
+    pub fn new_equality(first: T, second: T) -> Self {
+        Self::equality(first, second)
+    }
+
+    #[doc(alias = "new_predicate")]
+    pub fn predicate<V: IntoIterator<Item = T>>(predicate: Predicate, values: V) -> Self {
         Self::Predicate(PredicateAtomicFormula::new(
             predicate,
             values.into_iter().collect(),
         ))
+    }
+
+    pub fn new_predicate<V: IntoIterator<Item = T>>(predicate: Predicate, values: V) -> Self {
+        Self::predicate(predicate, values)
     }
 }
 

--- a/src/types/binary_comp.rs
+++ b/src/types/binary_comp.rs
@@ -1,13 +1,14 @@
-//! Contains binary comparison operations via the [`BinaryComp`] type.
+//! Contains binary comparison operations via the [`BinaryComparison`] type.
 
 use std::fmt::{Display, Formatter};
 
 /// A binary comparison operation.
 ///
 /// ## Usage
-/// Used by [`FComp`](crate::FComp).
+/// Used by [`FluentComparison`](crate::FluentComparison).
+#[doc(alias("binary-comp"))]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum BinaryComp {
+pub enum BinaryComparison {
     GreaterThan,
     LessThan,
     Equal,
@@ -23,19 +24,19 @@ pub mod names {
     pub const LESS_THAN_OR_EQUAL: &str = "<=";
 }
 
-impl Display for BinaryComp {
+impl Display for BinaryComparison {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            BinaryComp::GreaterThan => write!(f, "{}", names::GREATER_THAN),
-            BinaryComp::LessThan => write!(f, "{}", names::LESS_THAN),
-            BinaryComp::Equal => write!(f, "{}", names::EQUAL),
-            BinaryComp::GreaterOrEqual => write!(f, "{}", names::GREATER_THAN_OR_EQUAL),
-            BinaryComp::LessThanOrEqual => write!(f, "{}", names::LESS_THAN_OR_EQUAL),
+            BinaryComparison::GreaterThan => write!(f, "{}", names::GREATER_THAN),
+            BinaryComparison::LessThan => write!(f, "{}", names::LESS_THAN),
+            BinaryComparison::Equal => write!(f, "{}", names::EQUAL),
+            BinaryComparison::GreaterOrEqual => write!(f, "{}", names::GREATER_THAN_OR_EQUAL),
+            BinaryComparison::LessThanOrEqual => write!(f, "{}", names::LESS_THAN_OR_EQUAL),
         }
     }
 }
 
-impl TryFrom<&str> for BinaryComp {
+impl TryFrom<&str> for BinaryComparison {
     type Error = ParseError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
@@ -55,3 +56,8 @@ pub enum ParseError {
     #[error("Invalid operation")]
     InvalidOperation,
 }
+
+/// Alias for [`BinaryComparison`].
+#[deprecated(since = "0.2.0", note = "Use `BinaryComparison` instead")]
+#[allow(dead_code)]
+pub type BinaryComp = BinaryComparison;

--- a/src/types/c_effect.rs
+++ b/src/types/c_effect.rs
@@ -66,15 +66,20 @@ impl WhenConditionalEffect {
 }
 
 impl ConditionalEffect {
-    /// Crates a new effect.
+    /// Creates a new effect.
     pub const fn new_primitive_effect(effect: PrimitiveEffect) -> Self {
         Self::Effect(effect)
     }
 
-    /// Creates a new effect.
+    /// Crates a new effect.
     #[deprecated(since = "0.2.0", note = "Use `new_primitive_effect` instead")]
     pub const fn new_p_effect(effect: PrimitiveEffect) -> Self {
         Self::new_primitive_effect(effect)
+    }
+
+    /// Creates a new effect.
+    pub const fn primitive_effect(effect: PrimitiveEffect) -> Self {
+        Self::Effect(effect)
     }
 
     /// Creates a new universal effect that applies to all
@@ -82,16 +87,26 @@ impl ConditionalEffect {
     ///
     /// ## Requirements
     /// Requires [Conditional Effects](crate::Requirement::ConditionalEffects).
-    pub const fn new_forall(variables: TypedVariables, effect: Effects) -> Self {
+    pub const fn forall(variables: TypedVariables, effect: Effects) -> Self {
         Self::Forall(ForallConditionalEffect::new(variables, effect))
+    }
+
+    #[deprecated(since = "0.2.0", note = "Use `forall` instead")]
+    pub const fn new_forall(variables: TypedVariables, effect: Effects) -> Self {
+        Self::forall(variables, effect)
     }
 
     /// Creates a new conditional effect.
     ///
     /// ## Requirements
     /// Requires [Conditional Effects](crate::Requirement::ConditionalEffects).
-    pub const fn new_when(condition: GoalDefinition, effect: EffectCondition) -> Self {
+    pub const fn when(condition: GoalDefinition, effect: EffectCondition) -> Self {
         Self::When(WhenConditionalEffect::new(condition, effect))
+    }
+
+    #[deprecated(since = "0.2.0", note = "Use `when` instead")]
+    pub const fn new_when(condition: GoalDefinition, effect: EffectCondition) -> Self {
+        Self::when(condition, effect)
     }
 }
 
@@ -172,3 +187,75 @@ pub type ForallCEffect = ForallConditionalEffect;
 /// Alias for [`WhenConditionalEffect`]; matches BNF `<c-effect>` (when variant).
 #[deprecated(since = "0.2.0", note = "Use `WhenConditionalEffect` instead")]
 pub type WhenCEffect = WhenConditionalEffect;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{AtomicFormula, Term};
+
+    #[test]
+    fn conditional_effect_try_into_primitive_effect() {
+        let pe = PrimitiveEffect::new(AtomicFormula::equality(
+            Term::Name("x".into()),
+            Term::Name("y".into()),
+        ));
+        let ce: ConditionalEffect = pe.clone().into();
+        let result: Result<PrimitiveEffect, ()> = ce.try_into();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn conditional_effect_try_into_primitive_effect_fails() {
+        let vars = TypedVariables::default();
+        let ce = ConditionalEffect::forall(vars, Effects::default());
+        let result: Result<PrimitiveEffect, ()> = ce.try_into();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn conditional_effect_try_into_when() {
+        let cond = GoalDefinition::and(Vec::new());
+        let effect = EffectCondition::all(Vec::new());
+        let ce = ConditionalEffect::when(cond, effect);
+        let result: Result<WhenConditionalEffect, ()> = ce.try_into();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn conditional_effect_try_into_when_fails() {
+        let ce = ConditionalEffect::new_primitive_effect(PrimitiveEffect::new(
+            AtomicFormula::equality(Term::Name("x".into()), Term::Name("y".into())),
+        ));
+        let result: Result<WhenConditionalEffect, ()> = ce.try_into();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn conditional_effect_try_into_forall() {
+        let vars = TypedVariables::default();
+        let effects = Effects::default();
+        let ce = ConditionalEffect::forall(vars, effects);
+        let result: Result<ForallConditionalEffect, ()> = ce.try_into();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn conditional_effect_from_tuples() {
+        let effects = Effects::default();
+        let forall: ForallConditionalEffect = (TypedVariables::default(), effects).into();
+        assert!(forall.effects.is_empty());
+
+        let cond = GoalDefinition::and(Vec::new());
+        let effect = EffectCondition::all(Vec::new());
+        let when: WhenConditionalEffect = (cond, effect).into();
+        assert!(matches!(when.condition, GoalDefinition::And(_)));
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn deprecated_aliases_exist() {
+        fn _assert_alias_ce(_: CEffect) {}
+        fn _assert_alias_fc(_: ForallCEffect) {}
+        fn _assert_alias_wc(_: WhenCEffect) {}
+    }
+}

--- a/src/types/c_effect.rs
+++ b/src/types/c_effect.rs
@@ -1,45 +1,47 @@
-//! Contains the [`CEffect`] type.
+//! Contains the [`ConditionalEffect`] type.
 
 use crate::types::TypedVariables;
-use crate::types::{ConditionalEffect, Effects, GoalDefinition, PEffect};
+use crate::types::{EffectCondition, Effects, GoalDefinition, PrimitiveEffect};
 
 /// A (potentially conditional) effect. Occurs as part of [`Effects`].
 ///
 /// ## Usage
 /// Used by [`Effect`](Effects).
+#[doc(alias("c-effect"))]
 #[derive(Debug, Clone, PartialEq)]
-pub enum CEffect {
+pub enum ConditionalEffect {
     /// A regular effect.
-    Effect(PEffect),
+    Effect(PrimitiveEffect),
     /// A universal affect that is conditioned by variables.
     ///
     /// ## Requirements
     /// Requires [Conditional Effects](crate::Requirement::ConditionalEffects).
-    Forall(ForallCEffect),
+    Forall(ForallConditionalEffect),
     /// A conditional effect that applies only if a given
     /// precondition holds true.
     ///
     /// ## Requirements
     /// Requires [Conditional Effects](crate::Requirement::ConditionalEffects).
-    When(WhenCEffect),
+    When(WhenConditionalEffect),
 }
 
 /// Applies the specified effects for all listed variables.
 ///
 /// ## Requirements
 /// Requires [Conditional Effects](crate::Requirement::ConditionalEffects).
+#[doc(alias("c-effect"))]
 #[derive(Debug, Clone, PartialEq)]
-pub struct ForallCEffect {
+pub struct ForallConditionalEffect {
     /// The (possibly empty) set of variables constraining the effects.
     pub variables: TypedVariables,
     /// The effects to apply.
     pub effects: Effects,
 }
 
-impl ForallCEffect {
-    /// Creates a new [`ForallCEffect`] value.
+impl ForallConditionalEffect {
+    /// Creates a new [`ForallConditionalEffect`] value.
     pub const fn new(variables: TypedVariables, effects: Effects) -> Self {
-        ForallCEffect { variables, effects }
+        ForallConditionalEffect { variables, effects }
     }
 }
 
@@ -47,25 +49,32 @@ impl ForallCEffect {
 ///
 /// ## Requirements
 /// Requires [Conditional Effects](crate::Requirement::ConditionalEffects).
+#[doc(alias("c-effect"))]
 #[derive(Debug, Clone, PartialEq)]
-pub struct WhenCEffect {
+pub struct WhenConditionalEffect {
     /// The antecedent. This needs to be true for the effect to apply.
     pub condition: GoalDefinition,
     /// The consequent. This is the effect that applies when the condition is true.
-    pub effect: ConditionalEffect,
+    pub effect: EffectCondition,
 }
 
-impl WhenCEffect {
-    /// Creates a new [`WhenCEffect`] value.
-    pub const fn new(condition: GoalDefinition, effect: ConditionalEffect) -> Self {
-        WhenCEffect { condition, effect }
+impl WhenConditionalEffect {
+    /// Creates a new [`WhenConditionalEffect`] value.
+    pub const fn new(condition: GoalDefinition, effect: EffectCondition) -> Self {
+        WhenConditionalEffect { condition, effect }
     }
 }
 
-impl CEffect {
+impl ConditionalEffect {
     /// Crates a new effect.
-    pub const fn new_p_effect(effect: PEffect) -> Self {
+    pub const fn new_primitive_effect(effect: PrimitiveEffect) -> Self {
         Self::Effect(effect)
+    }
+
+    /// Creates a new effect.
+    #[deprecated(since = "0.2.0", note = "Use `new_primitive_effect` instead")]
+    pub const fn new_p_effect(effect: PrimitiveEffect) -> Self {
+        Self::new_primitive_effect(effect)
     }
 
     /// Creates a new universal effect that applies to all
@@ -74,80 +83,92 @@ impl CEffect {
     /// ## Requirements
     /// Requires [Conditional Effects](crate::Requirement::ConditionalEffects).
     pub const fn new_forall(variables: TypedVariables, effect: Effects) -> Self {
-        Self::Forall(ForallCEffect::new(variables, effect))
+        Self::Forall(ForallConditionalEffect::new(variables, effect))
     }
 
     /// Creates a new conditional effect.
     ///
     /// ## Requirements
     /// Requires [Conditional Effects](crate::Requirement::ConditionalEffects).
-    pub const fn new_when(condition: GoalDefinition, effect: ConditionalEffect) -> Self {
-        Self::When(WhenCEffect::new(condition, effect))
+    pub const fn new_when(condition: GoalDefinition, effect: EffectCondition) -> Self {
+        Self::When(WhenConditionalEffect::new(condition, effect))
     }
 }
 
-impl From<PEffect> for CEffect {
-    fn from(value: PEffect) -> Self {
-        CEffect::new_p_effect(value)
+impl From<PrimitiveEffect> for ConditionalEffect {
+    fn from(value: PrimitiveEffect) -> Self {
+        ConditionalEffect::new_primitive_effect(value)
     }
 }
 
-impl From<ForallCEffect> for CEffect {
-    fn from(value: ForallCEffect) -> Self {
-        CEffect::Forall(value)
+impl From<ForallConditionalEffect> for ConditionalEffect {
+    fn from(value: ForallConditionalEffect) -> Self {
+        ConditionalEffect::Forall(value)
     }
 }
 
-impl From<WhenCEffect> for CEffect {
-    fn from(value: WhenCEffect) -> Self {
-        CEffect::When(value)
+impl From<WhenConditionalEffect> for ConditionalEffect {
+    fn from(value: WhenConditionalEffect) -> Self {
+        ConditionalEffect::When(value)
     }
 }
 
-impl From<(TypedVariables, Effects)> for ForallCEffect {
+impl From<(TypedVariables, Effects)> for ForallConditionalEffect {
     fn from(value: (TypedVariables, Effects)) -> Self {
-        ForallCEffect::new(value.0, value.1)
+        ForallConditionalEffect::new(value.0, value.1)
     }
 }
 
-impl From<(GoalDefinition, ConditionalEffect)> for WhenCEffect {
-    fn from(value: (GoalDefinition, ConditionalEffect)) -> Self {
-        WhenCEffect::new(value.0, value.1)
+impl From<(GoalDefinition, EffectCondition)> for WhenConditionalEffect {
+    fn from(value: (GoalDefinition, EffectCondition)) -> Self {
+        WhenConditionalEffect::new(value.0, value.1)
     }
 }
 
-impl TryInto<PEffect> for CEffect {
+impl TryInto<PrimitiveEffect> for ConditionalEffect {
     type Error = ();
 
-    fn try_into(self) -> Result<PEffect, Self::Error> {
+    fn try_into(self) -> Result<PrimitiveEffect, Self::Error> {
         match self {
-            CEffect::Effect(x) => Ok(x),
-            CEffect::Forall(_) => Err(()),
-            CEffect::When(_) => Err(()),
+            ConditionalEffect::Effect(x) => Ok(x),
+            ConditionalEffect::Forall(_) => Err(()),
+            ConditionalEffect::When(_) => Err(()),
         }
     }
 }
 
-impl TryInto<WhenCEffect> for CEffect {
+impl TryInto<WhenConditionalEffect> for ConditionalEffect {
     type Error = ();
 
-    fn try_into(self) -> Result<WhenCEffect, Self::Error> {
+    fn try_into(self) -> Result<WhenConditionalEffect, Self::Error> {
         match self {
-            CEffect::Effect(_) => Err(()),
-            CEffect::Forall(_) => Err(()),
-            CEffect::When(x) => Ok(x),
+            ConditionalEffect::Effect(_) => Err(()),
+            ConditionalEffect::Forall(_) => Err(()),
+            ConditionalEffect::When(x) => Ok(x),
         }
     }
 }
 
-impl TryInto<ForallCEffect> for CEffect {
+impl TryInto<ForallConditionalEffect> for ConditionalEffect {
     type Error = ();
 
-    fn try_into(self) -> Result<ForallCEffect, Self::Error> {
+    fn try_into(self) -> Result<ForallConditionalEffect, Self::Error> {
         match self {
-            CEffect::Effect(_) => Err(()),
-            CEffect::Forall(x) => Ok(x),
-            CEffect::When(_) => Err(()),
+            ConditionalEffect::Effect(_) => Err(()),
+            ConditionalEffect::Forall(x) => Ok(x),
+            ConditionalEffect::When(_) => Err(()),
         }
     }
 }
+
+/// Alias for [`ConditionalEffect`]; matches BNF `<c-effect>`.
+#[deprecated(since = "0.2.0", note = "Use `ConditionalEffect` instead")]
+pub type CEffect = ConditionalEffect;
+
+/// Alias for [`ForallConditionalEffect`]; matches BNF `<c-effect>` (forall variant).
+#[deprecated(since = "0.2.0", note = "Use `ForallConditionalEffect` instead")]
+pub type ForallCEffect = ForallConditionalEffect;
+
+/// Alias for [`WhenConditionalEffect`]; matches BNF `<c-effect>` (when variant).
+#[deprecated(since = "0.2.0", note = "Use `WhenConditionalEffect` instead")]
+pub type WhenCEffect = WhenConditionalEffect;

--- a/src/types/con_gd.rs
+++ b/src/types/con_gd.rs
@@ -1,48 +1,70 @@
-//! Contains the conditional problem/goal definition types [`ConGD`] and [`Con2GD`].
+//! Contains the constraint goal definition types [`ConstraintGoalDefinition`] and [`ConstraintGoalDefinitionInner`].
 
 use crate::types::{GoalDefinition, Number, TypedVariables};
 
+/// A constraint goal definition.
+///
+/// Represents temporal constraint goals for problem-level constraints in PDDL 3.1.
+/// Supports `always`, `sometime`, `within`, `at-most-once`, `sometime-after`,
+/// `sometime-before`, `always-within`, `hold-during`, and `hold-after`.
+///
+/// # BNF
+/// Corresponds to `<con-GD>` in the PDDL 3.1 specification.
+///
 /// ## Usage
-/// Used by [`ConGD`](ConGD) itself, as well as [`PrefConGD`](crate::types::PrefConGD) and [`Con2GD`](Con2GD).
+/// Used by [`PreferenceConstraintGoalDefinition`](crate::types::PreferenceConstraintGoalDefinition) and [`ConstraintGoalDefinitionInner`].
+#[doc(alias = "con-GD")]
 #[derive(Debug, Clone, PartialEq)]
-pub enum ConGD {
-    And(Vec<ConGD>),
-    Forall(TypedVariables, Box<ConGD>),
+pub enum ConstraintGoalDefinition {
+    And(Vec<ConstraintGoalDefinition>),
+    Forall(TypedVariables, Box<ConstraintGoalDefinition>),
     AtEnd(GoalDefinition),
-    Always(Con2GD),
-    Sometime(Con2GD),
-    Within(Number, Con2GD),
-    AtMostOnce(Con2GD),
-    SometimeAfter(Con2GD, Con2GD),
-    SometimeBefore(Con2GD, Con2GD),
-    AlwaysWithin(Number, Con2GD, Con2GD),
-    HoldDuring(Number, Number, Con2GD),
-    HoldAfter(Number, Con2GD),
+    Always(ConstraintGoalDefinitionInner),
+    Sometime(ConstraintGoalDefinitionInner),
+    Within(Number, ConstraintGoalDefinitionInner),
+    AtMostOnce(ConstraintGoalDefinitionInner),
+    SometimeAfter(ConstraintGoalDefinitionInner, ConstraintGoalDefinitionInner),
+    SometimeBefore(ConstraintGoalDefinitionInner, ConstraintGoalDefinitionInner),
+    AlwaysWithin(Number, ConstraintGoalDefinitionInner, ConstraintGoalDefinitionInner),
+    HoldDuring(Number, Number, ConstraintGoalDefinitionInner),
+    HoldAfter(Number, ConstraintGoalDefinitionInner),
 }
 
-impl Default for ConGD {
+/// Alias for [`ConstraintGoalDefinition`]; matches BNF `<con-GD>`.
+#[deprecated(since = "0.2.0", note = "Use `ConstraintGoalDefinition` instead")]
+pub type ConGD = ConstraintGoalDefinition;
+
+/// A type that represents either a [`GoalDefinition`] or an embedded [`ConstraintGoalDefinition`].
+///
+/// # BNF
+/// Corresponds to `<con2-GD>` in the PDDL 3.1 specification.
+///
+/// ## Usage
+/// Used by [`ConstraintGoalDefinition`].
+#[doc(alias = "con2-GD")]
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConstraintGoalDefinitionInner {
+    Goal(GoalDefinition),
+    Nested(Box<ConstraintGoalDefinition>),
+}
+
+/// Alias for [`ConstraintGoalDefinitionInner`]; matches BNF `<con2-GD>`.
+#[deprecated(since = "0.2.0", note = "Use `ConstraintGoalDefinitionInner` instead")]
+pub type Con2GD = ConstraintGoalDefinitionInner;
+
+impl Default for ConstraintGoalDefinition {
     fn default() -> Self {
         Self::And(Vec::default())
     }
 }
 
-/// A type that represents either a [`GoalDefinition`] or an embedded [`ConGD`].
-///
-/// ## Usage
-/// Used by [`ConGD`](ConGD).
-#[derive(Debug, Clone, PartialEq)]
-pub enum Con2GD {
-    Goal(GoalDefinition),
-    Nested(Box<ConGD>),
-}
-
-impl ConGD {
-    pub fn new_and<G: IntoIterator<Item = ConGD>>(goals: G) -> Self {
+impl ConstraintGoalDefinition {
+    pub fn new_and<G: IntoIterator<Item = ConstraintGoalDefinition>>(goals: G) -> Self {
         // TODO: Flatten `(and (and a b) (and x y))` into `(and a b c y)`.
         Self::And(goals.into_iter().collect())
     }
 
-    pub fn new_forall(variables: TypedVariables, gd: ConGD) -> Self {
+    pub fn new_forall(variables: TypedVariables, gd: ConstraintGoalDefinition) -> Self {
         Self::Forall(variables, Box::new(gd))
     }
 
@@ -50,62 +72,62 @@ impl ConGD {
         Self::AtEnd(gd)
     }
 
-    pub const fn new_always(gd: Con2GD) -> Self {
+    pub const fn new_always(gd: ConstraintGoalDefinitionInner) -> Self {
         Self::Always(gd)
     }
 
-    pub const fn new_sometime(gd: Con2GD) -> Self {
+    pub const fn new_sometime(gd: ConstraintGoalDefinitionInner) -> Self {
         Self::Sometime(gd)
     }
 
-    pub const fn new_within(number: Number, gd: Con2GD) -> Self {
+    pub const fn new_within(number: Number, gd: ConstraintGoalDefinitionInner) -> Self {
         Self::Within(number, gd)
     }
 
-    pub const fn new_at_most_once(gd: Con2GD) -> Self {
+    pub const fn new_at_most_once(gd: ConstraintGoalDefinitionInner) -> Self {
         Self::AtMostOnce(gd)
     }
 
-    pub const fn new_sometime_after(first: Con2GD, then: Con2GD) -> Self {
+    pub const fn new_sometime_after(first: ConstraintGoalDefinitionInner, then: ConstraintGoalDefinitionInner) -> Self {
         Self::SometimeAfter(first, then)
     }
 
-    pub const fn new_sometime_before(later: Con2GD, earlier: Con2GD) -> Self {
+    pub const fn new_sometime_before(later: ConstraintGoalDefinitionInner, earlier: ConstraintGoalDefinitionInner) -> Self {
         Self::SometimeBefore(later, earlier)
     }
 
-    pub const fn new_always_within(number: Number, first: Con2GD, second: Con2GD) -> Self {
+    pub const fn new_always_within(number: Number, first: ConstraintGoalDefinitionInner, second: ConstraintGoalDefinitionInner) -> Self {
         Self::AlwaysWithin(number, first, second)
     }
 
-    pub const fn new_hold_during(begin: Number, end: Number, gd: Con2GD) -> Self {
+    pub const fn new_hold_during(begin: Number, end: Number, gd: ConstraintGoalDefinitionInner) -> Self {
         Self::HoldDuring(begin, end, gd)
     }
 
-    pub const fn new_hold_after(number: Number, gd: Con2GD) -> Self {
+    pub const fn new_hold_after(number: Number, gd: ConstraintGoalDefinitionInner) -> Self {
         Self::HoldAfter(number, gd)
     }
 
     pub fn is_empty(&self) -> bool {
         match self {
-            ConGD::And(x) => x.iter().all(|y| y.is_empty()),
-            ConGD::Forall(_, x) => x.is_empty(),
-            ConGD::AtEnd(x) => x.is_empty(),
-            ConGD::Always(x) => x.is_empty(),
-            ConGD::Sometime(x) => x.is_empty(),
-            ConGD::Within(_, x) => x.is_empty(),
-            ConGD::AtMostOnce(x) => x.is_empty(),
-            ConGD::SometimeAfter(x, y) => x.is_empty() && y.is_empty(),
-            ConGD::SometimeBefore(x, y) => x.is_empty() && y.is_empty(),
-            ConGD::AlwaysWithin(_, x, y) => x.is_empty() && y.is_empty(),
-            ConGD::HoldDuring(_, _, x) => x.is_empty(),
-            ConGD::HoldAfter(_, x) => x.is_empty(),
+            ConstraintGoalDefinition::And(x) => x.iter().all(|y| y.is_empty()),
+            ConstraintGoalDefinition::Forall(_, x) => x.is_empty(),
+            ConstraintGoalDefinition::AtEnd(x) => x.is_empty(),
+            ConstraintGoalDefinition::Always(x) => x.is_empty(),
+            ConstraintGoalDefinition::Sometime(x) => x.is_empty(),
+            ConstraintGoalDefinition::Within(_, x) => x.is_empty(),
+            ConstraintGoalDefinition::AtMostOnce(x) => x.is_empty(),
+            ConstraintGoalDefinition::SometimeAfter(x, y) => x.is_empty() && y.is_empty(),
+            ConstraintGoalDefinition::SometimeBefore(x, y) => x.is_empty() && y.is_empty(),
+            ConstraintGoalDefinition::AlwaysWithin(_, x, y) => x.is_empty() && y.is_empty(),
+            ConstraintGoalDefinition::HoldDuring(_, _, x) => x.is_empty(),
+            ConstraintGoalDefinition::HoldAfter(_, x) => x.is_empty(),
         }
     }
 }
 
-impl Con2GD {
-    pub fn new_nested(gd: ConGD) -> Self {
+impl ConstraintGoalDefinitionInner {
+    pub fn new_nested(gd: ConstraintGoalDefinition) -> Self {
         Self::Nested(Box::new(gd))
     }
 
@@ -121,14 +143,14 @@ impl Con2GD {
     }
 }
 
-impl From<ConGD> for Con2GD {
-    fn from(value: ConGD) -> Self {
-        Con2GD::new_nested(value)
+impl From<ConstraintGoalDefinition> for ConstraintGoalDefinitionInner {
+    fn from(value: ConstraintGoalDefinition) -> Self {
+        ConstraintGoalDefinitionInner::new_nested(value)
     }
 }
 
-impl From<GoalDefinition> for Con2GD {
+impl From<GoalDefinition> for ConstraintGoalDefinitionInner {
     fn from(value: GoalDefinition) -> Self {
-        Con2GD::new_goal(value)
+        ConstraintGoalDefinitionInner::new_goal(value)
     }
 }

--- a/src/types/con_gd.rs
+++ b/src/types/con_gd.rs
@@ -25,7 +25,11 @@ pub enum ConstraintGoalDefinition {
     AtMostOnce(ConstraintGoalDefinitionInner),
     SometimeAfter(ConstraintGoalDefinitionInner, ConstraintGoalDefinitionInner),
     SometimeBefore(ConstraintGoalDefinitionInner, ConstraintGoalDefinitionInner),
-    AlwaysWithin(Number, ConstraintGoalDefinitionInner, ConstraintGoalDefinitionInner),
+    AlwaysWithin(
+        Number,
+        ConstraintGoalDefinitionInner,
+        ConstraintGoalDefinitionInner,
+    ),
     HoldDuring(Number, Number, ConstraintGoalDefinitionInner),
     HoldAfter(Number, ConstraintGoalDefinitionInner),
 }
@@ -88,19 +92,33 @@ impl ConstraintGoalDefinition {
         Self::AtMostOnce(gd)
     }
 
-    pub const fn new_sometime_after(first: ConstraintGoalDefinitionInner, then: ConstraintGoalDefinitionInner) -> Self {
+    pub const fn new_sometime_after(
+        first: ConstraintGoalDefinitionInner,
+        then: ConstraintGoalDefinitionInner,
+    ) -> Self {
         Self::SometimeAfter(first, then)
     }
 
-    pub const fn new_sometime_before(later: ConstraintGoalDefinitionInner, earlier: ConstraintGoalDefinitionInner) -> Self {
+    pub const fn new_sometime_before(
+        later: ConstraintGoalDefinitionInner,
+        earlier: ConstraintGoalDefinitionInner,
+    ) -> Self {
         Self::SometimeBefore(later, earlier)
     }
 
-    pub const fn new_always_within(number: Number, first: ConstraintGoalDefinitionInner, second: ConstraintGoalDefinitionInner) -> Self {
+    pub const fn new_always_within(
+        number: Number,
+        first: ConstraintGoalDefinitionInner,
+        second: ConstraintGoalDefinitionInner,
+    ) -> Self {
         Self::AlwaysWithin(number, first, second)
     }
 
-    pub const fn new_hold_during(begin: Number, end: Number, gd: ConstraintGoalDefinitionInner) -> Self {
+    pub const fn new_hold_during(
+        begin: Number,
+        end: Number,
+        gd: ConstraintGoalDefinitionInner,
+    ) -> Self {
         Self::HoldDuring(begin, end, gd)
     }
 

--- a/src/types/con_gd.rs
+++ b/src/types/con_gd.rs
@@ -63,50 +63,102 @@ impl Default for ConstraintGoalDefinition {
 }
 
 impl ConstraintGoalDefinition {
-    pub fn new_and<G: IntoIterator<Item = ConstraintGoalDefinition>>(goals: G) -> Self {
+    #[doc(alias = "new_and")]
+    pub fn and<G: IntoIterator<Item = ConstraintGoalDefinition>>(goals: G) -> Self {
         // TODO: Flatten `(and (and a b) (and x y))` into `(and a b c y)`.
         Self::And(goals.into_iter().collect())
     }
 
-    pub fn new_forall(variables: TypedVariables, gd: ConstraintGoalDefinition) -> Self {
+    pub fn new_and<G: IntoIterator<Item = ConstraintGoalDefinition>>(goals: G) -> Self {
+        Self::and(goals)
+    }
+
+    #[doc(alias = "new_forall")]
+    pub fn r#forall(variables: TypedVariables, gd: ConstraintGoalDefinition) -> Self {
         Self::Forall(variables, Box::new(gd))
     }
 
-    pub const fn new_at_end(gd: GoalDefinition) -> Self {
+    pub fn new_forall(variables: TypedVariables, gd: ConstraintGoalDefinition) -> Self {
+        Self::r#forall(variables, gd)
+    }
+
+    #[doc(alias = "new_at_end")]
+    pub const fn at_end(gd: GoalDefinition) -> Self {
         Self::AtEnd(gd)
     }
 
-    pub const fn new_always(gd: ConstraintGoalDefinitionInner) -> Self {
+    pub fn new_at_end(gd: GoalDefinition) -> Self {
+        Self::at_end(gd)
+    }
+
+    #[doc(alias = "new_always")]
+    pub const fn always(gd: ConstraintGoalDefinitionInner) -> Self {
         Self::Always(gd)
     }
 
-    pub const fn new_sometime(gd: ConstraintGoalDefinitionInner) -> Self {
+    pub fn new_always(gd: ConstraintGoalDefinitionInner) -> Self {
+        Self::always(gd)
+    }
+
+    #[doc(alias = "new_sometime")]
+    pub const fn sometime(gd: ConstraintGoalDefinitionInner) -> Self {
         Self::Sometime(gd)
     }
 
-    pub const fn new_within(number: Number, gd: ConstraintGoalDefinitionInner) -> Self {
+    pub fn new_sometime(gd: ConstraintGoalDefinitionInner) -> Self {
+        Self::sometime(gd)
+    }
+
+    #[doc(alias = "new_within")]
+    pub const fn within(number: Number, gd: ConstraintGoalDefinitionInner) -> Self {
         Self::Within(number, gd)
     }
 
-    pub const fn new_at_most_once(gd: ConstraintGoalDefinitionInner) -> Self {
+    pub fn new_within(number: Number, gd: ConstraintGoalDefinitionInner) -> Self {
+        Self::within(number, gd)
+    }
+
+    #[doc(alias = "new_at_most_once")]
+    pub const fn at_most_once(gd: ConstraintGoalDefinitionInner) -> Self {
         Self::AtMostOnce(gd)
     }
 
-    pub const fn new_sometime_after(
+    pub fn new_at_most_once(gd: ConstraintGoalDefinitionInner) -> Self {
+        Self::at_most_once(gd)
+    }
+
+    #[doc(alias = "new_sometime_after")]
+    pub const fn sometime_after(
         first: ConstraintGoalDefinitionInner,
         then: ConstraintGoalDefinitionInner,
     ) -> Self {
         Self::SometimeAfter(first, then)
     }
 
-    pub const fn new_sometime_before(
+    pub fn new_sometime_after(
+        first: ConstraintGoalDefinitionInner,
+        then: ConstraintGoalDefinitionInner,
+    ) -> Self {
+        Self::sometime_after(first, then)
+    }
+
+    #[doc(alias = "new_sometime_before")]
+    pub const fn sometime_before(
         later: ConstraintGoalDefinitionInner,
         earlier: ConstraintGoalDefinitionInner,
     ) -> Self {
         Self::SometimeBefore(later, earlier)
     }
 
-    pub const fn new_always_within(
+    pub fn new_sometime_before(
+        later: ConstraintGoalDefinitionInner,
+        earlier: ConstraintGoalDefinitionInner,
+    ) -> Self {
+        Self::sometime_before(later, earlier)
+    }
+
+    #[doc(alias = "new_always_within")]
+    pub const fn always_within(
         number: Number,
         first: ConstraintGoalDefinitionInner,
         second: ConstraintGoalDefinitionInner,
@@ -114,7 +166,16 @@ impl ConstraintGoalDefinition {
         Self::AlwaysWithin(number, first, second)
     }
 
-    pub const fn new_hold_during(
+    pub fn new_always_within(
+        number: Number,
+        first: ConstraintGoalDefinitionInner,
+        second: ConstraintGoalDefinitionInner,
+    ) -> Self {
+        Self::always_within(number, first, second)
+    }
+
+    #[doc(alias = "new_hold_during")]
+    pub const fn hold_during(
         begin: Number,
         end: Number,
         gd: ConstraintGoalDefinitionInner,
@@ -122,8 +183,17 @@ impl ConstraintGoalDefinition {
         Self::HoldDuring(begin, end, gd)
     }
 
-    pub const fn new_hold_after(number: Number, gd: ConstraintGoalDefinitionInner) -> Self {
+    pub fn new_hold_during(begin: Number, end: Number, gd: ConstraintGoalDefinitionInner) -> Self {
+        Self::hold_during(begin, end, gd)
+    }
+
+    #[doc(alias = "new_hold_after")]
+    pub const fn hold_after(number: Number, gd: ConstraintGoalDefinitionInner) -> Self {
         Self::HoldAfter(number, gd)
+    }
+
+    pub fn new_hold_after(number: Number, gd: ConstraintGoalDefinitionInner) -> Self {
+        Self::hold_after(number, gd)
     }
 
     pub fn is_empty(&self) -> bool {
@@ -145,12 +215,22 @@ impl ConstraintGoalDefinition {
 }
 
 impl ConstraintGoalDefinitionInner {
-    pub fn new_nested(gd: ConstraintGoalDefinition) -> Self {
+    #[doc(alias = "new_nested")]
+    pub fn nested(gd: ConstraintGoalDefinition) -> Self {
         Self::Nested(Box::new(gd))
     }
 
-    pub const fn new_goal(gd: GoalDefinition) -> Self {
+    pub fn new_nested(gd: ConstraintGoalDefinition) -> Self {
+        Self::nested(gd)
+    }
+
+    #[doc(alias = "new_goal")]
+    pub const fn goal(gd: GoalDefinition) -> Self {
         Self::Goal(gd)
+    }
+
+    pub fn new_goal(gd: GoalDefinition) -> Self {
+        Self::goal(gd)
     }
 
     pub fn is_empty(&self) -> bool {
@@ -163,12 +243,72 @@ impl ConstraintGoalDefinitionInner {
 
 impl From<ConstraintGoalDefinition> for ConstraintGoalDefinitionInner {
     fn from(value: ConstraintGoalDefinition) -> Self {
-        ConstraintGoalDefinitionInner::new_nested(value)
+        ConstraintGoalDefinitionInner::nested(value)
     }
 }
 
 impl From<GoalDefinition> for ConstraintGoalDefinitionInner {
     fn from(value: GoalDefinition) -> Self {
-        ConstraintGoalDefinitionInner::new_goal(value)
+        ConstraintGoalDefinitionInner::goal(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constraint_goal_definition_is_empty() {
+        let empty = ConstraintGoalDefinition::default();
+        assert!(empty.is_empty());
+
+        let gd = GoalDefinition::and(Vec::new());
+        let non_empty = ConstraintGoalDefinition::at_end(gd);
+        assert!(non_empty.is_empty());
+    }
+
+    #[test]
+    fn constraint_goal_definition_is_empty_nested() {
+        let inner = ConstraintGoalDefinitionInner::goal(GoalDefinition::and(Vec::new()));
+        let always = ConstraintGoalDefinition::always(inner);
+        assert!(always.is_empty());
+    }
+
+    #[test]
+    fn constraint_goal_definition_inner_is_empty() {
+        let goal_inner = ConstraintGoalDefinitionInner::goal(GoalDefinition::and(Vec::new()));
+        assert!(goal_inner.is_empty());
+
+        let nested = ConstraintGoalDefinitionInner::nested(ConstraintGoalDefinition::default());
+        assert!(nested.is_empty());
+    }
+
+    #[test]
+    fn constraint_goal_definition_constructors() {
+        let inner = ConstraintGoalDefinitionInner::goal(GoalDefinition::and(Vec::new()));
+
+        let _ = ConstraintGoalDefinition::sometime(inner.clone());
+        let _ = ConstraintGoalDefinition::at_most_once(inner.clone());
+        let _ = ConstraintGoalDefinition::sometime_after(inner.clone(), inner.clone());
+        let _ = ConstraintGoalDefinition::sometime_before(inner.clone(), inner.clone());
+        let _ =
+            ConstraintGoalDefinition::always_within(Number::from(5), inner.clone(), inner.clone());
+        let _ =
+            ConstraintGoalDefinition::hold_during(Number::from(0), Number::from(10), inner.clone());
+        let _ = ConstraintGoalDefinition::hold_after(Number::from(5), inner);
+    }
+
+    #[test]
+    fn constraint_goal_definition_inner_from() {
+        let gd = GoalDefinition::and(Vec::new());
+        let from_gd: ConstraintGoalDefinitionInner = gd.clone().into();
+        assert!(matches!(from_gd, ConstraintGoalDefinitionInner::Goal(_)));
+
+        let con_gd = ConstraintGoalDefinition::default();
+        let from_con_gd: ConstraintGoalDefinitionInner = con_gd.into();
+        assert!(matches!(
+            from_con_gd,
+            ConstraintGoalDefinitionInner::Nested(_)
+        ));
     }
 }

--- a/src/types/con_gd.rs
+++ b/src/types/con_gd.rs
@@ -311,4 +311,91 @@ mod tests {
             ConstraintGoalDefinitionInner::Nested(_)
         ));
     }
+
+    #[test]
+    #[allow(deprecated)]
+    fn deprecated_new_constructors() {
+        let inner = ConstraintGoalDefinitionInner::goal(GoalDefinition::and(Vec::new()));
+        let num = Number::from(5);
+
+        let _ = ConstraintGoalDefinition::new_and(vec![ConstraintGoalDefinition::default()]);
+        let _ = ConstraintGoalDefinition::new_forall(
+            TypedVariables::default(),
+            ConstraintGoalDefinition::default(),
+        );
+        let _ = ConstraintGoalDefinition::new_at_end(GoalDefinition::and(Vec::new()));
+        let _ = ConstraintGoalDefinition::new_always(inner.clone());
+        let _ = ConstraintGoalDefinition::new_sometime(inner.clone());
+        let _ = ConstraintGoalDefinition::new_within(num, inner.clone());
+        let _ = ConstraintGoalDefinition::new_at_most_once(inner.clone());
+        let _ = ConstraintGoalDefinition::new_sometime_after(inner.clone(), inner.clone());
+        let _ = ConstraintGoalDefinition::new_sometime_before(inner.clone(), inner.clone());
+        let _ = ConstraintGoalDefinition::new_always_within(num, inner.clone(), inner.clone());
+        let _ = ConstraintGoalDefinition::new_hold_during(
+            Number::from(0),
+            Number::from(10),
+            inner.clone(),
+        );
+        let _ = ConstraintGoalDefinition::new_hold_after(num, inner.clone());
+
+        // ConstraintGoalDefinitionInner
+        let _ = ConstraintGoalDefinitionInner::new_nested(ConstraintGoalDefinition::default());
+        let _ = ConstraintGoalDefinitionInner::new_goal(GoalDefinition::and(Vec::new()));
+    }
+
+    #[test]
+    fn is_empty_non_empty_variants() {
+        use crate::types::{AtomicFormula, Predicate, Term};
+
+        let term = Term::new_name(crate::types::Name::new("x"));
+        let atomic = AtomicFormula::predicate(Predicate::string("at"), vec![term]);
+        let gd = GoalDefinition::AtomicFormula(atomic);
+        let inner = ConstraintGoalDefinitionInner::goal(gd.clone());
+
+        let always = ConstraintGoalDefinition::always(inner.clone());
+        assert!(!always.is_empty());
+
+        let sometime = ConstraintGoalDefinition::sometime(inner.clone());
+        assert!(!sometime.is_empty());
+
+        let within = ConstraintGoalDefinition::within(Number::from(5), inner.clone());
+        assert!(!within.is_empty());
+
+        let at_most_once = ConstraintGoalDefinition::at_most_once(inner.clone());
+        assert!(!at_most_once.is_empty());
+
+        let sometime_after = ConstraintGoalDefinition::sometime_after(inner.clone(), inner.clone());
+        assert!(!sometime_after.is_empty());
+
+        let sometime_before =
+            ConstraintGoalDefinition::sometime_before(inner.clone(), inner.clone());
+        assert!(!sometime_before.is_empty());
+
+        let always_within =
+            ConstraintGoalDefinition::always_within(Number::from(5), inner.clone(), inner.clone());
+        assert!(!always_within.is_empty());
+
+        let hold_during =
+            ConstraintGoalDefinition::hold_during(Number::from(0), Number::from(10), inner.clone());
+        assert!(!hold_during.is_empty());
+
+        let hold_after = ConstraintGoalDefinition::hold_after(Number::from(5), inner);
+        assert!(!hold_after.is_empty());
+
+        let at_end = ConstraintGoalDefinition::at_end(gd);
+        assert!(!at_end.is_empty());
+
+        let nested_inner = ConstraintGoalDefinitionInner::nested(ConstraintGoalDefinition::at_end(
+            GoalDefinition::and(vec![GoalDefinition::AtomicFormula(
+                AtomicFormula::predicate(
+                    Predicate::string("on"),
+                    vec![
+                        Term::new_name(crate::types::Name::new("a")),
+                        Term::new_name(crate::types::Name::new("b")),
+                    ],
+                ),
+            )]),
+        ));
+        assert!(!nested_inner.is_empty());
+    }
 }

--- a/src/types/conditional_effect.rs
+++ b/src/types/conditional_effect.rs
@@ -24,8 +24,14 @@ impl EffectCondition {
     pub const fn new(effect: PrimitiveEffect) -> Self {
         Self::Single(effect)
     }
-    pub const fn new_and(effect: Vec<PrimitiveEffect>) -> Self {
+
+    pub const fn all(effect: Vec<PrimitiveEffect>) -> Self {
         Self::All(effect)
+    }
+
+    #[deprecated(since = "0.2.0", note = "Use `all` instead")]
+    pub const fn new_and(effect: Vec<PrimitiveEffect>) -> Self {
+        Self::all(effect)
     }
 }
 
@@ -49,13 +55,13 @@ impl From<PrimitiveEffect> for EffectCondition {
 
 impl From<Vec<PrimitiveEffect>> for EffectCondition {
     fn from(value: Vec<PrimitiveEffect>) -> Self {
-        EffectCondition::new_and(value)
+        EffectCondition::all(value)
     }
 }
 
 impl FromIterator<PrimitiveEffect> for EffectCondition {
     fn from_iter<T: IntoIterator<Item = PrimitiveEffect>>(iter: T) -> Self {
-        EffectCondition::new_and(iter.into_iter().collect())
+        EffectCondition::all(iter.into_iter().collect())
     }
 }
 

--- a/src/types/conditional_effect.rs
+++ b/src/types/conditional_effect.rs
@@ -1,56 +1,61 @@
-//! Contains conditional effects via the [`ConditionalEffect`] type.
+//! Contains effect conditions via the [`EffectCondition`] type.
 
 use crate::types::iterators::FlatteningIntoIterator;
-use crate::types::PEffect;
+use crate::types::PrimitiveEffect;
 
-/// A conditional effect as used by [`CEffect::When`](crate::types::CEffect::When) and [`TimedEffect::Conditional`](crate::types::TimedEffect::Conditional).
+/// An effect condition as used by [`WhenConditionalEffect::effect`](crate::types::WhenConditionalEffect::effect) and [`TimedEffect::Conditional`](crate::types::TimedEffect::Conditional).
+///
+/// # BNF
+/// Corresponds to `<conditional-effect>` in the PDDL 3.1 specification.
 ///
 /// ## Usage
-/// Used by [`CEffect`](crate::CEffect) and [`TimedEffect`](crate::types::TimedEffect).
+/// Used by [`WhenConditionalEffect`](crate::WhenConditionalEffect) and [`TimedEffect`](crate::types::TimedEffect).
+#[doc(alias("conditional-effect"))]
+#[doc(alias("ConditionalEffect"))]
 #[derive(Debug, Clone, PartialEq)]
-pub enum ConditionalEffect {
+pub enum EffectCondition {
     /// Exactly the specified effect applies.
-    Single(PEffect), // TODO: Unify with `All`; vector is allowed to be empty.
+    Single(PrimitiveEffect), // TODO: Unify with `All`; vector is allowed to be empty.
     /// Conjunction: All effects apply (i.e. a and b and c ..).
-    All(Vec<PEffect>),
+    All(Vec<PrimitiveEffect>),
 }
 
-impl ConditionalEffect {
-    pub const fn new(effect: PEffect) -> Self {
+impl EffectCondition {
+    pub const fn new(effect: PrimitiveEffect) -> Self {
         Self::Single(effect)
     }
-    pub const fn new_and(effect: Vec<PEffect>) -> Self {
+    pub const fn new_and(effect: Vec<PrimitiveEffect>) -> Self {
         Self::All(effect)
     }
 }
 
-impl IntoIterator for ConditionalEffect {
-    type Item = PEffect;
+impl IntoIterator for EffectCondition {
+    type Item = PrimitiveEffect;
     type IntoIter = FlatteningIntoIterator<Self::Item>;
 
     fn into_iter(self) -> Self::IntoIter {
         match self {
-            ConditionalEffect::Single(item) => FlatteningIntoIterator::new(item),
-            ConditionalEffect::All(vec) => FlatteningIntoIterator::new_vec(vec),
+            EffectCondition::Single(item) => FlatteningIntoIterator::new(item),
+            EffectCondition::All(vec) => FlatteningIntoIterator::new_vec(vec),
         }
     }
 }
 
-impl From<PEffect> for ConditionalEffect {
-    fn from(value: PEffect) -> Self {
-        ConditionalEffect::new(value)
+impl From<PrimitiveEffect> for EffectCondition {
+    fn from(value: PrimitiveEffect) -> Self {
+        EffectCondition::new(value)
     }
 }
 
-impl From<Vec<PEffect>> for ConditionalEffect {
-    fn from(value: Vec<PEffect>) -> Self {
-        ConditionalEffect::new_and(value)
+impl From<Vec<PrimitiveEffect>> for EffectCondition {
+    fn from(value: Vec<PrimitiveEffect>) -> Self {
+        EffectCondition::new_and(value)
     }
 }
 
-impl FromIterator<PEffect> for ConditionalEffect {
-    fn from_iter<T: IntoIterator<Item = PEffect>>(iter: T) -> Self {
-        ConditionalEffect::new_and(iter.into_iter().collect())
+impl FromIterator<PrimitiveEffect> for EffectCondition {
+    fn from_iter<T: IntoIterator<Item = PrimitiveEffect>>(iter: T) -> Self {
+        EffectCondition::new_and(iter.into_iter().collect())
     }
 }
 
@@ -62,19 +67,19 @@ mod tests {
 
     #[test]
     fn flatten_with_single_element_works() {
-        let (_, effect_a) = PEffect::parse(Span::new("(= x y)")).unwrap();
+        let (_, effect_a) = PrimitiveEffect::parse(Span::new("(= x y)")).unwrap();
 
-        let mut iter = ConditionalEffect::new(effect_a).into_iter();
+        let mut iter = EffectCondition::new(effect_a).into_iter();
         assert!(iter.next().is_some());
         assert!(iter.next().is_none());
     }
 
     #[test]
     fn flatten_with_many_elements_works() {
-        let (_, effect_a) = PEffect::parse(Span::new("(= x y)")).unwrap();
-        let (_, effect_b) = PEffect::parse(Span::new("(assign fun-sym 1.23)")).unwrap();
+        let (_, effect_a) = PrimitiveEffect::parse(Span::new("(= x y)")).unwrap();
+        let (_, effect_b) = PrimitiveEffect::parse(Span::new("(assign fun-sym 1.23)")).unwrap();
 
-        let mut iter = ConditionalEffect::from_iter([effect_a, effect_b]).into_iter();
+        let mut iter = EffectCondition::from_iter([effect_a, effect_b]).into_iter();
         assert!(iter.next().is_some());
         assert!(iter.next().is_some());
         assert!(iter.next().is_none());

--- a/src/types/d_op.rs
+++ b/src/types/d_op.rs
@@ -1,11 +1,12 @@
-//! Contains the [`DOp`] type.
+//! Contains the [`DurationOperator`] type.
 
 use std::fmt::{Display, Formatter};
 
 /// ## Usage
 /// Used by [`SimpleDurationConstraint`](crate::SimpleDurationConstraint).
+#[doc(alias("d-op"))]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum DOp {
+pub enum DurationOperator {
     Equal,
     /// ## Requirements
     /// Requires [Duration Inequalities](crate::Requirement::DurationInequalities);
@@ -21,17 +22,17 @@ pub mod names {
     pub const LESS_THAN_OR_EQUAL: &str = "<=";
 }
 
-impl Display for DOp {
+impl Display for DurationOperator {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            DOp::Equal => write!(f, "{}", names::EQUAL),
-            DOp::GreaterOrEqual => write!(f, "{}", names::GREATER_OR_EQUAL),
-            DOp::LessThanOrEqual => write!(f, "{}", names::LESS_THAN_OR_EQUAL),
+            DurationOperator::Equal => write!(f, "{}", names::EQUAL),
+            DurationOperator::GreaterOrEqual => write!(f, "{}", names::GREATER_OR_EQUAL),
+            DurationOperator::LessThanOrEqual => write!(f, "{}", names::LESS_THAN_OR_EQUAL),
         }
     }
 }
 
-impl TryFrom<&str> for DOp {
+impl TryFrom<&str> for DurationOperator {
     type Error = ParseError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
@@ -49,3 +50,7 @@ pub enum ParseError {
     #[error("Invalid operation")]
     InvalidOperation,
 }
+
+/// Alias for [`DurationOperator`]; matches BNF `<d-op>`.
+#[deprecated(since = "0.2.0", note = "Use `DurationOperator` instead")]
+pub type DOp = DurationOperator;

--- a/src/types/d_value.rs
+++ b/src/types/d_value.rs
@@ -1,8 +1,8 @@
 //! Contains the [`DurationValue`] type.
 
-use crate::types::{FExp, Number};
+use crate::types::{FluentExpression, Number};
 
-/// A duration value, either a [`Number`] or an [`FExp`](FExp).
+/// A duration value, either a [`Number`] or an [`FluentExpression`](FluentExpression).
 ///
 /// ## Usage
 /// Used by [`SimpleDurationConstraint`](crate::SimpleDurationConstraint).
@@ -13,7 +13,7 @@ pub enum DurationValue {
     /// A function expression that produces the duration value.
     /// ## Requirements
     /// Requires [Numeric Fluents](crate::Requirement::NumericFluents).
-    FExp(FExp),
+    FluentExpression(FluentExpression),
 }
 
 impl DurationValue {
@@ -21,8 +21,8 @@ impl DurationValue {
         Self::Number(number.into())
     }
 
-    pub fn new_f_exp(exp: FExp) -> Self {
-        Self::FExp(exp)
+    pub fn new_f_exp(exp: FluentExpression) -> Self {
+        Self::FluentExpression(exp)
     }
 }
 
@@ -32,8 +32,8 @@ impl From<Number> for DurationValue {
     }
 }
 
-impl From<FExp> for DurationValue {
-    fn from(value: FExp) -> Self {
-        Self::FExp(value)
+impl From<FluentExpression> for DurationValue {
+    fn from(value: FluentExpression) -> Self {
+        Self::FluentExpression(value)
     }
 }

--- a/src/types/d_value.rs
+++ b/src/types/d_value.rs
@@ -17,12 +17,22 @@ pub enum DurationValue {
 }
 
 impl DurationValue {
-    pub fn new_number<I: Into<Number>>(number: I) -> Self {
+    #[doc(alias = "new_number")]
+    pub fn number<I: Into<Number>>(number: I) -> Self {
         Self::Number(number.into())
     }
 
-    pub fn new_f_exp(exp: FluentExpression) -> Self {
+    pub fn new_number<I: Into<Number>>(number: I) -> Self {
+        Self::number(number)
+    }
+
+    #[doc(alias = "new_f_exp")]
+    pub fn fluent_expression(exp: FluentExpression) -> Self {
         Self::FluentExpression(exp)
+    }
+
+    pub fn new_f_exp(exp: FluentExpression) -> Self {
+        Self::fluent_expression(exp)
     }
 }
 
@@ -34,6 +44,25 @@ impl From<Number> for DurationValue {
 
 impl From<FluentExpression> for DurationValue {
     fn from(value: FluentExpression) -> Self {
-        Self::FluentExpression(value)
+        Self::fluent_expression(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn duration_value_from_number() {
+        let n = Number::from(5);
+        let dv: DurationValue = n.into();
+        assert_eq!(dv, DurationValue::number(n));
+    }
+
+    #[test]
+    fn duration_value_from_f_exp() {
+        let exp = FluentExpression::number(Number::from(10));
+        let dv: DurationValue = exp.clone().into();
+        assert_eq!(dv, DurationValue::fluent_expression(exp));
     }
 }

--- a/src/types/da_effect.rs
+++ b/src/types/da_effect.rs
@@ -81,3 +81,85 @@ impl From<(DurativeActionGoalDefinition, TimedEffect)> for DurativeActionEffect 
         Self::when(value.0, value.1)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{
+        AtomicFormula, EffectCondition, GoalDefinition, Name, Predicate,
+        PreferenceTimedGoalDefinition, PrimitiveEffect, Term, TimeSpecifier, TimedGoalDefinition,
+        TypedVariables,
+    };
+
+    fn make_timed_effect() -> TimedEffect {
+        let af = AtomicFormula::<Term>::predicate(
+            Predicate::string("on"),
+            vec![Term::new_name(Name::new("a"))],
+        );
+        let ec = EffectCondition::new(PrimitiveEffect::atomic_formula(af));
+        TimedEffect::conditional(TimeSpecifier::Start, ec)
+    }
+
+    fn make_da_effect() -> DurativeActionEffect {
+        DurativeActionEffect::timed(make_timed_effect())
+    }
+
+    fn make_da_gd() -> DurativeActionGoalDefinition {
+        let af = AtomicFormula::<Term>::predicate(
+            Predicate::string("clear"),
+            vec![Term::new_name(Name::new("b"))],
+        );
+        let timed_gd =
+            TimedGoalDefinition::at(TimeSpecifier::Start, GoalDefinition::AtomicFormula(af));
+        let pref_timed = PreferenceTimedGoalDefinition::required(timed_gd);
+        DurativeActionGoalDefinition::timed(pref_timed)
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn deprecated_new_constructors() {
+        let effect = make_timed_effect();
+        let _ = DurativeActionEffect::new_timed(effect.clone());
+        let _ = DurativeActionEffect::new_and(vec![DurativeActionEffect::timed(effect.clone())]);
+        let _ = DurativeActionEffect::new_forall(
+            TypedVariables::default(),
+            DurativeActionEffect::timed(effect.clone()),
+        );
+        let da_gd = make_da_gd();
+        let _ = DurativeActionEffect::new_when(da_gd, effect);
+    }
+
+    #[test]
+    fn from_timed_effect() {
+        let effect = make_timed_effect();
+        let from_effect: DurativeActionEffect = effect.clone().into();
+        assert_eq!(from_effect, DurativeActionEffect::timed(effect));
+    }
+
+    #[test]
+    fn from_iterator() {
+        let effect = make_da_effect();
+        let from_iter: DurativeActionEffect =
+            vec![effect.clone(), effect.clone()].into_iter().collect();
+        assert_eq!(
+            from_iter,
+            DurativeActionEffect::and(vec![effect, make_da_effect()])
+        );
+    }
+
+    #[test]
+    fn from_tuple_forall() {
+        let effect = make_da_effect();
+        let vars = TypedVariables::default();
+        let from_tuple: DurativeActionEffect = (vars.clone(), effect.clone()).into();
+        assert_eq!(from_tuple, DurativeActionEffect::r#forall(vars, effect));
+    }
+
+    #[test]
+    fn from_tuple_when() {
+        let effect = make_timed_effect();
+        let da_gd = make_da_gd();
+        let from_tuple: DurativeActionEffect = (da_gd.clone(), effect.clone()).into();
+        assert_eq!(from_tuple, DurativeActionEffect::when(da_gd, effect));
+    }
+}

--- a/src/types/da_effect.rs
+++ b/src/types/da_effect.rs
@@ -21,40 +21,63 @@ pub enum DurativeActionEffect {
 }
 
 impl DurativeActionEffect {
-    pub const fn new_timed(effect: TimedEffect) -> Self {
+    #[doc(alias = "new_timed")]
+    pub const fn timed(effect: TimedEffect) -> Self {
         Self::Timed(effect)
     }
-    pub fn new_and<E: IntoIterator<Item = DurativeActionEffect>>(effect: E) -> Self {
+
+    pub fn new_timed(effect: TimedEffect) -> Self {
+        Self::timed(effect)
+    }
+
+    #[doc(alias = "new_and")]
+    pub fn and<E: IntoIterator<Item = DurativeActionEffect>>(effect: E) -> Self {
         Self::All(effect.into_iter().collect())
     }
-    pub fn new_forall(variables: TypedVariables, effect: DurativeActionEffect) -> Self {
+
+    pub fn new_and<E: IntoIterator<Item = DurativeActionEffect>>(effect: E) -> Self {
+        Self::and(effect)
+    }
+
+    #[doc(alias = "new_forall")]
+    pub fn r#forall(variables: TypedVariables, effect: DurativeActionEffect) -> Self {
         Self::Forall(variables, Box::new(effect))
     }
-    pub const fn new_when(gd: DurativeActionGoalDefinition, effect: TimedEffect) -> Self {
+
+    pub fn new_forall(variables: TypedVariables, effect: DurativeActionEffect) -> Self {
+        Self::r#forall(variables, effect)
+    }
+
+    #[doc(alias = "new_when")]
+    pub const fn when(gd: DurativeActionGoalDefinition, effect: TimedEffect) -> Self {
         Self::When(gd, effect)
+    }
+
+    pub fn new_when(gd: DurativeActionGoalDefinition, effect: TimedEffect) -> Self {
+        Self::when(gd, effect)
     }
 }
 
 impl From<TimedEffect> for DurativeActionEffect {
     fn from(value: TimedEffect) -> Self {
-        Self::new_timed(value)
+        Self::timed(value)
     }
 }
 
 impl FromIterator<DurativeActionEffect> for DurativeActionEffect {
     fn from_iter<T: IntoIterator<Item = DurativeActionEffect>>(iter: T) -> Self {
-        Self::new_and(iter)
+        Self::and(iter)
     }
 }
 
 impl From<(TypedVariables, DurativeActionEffect)> for DurativeActionEffect {
     fn from(value: (TypedVariables, DurativeActionEffect)) -> Self {
-        Self::new_forall(value.0, value.1)
+        Self::r#forall(value.0, value.1)
     }
 }
 
 impl From<(DurativeActionGoalDefinition, TimedEffect)> for DurativeActionEffect {
     fn from(value: (DurativeActionGoalDefinition, TimedEffect)) -> Self {
-        Self::new_when(value.0, value.1)
+        Self::when(value.0, value.1)
     }
 }

--- a/src/types/da_gd.rs
+++ b/src/types/da_gd.rs
@@ -1,6 +1,6 @@
 //! Contains durative action goal definitions via the [`DurativeActionGoalDefinition`] type.
 
-use crate::types::PrefTimedGD;
+use crate::types::PreferenceTimedGoalDefinition;
 use crate::types::TypedVariables;
 
 /// A durative action goal definition.
@@ -10,7 +10,7 @@ use crate::types::TypedVariables;
 /// [`DurativeActionEffect`](crate::DurativeActionEffect).
 #[derive(Debug, Clone, PartialEq)]
 pub enum DurativeActionGoalDefinition {
-    Timed(PrefTimedGD),
+    Timed(PreferenceTimedGoalDefinition),
     And(Vec<DurativeActionGoalDefinition>),
     /// ## Requirements
     /// Requires [Universal Preconditions](crate::Requirement::UniversalPreconditions).
@@ -18,7 +18,7 @@ pub enum DurativeActionGoalDefinition {
 }
 
 impl DurativeActionGoalDefinition {
-    pub fn new_timed(pref: PrefTimedGD) -> Self {
+    pub fn new_timed(pref: PreferenceTimedGoalDefinition) -> Self {
         Self::Timed(pref)
     }
     pub fn new_and<I: IntoIterator<Item = DurativeActionGoalDefinition>>(prefs: I) -> Self {
@@ -29,8 +29,8 @@ impl DurativeActionGoalDefinition {
     }
 }
 
-impl From<PrefTimedGD> for DurativeActionGoalDefinition {
-    fn from(value: PrefTimedGD) -> Self {
+impl From<PreferenceTimedGoalDefinition> for DurativeActionGoalDefinition {
+    fn from(value: PreferenceTimedGoalDefinition) -> Self {
         DurativeActionGoalDefinition::new_timed(value)
     }
 }

--- a/src/types/da_gd.rs
+++ b/src/types/da_gd.rs
@@ -18,19 +18,36 @@ pub enum DurativeActionGoalDefinition {
 }
 
 impl DurativeActionGoalDefinition {
-    pub fn new_timed(pref: PreferenceTimedGoalDefinition) -> Self {
+    #[doc(alias = "new_timed")]
+    pub fn timed(pref: PreferenceTimedGoalDefinition) -> Self {
         Self::Timed(pref)
     }
-    pub fn new_and<I: IntoIterator<Item = DurativeActionGoalDefinition>>(prefs: I) -> Self {
+
+    pub fn new_timed(pref: PreferenceTimedGoalDefinition) -> Self {
+        Self::timed(pref)
+    }
+
+    #[doc(alias = "new_and")]
+    pub fn and<I: IntoIterator<Item = DurativeActionGoalDefinition>>(prefs: I) -> Self {
         Self::And(prefs.into_iter().collect())
     }
-    pub fn new_forall(variables: TypedVariables, gd: DurativeActionGoalDefinition) -> Self {
+
+    pub fn new_and<I: IntoIterator<Item = DurativeActionGoalDefinition>>(prefs: I) -> Self {
+        Self::and(prefs)
+    }
+
+    #[doc(alias = "new_forall")]
+    pub fn r#forall(variables: TypedVariables, gd: DurativeActionGoalDefinition) -> Self {
         Self::Forall(variables, Box::new(gd))
+    }
+
+    pub fn new_forall(variables: TypedVariables, gd: DurativeActionGoalDefinition) -> Self {
+        Self::r#forall(variables, gd)
     }
 }
 
 impl From<PreferenceTimedGoalDefinition> for DurativeActionGoalDefinition {
     fn from(value: PreferenceTimedGoalDefinition) -> Self {
-        DurativeActionGoalDefinition::new_timed(value)
+        DurativeActionGoalDefinition::timed(value)
     }
 }

--- a/src/types/da_symbol.rs
+++ b/src/types/da_symbol.rs
@@ -17,8 +17,14 @@ impl DurativeActionSymbol {
     }
 
     #[inline(always)]
-    pub fn new_string(name: &str) -> Self {
+    #[doc(alias = "new_string")]
+    pub fn string(name: &str) -> Self {
         Self(Name::new(name))
+    }
+
+    #[inline(always)]
+    pub fn new_string(name: &str) -> Self {
+        Self::string(name)
     }
 
     #[inline(always)]

--- a/src/types/domain.rs
+++ b/src/types/domain.rs
@@ -1,7 +1,7 @@
 //! Contains the [`Domain`] type.
 
 use crate::types::{
-    ConGD, Constants, DomainConstraintsDef, Functions, PredicateDefinitions, Requirements,
+    ConstraintGoalDefinition, Constants, DomainConstraintsDef, Functions, PredicateDefinitions, Requirements,
     StructureDefs, Timeless,
 };
 use crate::types::{Name, Types};
@@ -209,7 +209,7 @@ impl Domain {
     }
 
     /// Returns the optional constraint declaration.
-    pub const fn constraints(&self) -> &ConGD {
+    pub const fn constraints(&self) -> &ConstraintGoalDefinition {
         self.constraints.value()
     }
 

--- a/src/types/domain.rs
+++ b/src/types/domain.rs
@@ -1,8 +1,8 @@
 //! Contains the [`Domain`] type.
 
 use crate::types::{
-    ConstraintGoalDefinition, Constants, DomainConstraintsDef, Functions, PredicateDefinitions, Requirements,
-    StructureDefs, Timeless,
+    Constants, ConstraintGoalDefinition, DomainConstraintsDef, Functions, PredicateDefinitions,
+    Requirements, StructureDefs, Timeless,
 };
 use crate::types::{Name, Types};
 

--- a/src/types/domain_constraints_def.rs
+++ b/src/types/domain_constraints_def.rs
@@ -1,9 +1,9 @@
 //! Contains the [`DomainConstraintsDef`] type.
 
-use crate::types::ConGD;
+use crate::types::ConstraintGoalDefinition;
 use std::ops::Deref;
 
-/// A domain constraints definition; wraps a [`ConGD`].
+/// A domain constraints definition; wraps a [`ConstraintGoalDefinition`].
 ///
 /// ## Requirements
 /// Requires [Constraints](crate::Requirement::Constraints).
@@ -11,40 +11,40 @@ use std::ops::Deref;
 /// ## Usage
 /// Used by [`Domain`](crate::Domain).
 #[derive(Debug, Default, Clone, PartialEq)]
-pub struct DomainConstraintsDef(ConGD);
+pub struct DomainConstraintsDef(ConstraintGoalDefinition);
 
 impl DomainConstraintsDef {
-    pub const fn new(gd: ConGD) -> Self {
+    pub const fn new(gd: ConstraintGoalDefinition) -> Self {
         Self(gd)
     }
 
     /// Gets the value.
-    pub const fn value(&self) -> &ConGD {
+    pub const fn value(&self) -> &ConstraintGoalDefinition {
         &self.0
     }
 }
 
-impl PartialEq<ConGD> for DomainConstraintsDef {
-    fn eq(&self, other: &ConGD) -> bool {
+impl PartialEq<ConstraintGoalDefinition> for DomainConstraintsDef {
+    fn eq(&self, other: &ConstraintGoalDefinition) -> bool {
         self.0.eq(other)
     }
 }
 
-impl From<ConGD> for DomainConstraintsDef {
-    fn from(value: ConGD) -> Self {
+impl From<ConstraintGoalDefinition> for DomainConstraintsDef {
+    fn from(value: ConstraintGoalDefinition) -> Self {
         Self::new(value)
     }
 }
 
 impl Deref for DomainConstraintsDef {
-    type Target = ConGD;
+    type Target = ConstraintGoalDefinition;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl From<DomainConstraintsDef> for ConGD {
+impl From<DomainConstraintsDef> for ConstraintGoalDefinition {
     fn from(val: DomainConstraintsDef) -> Self {
         val.0
     }

--- a/src/types/domain_constraints_def.rs
+++ b/src/types/domain_constraints_def.rs
@@ -49,3 +49,23 @@ impl From<DomainConstraintsDef> for ConstraintGoalDefinition {
         val.0
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn domain_constraints_def_from_con_gd() {
+        let gd = ConstraintGoalDefinition::default();
+        let dcd: DomainConstraintsDef = gd.clone().into();
+        assert_eq!(*dcd, gd);
+    }
+
+    #[test]
+    fn domain_constraints_def_into_con_gd() {
+        let gd = ConstraintGoalDefinition::default();
+        let dcd = DomainConstraintsDef::new(gd.clone());
+        let back: ConstraintGoalDefinition = dcd.into();
+        assert_eq!(back, gd);
+    }
+}

--- a/src/types/duration_constraint.rs
+++ b/src/types/duration_constraint.rs
@@ -30,10 +30,15 @@ impl DurationConstraint {
         Self::Single(constraint)
     }
 
-    pub fn new_all<I: IntoIterator<Item = SimpleDurationConstraint>>(constraints: I) -> Self {
+    #[doc(alias = "new_all")]
+    pub fn all<I: IntoIterator<Item = SimpleDurationConstraint>>(constraints: I) -> Self {
         let vec: Vec<_> = constraints.into_iter().collect();
         debug_assert!(!vec.is_empty());
         Self::All(vec)
+    }
+
+    pub fn new_all<I: IntoIterator<Item = SimpleDurationConstraint>>(constraints: I) -> Self {
+        Self::all(constraints)
     }
 
     pub fn len(&self) -> usize {
@@ -59,7 +64,7 @@ impl From<SimpleDurationConstraint> for DurationConstraint {
 
 impl FromIterator<SimpleDurationConstraint> for DurationConstraint {
     fn from_iter<T: IntoIterator<Item = SimpleDurationConstraint>>(iter: T) -> Self {
-        DurationConstraint::new_all(iter)
+        DurationConstraint::all(iter)
     }
 }
 

--- a/src/types/effects.rs
+++ b/src/types/effects.rs
@@ -20,8 +20,13 @@ impl Effects {
     }
 
     /// Constructs a new instance from the provided vector of values.
-    pub fn new_and(effects: Vec<ConditionalEffect>) -> Self {
+    #[doc(alias = "new_and")]
+    pub fn and(effects: Vec<ConditionalEffect>) -> Self {
         Self(effects)
+    }
+
+    pub fn new_and(effects: Vec<ConditionalEffect>) -> Self {
+        Self::and(effects)
     }
 
     /// Returns `true` if the list contains no elements.
@@ -84,13 +89,13 @@ impl From<ConditionalEffect> for Effects {
 
 impl From<Vec<ConditionalEffect>> for Effects {
     fn from(value: Vec<ConditionalEffect>) -> Self {
-        Effects::new_and(value)
+        Effects::and(value)
     }
 }
 
 impl FromIterator<ConditionalEffect> for Effects {
     fn from_iter<T: IntoIterator<Item = ConditionalEffect>>(iter: T) -> Self {
-        Effects::new_and(iter.into_iter().collect())
+        Effects::and(iter.into_iter().collect())
     }
 }
 
@@ -99,5 +104,60 @@ impl TryInto<ConditionalEffect> for Effects {
 
     fn try_into(self) -> Result<ConditionalEffect, Self::Error> {
         self.try_get_single().ok_or(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{AtomicFormula, PrimitiveEffect, Term};
+
+    #[test]
+    fn effects_try_get_single_with_one() {
+        let pe = PrimitiveEffect::new(AtomicFormula::new_equality(
+            Term::Name("x".into()),
+            Term::Name("y".into()),
+        ));
+        let effects = Effects::new(ConditionalEffect::new_primitive_effect(pe));
+        assert!(effects.try_get_single().is_some());
+    }
+
+    #[test]
+    fn effects_try_get_single_with_zero() {
+        let effects = Effects::default();
+        assert!(effects.try_get_single().is_none());
+    }
+
+    #[test]
+    fn effects_try_get_single_with_many() {
+        let pe1 = PrimitiveEffect::new(AtomicFormula::equality(
+            Term::Name("x".into()),
+            Term::Name("y".into()),
+        ));
+        let pe2 = PrimitiveEffect::new(AtomicFormula::equality(
+            Term::Name("a".into()),
+            Term::Name("b".into()),
+        ));
+        let effects = Effects::and(vec![
+            ConditionalEffect::new_primitive_effect(pe1),
+            ConditionalEffect::new_primitive_effect(pe2),
+        ]);
+        assert!(effects.try_get_single().is_none());
+    }
+
+    #[test]
+    fn effects_try_into() {
+        let pe = PrimitiveEffect::new(AtomicFormula::new_equality(
+            Term::Name("x".into()),
+            Term::Name("y".into()),
+        ));
+        let effects = Effects::new(ConditionalEffect::new_primitive_effect(pe));
+        let result: Result<ConditionalEffect, ()> = effects.try_into();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn effects_from_vec() {
+        let _ = Effects::from(Vec::<ConditionalEffect>::new());
     }
 }

--- a/src/types/effects.rs
+++ b/src/types/effects.rs
@@ -1,6 +1,6 @@
 //! Contains effects via the [`Effects`] type.
 
-use crate::types::CEffect;
+use crate::types::ConditionalEffect;
 use std::ops::Deref;
 
 /// An effect. Occurs e.g. in a [`ActionDefinition`](crate::types::ActionDefinition).
@@ -11,16 +11,16 @@ use std::ops::Deref;
 /// ## Usage
 /// Used by [`ActionDefinition`](crate::ActionDefinition).
 #[derive(Debug, Clone, PartialEq, Default)]
-pub struct Effects(Vec<CEffect>);
+pub struct Effects(Vec<ConditionalEffect>);
 
 impl Effects {
     /// Constructs a new instance from the value.
-    pub fn new(effect: CEffect) -> Self {
+    pub fn new(effect: ConditionalEffect) -> Self {
         Self(vec![effect])
     }
 
     /// Constructs a new instance from the provided vector of values.
-    pub fn new_and(effects: Vec<CEffect>) -> Self {
+    pub fn new_and(effects: Vec<ConditionalEffect>) -> Self {
         Self(effects)
     }
 
@@ -38,13 +38,13 @@ impl Effects {
     /// Returns an iterator over the list.
     ///
     /// The iterator yields all items from start to end.
-    pub fn iter(&self) -> std::slice::Iter<'_, CEffect> {
+    pub fn iter(&self) -> std::slice::Iter<'_, ConditionalEffect> {
         self.0.iter()
     }
 
     /// Get the only element of this list if the list has
     /// exactly one element. Returns [`None`] in all other cases.
-    pub fn try_get_single(self) -> Option<CEffect> {
+    pub fn try_get_single(self) -> Option<ConditionalEffect> {
         if self.len() == 1 {
             self.into_iter().next()
         } else {
@@ -54,7 +54,7 @@ impl Effects {
 }
 
 impl IntoIterator for Effects {
-    type Item = CEffect;
+    type Item = ConditionalEffect;
     type IntoIter = std::vec::IntoIter<Self::Item>;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -63,41 +63,41 @@ impl IntoIterator for Effects {
 }
 
 impl Deref for Effects {
-    type Target = [CEffect];
+    type Target = [ConditionalEffect];
 
     fn deref(&self) -> &Self::Target {
         self.0.as_slice()
     }
 }
 
-impl AsRef<[CEffect]> for Effects {
-    fn as_ref(&self) -> &[CEffect] {
+impl AsRef<[ConditionalEffect]> for Effects {
+    fn as_ref(&self) -> &[ConditionalEffect] {
         self.0.as_slice()
     }
 }
 
-impl From<CEffect> for Effects {
-    fn from(value: CEffect) -> Self {
+impl From<ConditionalEffect> for Effects {
+    fn from(value: ConditionalEffect) -> Self {
         Effects::new(value)
     }
 }
 
-impl From<Vec<CEffect>> for Effects {
-    fn from(value: Vec<CEffect>) -> Self {
+impl From<Vec<ConditionalEffect>> for Effects {
+    fn from(value: Vec<ConditionalEffect>) -> Self {
         Effects::new_and(value)
     }
 }
 
-impl FromIterator<CEffect> for Effects {
-    fn from_iter<T: IntoIterator<Item = CEffect>>(iter: T) -> Self {
+impl FromIterator<ConditionalEffect> for Effects {
+    fn from_iter<T: IntoIterator<Item = ConditionalEffect>>(iter: T) -> Self {
         Effects::new_and(iter.into_iter().collect())
     }
 }
 
-impl TryInto<CEffect> for Effects {
+impl TryInto<ConditionalEffect> for Effects {
     type Error = ();
 
-    fn try_into(self) -> Result<CEffect, Self::Error> {
+    fn try_into(self) -> Result<ConditionalEffect, Self::Error> {
         self.try_get_single().ok_or(())
     }
 }

--- a/src/types/f_assign_da.rs
+++ b/src/types/f_assign_da.rs
@@ -16,7 +16,11 @@ use crate::types::{AssignOp, DurativeActionFluentExpression, FunctionHead};
 pub struct DurativeActionFunctionAssignment(AssignOp, FunctionHead, DurativeActionFluentExpression);
 
 impl DurativeActionFunctionAssignment {
-    pub const fn new(comp: AssignOp, head: FunctionHead, exp: DurativeActionFluentExpression) -> Self {
+    pub const fn new(
+        comp: AssignOp,
+        head: FunctionHead,
+        exp: DurativeActionFluentExpression,
+    ) -> Self {
         Self(comp, head, exp)
     }
 
@@ -36,12 +40,17 @@ impl DurativeActionFunctionAssignment {
     }
 }
 
-impl From<(AssignOp, FunctionHead, DurativeActionFluentExpression)> for DurativeActionFunctionAssignment {
+impl From<(AssignOp, FunctionHead, DurativeActionFluentExpression)>
+    for DurativeActionFunctionAssignment
+{
     fn from(value: (AssignOp, FunctionHead, DurativeActionFluentExpression)) -> Self {
         DurativeActionFunctionAssignment::new(value.0, value.1, value.2)
     }
 }
 
 /// Alias for [`DurativeActionFunctionAssignment`]; matches BNF `<f-assign-da>`.
-#[deprecated(since = "0.2.0", note = "Use `DurativeActionFunctionAssignment` instead")]
+#[deprecated(
+    since = "0.2.0",
+    note = "Use `DurativeActionFunctionAssignment` instead"
+)]
 pub type FAssignDa = DurativeActionFunctionAssignment;

--- a/src/types/f_assign_da.rs
+++ b/src/types/f_assign_da.rs
@@ -1,6 +1,6 @@
-//! Contains the durative action assignment expressions via the [`FAssignDa`] type.
+//! Contains the durative action assignment expressions via the [`DurativeActionFunctionAssignment`] type.
 
-use crate::types::{AssignOp, FExpDa, FHead};
+use crate::types::{AssignOp, DurativeActionFluentExpression, FunctionHead};
 
 /// An timed effect assignment operation. Will perform the
 /// specified assignment `at` [`TimeSpecifier`](crate::TimeSpecifier) when
@@ -11,11 +11,12 @@ use crate::types::{AssignOp, FExpDa, FHead};
 ///
 /// ## Usage
 /// Used by [`TimedEffect`](crate::TimedEffect).
+#[doc(alias("f-assign-da"))]
 #[derive(Debug, Clone, PartialEq)]
-pub struct FAssignDa(AssignOp, FHead, FExpDa);
+pub struct DurativeActionFunctionAssignment(AssignOp, FunctionHead, DurativeActionFluentExpression);
 
-impl FAssignDa {
-    pub const fn new(comp: AssignOp, head: FHead, exp: FExpDa) -> Self {
+impl DurativeActionFunctionAssignment {
+    pub const fn new(comp: AssignOp, head: FunctionHead, exp: DurativeActionFluentExpression) -> Self {
         Self(comp, head, exp)
     }
 
@@ -25,18 +26,22 @@ impl FAssignDa {
     }
 
     /// Returns the function head.
-    pub const fn function(&self) -> &FHead {
+    pub const fn function(&self) -> &FunctionHead {
         &self.1
     }
 
     /// Returns the function expression of the durative action.
-    pub const fn function_expr(&self) -> &FExpDa {
+    pub const fn function_expr(&self) -> &DurativeActionFluentExpression {
         &self.2
     }
 }
 
-impl From<(AssignOp, FHead, FExpDa)> for FAssignDa {
-    fn from(value: (AssignOp, FHead, FExpDa)) -> Self {
-        FAssignDa::new(value.0, value.1, value.2)
+impl From<(AssignOp, FunctionHead, DurativeActionFluentExpression)> for DurativeActionFunctionAssignment {
+    fn from(value: (AssignOp, FunctionHead, DurativeActionFluentExpression)) -> Self {
+        DurativeActionFunctionAssignment::new(value.0, value.1, value.2)
     }
 }
+
+/// Alias for [`DurativeActionFunctionAssignment`]; matches BNF `<f-assign-da>`.
+#[deprecated(since = "0.2.0", note = "Use `DurativeActionFunctionAssignment` instead")]
+pub type FAssignDa = DurativeActionFunctionAssignment;

--- a/src/types/f_comp.rs
+++ b/src/types/f_comp.rs
@@ -1,38 +1,43 @@
-//! Contains function expression comparisons via the [`FComp`] type.
+//! Contains function expression comparisons via the [`FluentComparison`] type.
 
-use crate::types::{BinaryComp, FExp};
+use crate::types::{BinaryComparison, FluentExpression};
 
 /// An fluent comparison used as part of a [`GoalDefinition`](crate::GoalDefinition)
 /// when [`NumericFluents`](crate::Requirement::NumericFluents) is allowed.
 ///
 /// ## Usage
 /// Used by [`GoalDefinition`](crate::GoalDefinition).
+#[doc(alias("f-comp"))]
 #[derive(Debug, Clone, PartialEq)]
-pub struct FComp(BinaryComp, FExp, FExp);
+pub struct FluentComparison(BinaryComparison, FluentExpression, FluentExpression);
 
-impl FComp {
-    pub const fn new(comp: BinaryComp, lhs: FExp, rhs: FExp) -> Self {
+impl FluentComparison {
+    pub const fn new(comp: BinaryComparison, lhs: FluentExpression, rhs: FluentExpression) -> Self {
         Self(comp, lhs, rhs)
     }
 
     /// Returns the comparison operator.
-    pub const fn comparison(&self) -> &BinaryComp {
+    pub const fn comparison(&self) -> &BinaryComparison {
         &self.0
     }
 
     /// Returns the first operand.
-    pub const fn first(&self) -> &FExp {
+    pub const fn first(&self) -> &FluentExpression {
         &self.1
     }
 
     /// Returns the second operand.
-    pub const fn second(&self) -> &FExp {
+    pub const fn second(&self) -> &FluentExpression {
         &self.2
     }
 }
 
-impl From<(BinaryComp, FExp, FExp)> for FComp {
-    fn from(value: (BinaryComp, FExp, FExp)) -> Self {
-        FComp::new(value.0, value.1, value.2)
+impl From<(BinaryComparison, FluentExpression, FluentExpression)> for FluentComparison {
+    fn from(value: (BinaryComparison, FluentExpression, FluentExpression)) -> Self {
+        FluentComparison::new(value.0, value.1, value.2)
     }
 }
+
+/// Alias for [`FluentComparison`]; matches BNF `<f-comp>`.
+#[deprecated(since = "0.2.0", note = "Use `FluentComparison` instead")]
+pub type FComp = FluentComparison;

--- a/src/types/f_exp.rs
+++ b/src/types/f_exp.rs
@@ -27,15 +27,26 @@ pub enum FluentExpression {
 
 impl FluentExpression {
     #[inline(always)]
-    pub fn new_number<N: Into<Number>>(number: N) -> Self {
+    #[doc(alias = "new_number")]
+    pub fn number<N: Into<Number>>(number: N) -> Self {
         Self::Number(number.into())
     }
 
-    pub fn new_binary_op(op: BinaryOp, lhs: FluentExpression, rhs: FluentExpression) -> Self {
+    pub fn new_number<N: Into<Number>>(number: N) -> Self {
+        Self::number(number)
+    }
+
+    #[doc(alias = "new_binary_op")]
+    pub fn binary_op(op: BinaryOp, lhs: FluentExpression, rhs: FluentExpression) -> Self {
         Self::BinaryOp(op, Box::new(lhs), Box::new(rhs))
     }
 
-    pub fn new_multi_op<I: IntoIterator<Item = FluentExpression>>(
+    pub fn new_binary_op(op: BinaryOp, lhs: FluentExpression, rhs: FluentExpression) -> Self {
+        Self::binary_op(op, lhs, rhs)
+    }
+
+    #[doc(alias = "new_multi_op")]
+    pub fn multi_op<I: IntoIterator<Item = FluentExpression>>(
         op: MultiOp,
         lhs: FluentExpression,
         rhs: I,
@@ -43,12 +54,30 @@ impl FluentExpression {
         Self::MultiOp(op, Box::new(lhs), rhs.into_iter().collect())
     }
 
-    pub fn new_negative(value: FluentExpression) -> Self {
+    pub fn new_multi_op<I: IntoIterator<Item = FluentExpression>>(
+        op: MultiOp,
+        lhs: FluentExpression,
+        rhs: I,
+    ) -> Self {
+        Self::multi_op(op, lhs, rhs)
+    }
+
+    #[doc(alias = "new_negative")]
+    pub fn negative(value: FluentExpression) -> Self {
         Self::Negative(Box::new(value))
     }
 
-    pub const fn new_function(f_head: FunctionHead) -> Self {
+    pub fn new_negative(value: FluentExpression) -> Self {
+        Self::negative(value)
+    }
+
+    #[doc(alias = "new_function")]
+    pub const fn function(f_head: FunctionHead) -> Self {
         Self::Function(f_head)
+    }
+
+    pub fn new_function(f_head: FunctionHead) -> Self {
+        Self::function(f_head)
     }
 }
 

--- a/src/types/f_exp.rs
+++ b/src/types/f_exp.rs
@@ -1,6 +1,6 @@
-//! Contains function expressions via the [`FExp`] type.
+//! Contains function expressions via the [`FluentExpression`] type.
 
-use crate::types::{BinaryOp, FHead, MultiOp, Number};
+use crate::types::{BinaryOp, FunctionHead, MultiOp, Number};
 
 /// A function/fluent expression used e.g. in a [`DurationValue`](crate::types::DurationValue).
 ///
@@ -8,41 +8,46 @@ use crate::types::{BinaryOp, FHead, MultiOp, Number};
 /// Requires [Numeric Fluents](crate::Requirement::NumericFluents).
 ///
 /// ## Usage
-/// Used by [`FExp`] itself, as well as [`PEffect`](crate::PEffect), [`DurationValue`](crate::DurationValue),
-/// [`FExpDa`](crate::FExpDa) and [`FExpT`](crate::FExpT).
+/// Used by [`FluentExpression`] itself, as well as [`PrimitiveEffect`](crate::PrimitiveEffect), [`DurationValue`](crate::DurationValue),
+/// [`DurativeActionFluentExpression`](crate::DurativeActionFluentExpression) and [`TimedFluentExpression`](crate::TimedFluentExpression).
+#[doc(alias("f-exp"))]
 #[derive(Debug, Clone, PartialEq)]
-pub enum FExp {
+pub enum FluentExpression {
     /// A numerical expression.
     Number(Number),
     /// A function that derives a value.
-    Function(FHead),
-    /// The negative value of a function expression.
-    Negative(Box<FExp>),
-    /// An operation applied to two function expressions.
-    BinaryOp(BinaryOp, Box<FExp>, Box<FExp>),
-    /// An operation applied to two or more function expressions.
-    MultiOp(MultiOp, Box<FExp>, Vec<FExp>),
+    Function(FunctionHead),
+    /// The negative value of a fluent expression.
+    Negative(Box<FluentExpression>),
+    /// An operation applied to two fluent expressions.
+    BinaryOp(BinaryOp, Box<FluentExpression>, Box<FluentExpression>),
+    /// An operation applied to two or more fluent expressions.
+    MultiOp(MultiOp, Box<FluentExpression>, Vec<FluentExpression>),
 }
 
-impl FExp {
+impl FluentExpression {
     #[inline(always)]
     pub fn new_number<N: Into<Number>>(number: N) -> Self {
         Self::Number(number.into())
     }
 
-    pub fn new_binary_op(op: BinaryOp, lhs: FExp, rhs: FExp) -> Self {
+    pub fn new_binary_op(op: BinaryOp, lhs: FluentExpression, rhs: FluentExpression) -> Self {
         Self::BinaryOp(op, Box::new(lhs), Box::new(rhs))
     }
 
-    pub fn new_multi_op<I: IntoIterator<Item = FExp>>(op: MultiOp, lhs: FExp, rhs: I) -> Self {
+    pub fn new_multi_op<I: IntoIterator<Item = FluentExpression>>(op: MultiOp, lhs: FluentExpression, rhs: I) -> Self {
         Self::MultiOp(op, Box::new(lhs), rhs.into_iter().collect())
     }
 
-    pub fn new_negative(value: FExp) -> Self {
+    pub fn new_negative(value: FluentExpression) -> Self {
         Self::Negative(Box::new(value))
     }
 
-    pub const fn new_function(f_head: FHead) -> Self {
+    pub const fn new_function(f_head: FunctionHead) -> Self {
         Self::Function(f_head)
     }
 }
+
+/// Alias for [`FluentExpression`]; matches BNF `<f-exp>`.
+#[deprecated(since = "0.2.0", note = "Use `FluentExpression` instead")]
+pub type FExp = FluentExpression;

--- a/src/types/f_exp.rs
+++ b/src/types/f_exp.rs
@@ -35,7 +35,11 @@ impl FluentExpression {
         Self::BinaryOp(op, Box::new(lhs), Box::new(rhs))
     }
 
-    pub fn new_multi_op<I: IntoIterator<Item = FluentExpression>>(op: MultiOp, lhs: FluentExpression, rhs: I) -> Self {
+    pub fn new_multi_op<I: IntoIterator<Item = FluentExpression>>(
+        op: MultiOp,
+        lhs: FluentExpression,
+        rhs: I,
+    ) -> Self {
         Self::MultiOp(op, Box::new(lhs), rhs.into_iter().collect())
     }
 

--- a/src/types/f_exp_da.rs
+++ b/src/types/f_exp_da.rs
@@ -26,11 +26,17 @@ pub enum DurativeActionFluentExpression {
 }
 
 impl DurativeActionFluentExpression {
-    pub const fn new_duration() -> Self {
+    #[doc(alias = "new_duration")]
+    pub const fn duration() -> Self {
         Self::Duration
     }
 
-    pub fn new_binary_op(
+    pub fn new_duration() -> Self {
+        Self::duration()
+    }
+
+    #[doc(alias = "new_binary_op")]
+    pub fn binary_op(
         op: BinaryOp,
         lhs: DurativeActionFluentExpression,
         rhs: DurativeActionFluentExpression,
@@ -38,7 +44,16 @@ impl DurativeActionFluentExpression {
         Self::BinaryOp(op, Box::new(lhs), Box::new(rhs))
     }
 
-    pub fn new_multi_op<I: IntoIterator<Item = DurativeActionFluentExpression>>(
+    pub fn new_binary_op(
+        op: BinaryOp,
+        lhs: DurativeActionFluentExpression,
+        rhs: DurativeActionFluentExpression,
+    ) -> Self {
+        Self::binary_op(op, lhs, rhs)
+    }
+
+    #[doc(alias = "new_multi_op")]
+    pub fn multi_op<I: IntoIterator<Item = DurativeActionFluentExpression>>(
         op: MultiOp,
         lhs: DurativeActionFluentExpression,
         rhs: I,
@@ -46,18 +61,36 @@ impl DurativeActionFluentExpression {
         Self::MultiOp(op, Box::new(lhs), rhs.into_iter().collect())
     }
 
-    pub fn new_negative(value: DurativeActionFluentExpression) -> Self {
+    pub fn new_multi_op<I: IntoIterator<Item = DurativeActionFluentExpression>>(
+        op: MultiOp,
+        lhs: DurativeActionFluentExpression,
+        rhs: I,
+    ) -> Self {
+        Self::multi_op(op, lhs, rhs)
+    }
+
+    #[doc(alias = "new_negative")]
+    pub fn negative(value: DurativeActionFluentExpression) -> Self {
         Self::Negative(Box::new(value))
     }
 
-    pub const fn new_f_exp(f_head: FluentExpression) -> Self {
+    pub fn new_negative(value: DurativeActionFluentExpression) -> Self {
+        Self::negative(value)
+    }
+
+    #[doc(alias = "new_f_exp")]
+    pub const fn fluent_expression(f_head: FluentExpression) -> Self {
         Self::FluentExpression(f_head)
+    }
+
+    pub fn new_f_exp(f_head: FluentExpression) -> Self {
+        Self::fluent_expression(f_head)
     }
 }
 
 impl From<FluentExpression> for DurativeActionFluentExpression {
     fn from(value: FluentExpression) -> Self {
-        DurativeActionFluentExpression::new_f_exp(value)
+        DurativeActionFluentExpression::fluent_expression(value)
     }
 }
 

--- a/src/types/f_exp_da.rs
+++ b/src/types/f_exp_da.rs
@@ -8,8 +8,16 @@ use crate::types::{AssignOp, BinaryOp, FluentExpression, FunctionHead, MultiOp};
 #[derive(Debug, Clone, PartialEq)]
 pub enum DurativeActionFluentExpression {
     Assign(AssignOp, FunctionHead, Box<DurativeActionFluentExpression>),
-    BinaryOp(BinaryOp, Box<DurativeActionFluentExpression>, Box<DurativeActionFluentExpression>),
-    MultiOp(MultiOp, Box<DurativeActionFluentExpression>, Vec<DurativeActionFluentExpression>),
+    BinaryOp(
+        BinaryOp,
+        Box<DurativeActionFluentExpression>,
+        Box<DurativeActionFluentExpression>,
+    ),
+    MultiOp(
+        MultiOp,
+        Box<DurativeActionFluentExpression>,
+        Vec<DurativeActionFluentExpression>,
+    ),
     Negative(Box<DurativeActionFluentExpression>),
     /// ## Requirements
     /// Requires [Duration Inequalities](crate::Requirement::DurationInequalities).
@@ -22,11 +30,19 @@ impl DurativeActionFluentExpression {
         Self::Duration
     }
 
-    pub fn new_binary_op(op: BinaryOp, lhs: DurativeActionFluentExpression, rhs: DurativeActionFluentExpression) -> Self {
+    pub fn new_binary_op(
+        op: BinaryOp,
+        lhs: DurativeActionFluentExpression,
+        rhs: DurativeActionFluentExpression,
+    ) -> Self {
         Self::BinaryOp(op, Box::new(lhs), Box::new(rhs))
     }
 
-    pub fn new_multi_op<I: IntoIterator<Item = DurativeActionFluentExpression>>(op: MultiOp, lhs: DurativeActionFluentExpression, rhs: I) -> Self {
+    pub fn new_multi_op<I: IntoIterator<Item = DurativeActionFluentExpression>>(
+        op: MultiOp,
+        lhs: DurativeActionFluentExpression,
+        rhs: I,
+    ) -> Self {
         Self::MultiOp(op, Box::new(lhs), rhs.into_iter().collect())
     }
 

--- a/src/types/f_exp_da.rs
+++ b/src/types/f_exp_da.rs
@@ -1,45 +1,50 @@
-//! Contains durative function expressions via the [`FExpDa`] type.
+//! Contains durative function expressions via the [`DurativeActionFluentExpression`] type.
 
-use crate::types::{AssignOp, BinaryOp, FExp, FHead, MultiOp};
+use crate::types::{AssignOp, BinaryOp, FluentExpression, FunctionHead, MultiOp};
 
 /// ## Usage
-/// Used by [`FExpDa`] itself, as well as [`FAssignDa`](crate::FAssignDa).
+/// Used by [`DurativeActionFluentExpression`] itself, as well as [`DurativeActionFunctionAssignment`](crate::DurativeActionFunctionAssignment).
+#[doc(alias("f-exp-da"))]
 #[derive(Debug, Clone, PartialEq)]
-pub enum FExpDa {
-    Assign(AssignOp, FHead, Box<FExpDa>),
-    BinaryOp(BinaryOp, Box<FExpDa>, Box<FExpDa>),
-    MultiOp(MultiOp, Box<FExpDa>, Vec<FExpDa>),
-    Negative(Box<FExpDa>),
+pub enum DurativeActionFluentExpression {
+    Assign(AssignOp, FunctionHead, Box<DurativeActionFluentExpression>),
+    BinaryOp(BinaryOp, Box<DurativeActionFluentExpression>, Box<DurativeActionFluentExpression>),
+    MultiOp(MultiOp, Box<DurativeActionFluentExpression>, Vec<DurativeActionFluentExpression>),
+    Negative(Box<DurativeActionFluentExpression>),
     /// ## Requirements
     /// Requires [Duration Inequalities](crate::Requirement::DurationInequalities).
     Duration,
-    FExp(FExp),
+    FluentExpression(FluentExpression),
 }
 
-impl FExpDa {
+impl DurativeActionFluentExpression {
     pub const fn new_duration() -> Self {
         Self::Duration
     }
 
-    pub fn new_binary_op(op: BinaryOp, lhs: FExpDa, rhs: FExpDa) -> Self {
+    pub fn new_binary_op(op: BinaryOp, lhs: DurativeActionFluentExpression, rhs: DurativeActionFluentExpression) -> Self {
         Self::BinaryOp(op, Box::new(lhs), Box::new(rhs))
     }
 
-    pub fn new_multi_op<I: IntoIterator<Item = FExpDa>>(op: MultiOp, lhs: FExpDa, rhs: I) -> Self {
+    pub fn new_multi_op<I: IntoIterator<Item = DurativeActionFluentExpression>>(op: MultiOp, lhs: DurativeActionFluentExpression, rhs: I) -> Self {
         Self::MultiOp(op, Box::new(lhs), rhs.into_iter().collect())
     }
 
-    pub fn new_negative(value: FExpDa) -> Self {
+    pub fn new_negative(value: DurativeActionFluentExpression) -> Self {
         Self::Negative(Box::new(value))
     }
 
-    pub const fn new_f_exp(f_head: FExp) -> Self {
-        Self::FExp(f_head)
+    pub const fn new_f_exp(f_head: FluentExpression) -> Self {
+        Self::FluentExpression(f_head)
     }
 }
 
-impl From<FExp> for FExpDa {
-    fn from(value: FExp) -> Self {
-        FExpDa::new_f_exp(value)
+impl From<FluentExpression> for DurativeActionFluentExpression {
+    fn from(value: FluentExpression) -> Self {
+        DurativeActionFluentExpression::new_f_exp(value)
     }
 }
+
+/// Alias for [`DurativeActionFluentExpression`]; matches BNF `<f-exp-da>`.
+#[deprecated(since = "0.2.0", note = "Use `DurativeActionFluentExpression` instead")]
+pub type FExpDa = DurativeActionFluentExpression;

--- a/src/types/f_exp_t.rs
+++ b/src/types/f_exp_t.rs
@@ -23,8 +23,13 @@ impl TimedFluentExpression {
         Self::Now
     }
 
-    pub fn new_scaled(exp: FluentExpression) -> Self {
+    #[doc(alias = "new_scaled")]
+    pub const fn scaled(exp: FluentExpression) -> Self {
         Self::Scaled(exp)
+    }
+
+    pub fn new_scaled(exp: FluentExpression) -> Self {
+        Self::scaled(exp)
     }
 }
 

--- a/src/types/f_exp_t.rs
+++ b/src/types/f_exp_t.rs
@@ -1,6 +1,6 @@
-//! Contains timed function expressions via the [`FExpT`] type.
+//! Contains timed function expressions via the [`TimedFluentExpression`] type.
 
-use crate::types::FExp;
+use crate::types::FluentExpression;
 
 /// An f-exp-t.
 ///
@@ -10,25 +10,30 @@ use crate::types::FExp;
 ///
 /// ## Usage
 /// Used by [`TimedEffect`](crate::TimedEffect).
+#[doc(alias("f-exp-t"))]
 #[derive(Debug, Clone, PartialEq, Default)]
-pub enum FExpT {
+pub enum TimedFluentExpression {
     #[default]
     Now,
-    Scaled(FExp),
+    Scaled(FluentExpression),
 }
 
-impl FExpT {
+impl TimedFluentExpression {
     pub const fn new() -> Self {
         Self::Now
     }
 
-    pub fn new_scaled(exp: FExp) -> Self {
+    pub fn new_scaled(exp: FluentExpression) -> Self {
         Self::Scaled(exp)
     }
 }
 
-impl From<FExp> for FExpT {
-    fn from(value: FExp) -> Self {
+impl From<FluentExpression> for TimedFluentExpression {
+    fn from(value: FluentExpression) -> Self {
         Self::Scaled(value)
     }
 }
+
+/// Alias for [`TimedFluentExpression`]; matches BNF `<f-exp-t>`.
+#[deprecated(since = "0.2.0", note = "Use `TimedFluentExpression` instead")]
+pub type FExpT = TimedFluentExpression;

--- a/src/types/f_head.rs
+++ b/src/types/f_head.rs
@@ -1,4 +1,4 @@
-//! Contains function declarations via the [`FHead`] type.
+//! Contains function declarations via the [`FunctionHead`] type.
 
 use crate::types::{FunctionSymbol, Term};
 
@@ -8,15 +8,16 @@ use crate::types::{FunctionSymbol, Term};
 /// Requires [Numeric Fluents](crate::Requirement::NumericFluents).
 ///
 /// ## Usage
-/// Used by [`FExp`](crate::FExp), [`PEffect`](crate::PEffect), [`TimedEffect`](crate::TimedEffect)
-/// and [`FAssignDa`](crate::FAssignDa).
+/// Used by [`FluentExpression`](crate::FluentExpression), [`PrimitiveEffect`](crate::PrimitiveEffect), [`TimedEffect`](crate::TimedEffect)
+/// and [`DurativeActionFunctionAssignment`](crate::DurativeActionFunctionAssignment).
+#[doc(alias("f-head"))]
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub enum FHead {
+pub enum FunctionHead {
     Simple(FunctionSymbol), // TODO: Unify with `WithTerms`?
     WithTerms(FunctionSymbol, Vec<Term>),
 }
 
-impl FHead {
+impl FunctionHead {
     pub const fn new(symbol: FunctionSymbol) -> Self {
         Self::Simple(symbol)
     }
@@ -25,3 +26,7 @@ impl FHead {
         Self::WithTerms(symbol, terms.into_iter().collect())
     }
 }
+
+/// Alias for [`FunctionHead`]; matches BNF `<f-head>`.
+#[deprecated(since = "0.2.0", note = "Use `FunctionHead` instead")]
+pub type FHead = FunctionHead;

--- a/src/types/f_head.rs
+++ b/src/types/f_head.rs
@@ -22,8 +22,13 @@ impl FunctionHead {
         Self::Simple(symbol)
     }
 
-    pub fn new_with_terms<I: IntoIterator<Item = Term>>(symbol: FunctionSymbol, terms: I) -> Self {
+    #[doc(alias = "new_with_terms")]
+    pub fn with_terms<I: IntoIterator<Item = Term>>(symbol: FunctionSymbol, terms: I) -> Self {
         Self::WithTerms(symbol, terms.into_iter().collect())
+    }
+
+    pub fn new_with_terms<I: IntoIterator<Item = Term>>(symbol: FunctionSymbol, terms: I) -> Self {
+        Self::with_terms(symbol, terms)
     }
 }
 

--- a/src/types/function_symbols.rs
+++ b/src/types/function_symbols.rs
@@ -18,8 +18,14 @@ impl FunctionSymbol {
     }
 
     #[inline(always)]
-    pub fn new_string(name: &str) -> Self {
+    #[doc(alias = "new_string")]
+    pub fn string(name: &str) -> Self {
         Self(Name::new(name))
+    }
+
+    #[inline(always)]
+    pub fn new_string(name: &str) -> Self {
+        Self::string(name)
     }
 
     #[inline(always)]

--- a/src/types/function_symbols.rs
+++ b/src/types/function_symbols.rs
@@ -7,7 +7,7 @@ use std::ops::Deref;
 ///
 /// ## Usage
 /// Used by [`FunctionTerm`](crate::FunctionTerm), [`FHead`](crate::FHead),
-/// [`BasicFunctionTerm`](crate::BasicFunctionTerm) and [`MetricFExp`](crate::MetricFExp).
+/// [`BasicFunctionTerm`](crate::BasicFunctionTerm) and [`MetricFluentExpression`](crate::MetricFluentExpression).
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Default)]
 pub struct FunctionSymbol(Name);
 

--- a/src/types/function_term.rs
+++ b/src/types/function_term.rs
@@ -9,7 +9,7 @@ use crate::types::FunctionSymbol;
 /// Requires [Object Fluents](crate::Requirement::ObjectFluents).
 ///
 /// ## Usage
-/// Used by [`Term`], and [`PEffect`](crate::PEffect).
+/// Used by [`Term`], and [`PrimitiveEffect`](crate::PrimitiveEffect).
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct FunctionTerm(FunctionSymbol, Vec<Term>);
 

--- a/src/types/function_type.rs
+++ b/src/types/function_type.rs
@@ -61,3 +61,93 @@ impl Deref for FunctionType {
         &self.0
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Name, PrimitiveType};
+
+    #[test]
+    fn default_is_number() {
+        let ft = FunctionType::default();
+        assert_eq!(ft, FunctionType::NUMBER);
+    }
+
+    #[test]
+    fn number_constant() {
+        assert_eq!(FunctionType::NUMBER.deref(), &Type::NUMBER);
+    }
+
+    #[test]
+    fn new_from_type() {
+        let ft = FunctionType::new(Type::OBJECT);
+        assert_eq!(*ft, Type::OBJECT);
+    }
+
+    #[test]
+    fn new_from_str() {
+        let ft = FunctionType::new("location");
+        assert_eq!(
+            *ft,
+            Type::exactly(PrimitiveType::new(Name::new("location")))
+        );
+    }
+
+    #[test]
+    fn from_str() {
+        let ft: FunctionType = "number".into();
+        assert_eq!(*ft, Type::NUMBER);
+    }
+
+    #[test]
+    fn from_vec_str() {
+        let ft: FunctionType = vec!["location", "room"].into();
+        assert!(matches!(*ft, Type::EitherOf(_)));
+        if let Type::EitherOf(types) = &*ft {
+            assert_eq!(types.len(), 2);
+        }
+    }
+
+    #[test]
+    fn from_type() {
+        let t = Type::OBJECT;
+        let ft = FunctionType::from(t);
+        assert_eq!(*ft, Type::OBJECT);
+    }
+
+    #[test]
+    fn from_const() {
+        let ft = FunctionType::from(Type::NUMBER);
+        assert_eq!(ft, FunctionType::NUMBER);
+    }
+
+    #[test]
+    fn deref_works() {
+        let ft = FunctionType::new(Type::OBJECT);
+        let t: &Type = &ft;
+        assert_eq!(t, &Type::OBJECT);
+    }
+
+    #[test]
+    fn clone_works() {
+        let ft = FunctionType::new(Type::OBJECT);
+        let clone = ft.clone();
+        assert_eq!(ft, clone);
+    }
+
+    #[test]
+    fn eq_works() {
+        let a = FunctionType::new(Type::OBJECT);
+        let b = FunctionType::new(Type::OBJECT);
+        let c = FunctionType::NUMBER;
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn debug_impl() {
+        let ft = FunctionType::NUMBER;
+        let dbg = format!("{ft:?}");
+        assert!(dbg.contains("FunctionType"));
+    }
+}

--- a/src/types/function_typed.rs
+++ b/src/types/function_typed.rs
@@ -19,8 +19,13 @@ impl<O> FunctionTyped<O> {
         Self(value, r#type)
     }
 
-    pub const fn new_number(value: O) -> Self {
+    pub const fn number(value: O) -> Self {
         Self::new(value, FunctionType::NUMBER)
+    }
+
+    #[deprecated(since = "0.2.0", note = "Use `number` instead")]
+    pub const fn new_number(value: O) -> Self {
+        Self::number(value)
     }
 
     pub const fn from_type(value: O, r#type: Type) -> Self {
@@ -38,7 +43,7 @@ impl<O> FunctionTyped<O> {
 
 impl<O> From<O> for FunctionTyped<O> {
     fn from(value: O) -> Self {
-        FunctionTyped::new_number(value)
+        FunctionTyped::number(value)
     }
 }
 

--- a/src/types/gd.rs
+++ b/src/types/gd.rs
@@ -6,7 +6,7 @@ use crate::types::{AtomicFormula, FluentComparison, Term, TypedVariables};
 /// A goal definition.
 ///
 /// ## Usage
-/// Used by [`GoalDefinition`] itself, as well as [`PreferenceGD`](crate::PreferenceGD), [`ConditionalEffect`](crate::ConditionalEffect),
+/// Used by [`GoalDefinition`] itself, as well as [`PreferenceGoalDefinition`](crate::PreferenceGoalDefinition), [`ConditionalEffect`](crate::ConditionalEffect),
 /// [`TimedGoalDefinition`](crate::TimedGoalDefinition), [`DerivedPredicate`](crate::DerivedPredicate) and
 /// [`ConstraintGoalDefinitionInner`](crate::ConstraintGoalDefinitionInner).
 #[derive(Debug, Clone, PartialEq)]

--- a/src/types/gd.rs
+++ b/src/types/gd.rs
@@ -1,5 +1,7 @@
 //! Contains goal definitions via the [`GoalDefinition`] type.
 
+use std::ops::Not;
+
 use crate::types::TermLiteral;
 use crate::types::{AtomicFormula, FluentComparison, Term, TypedVariables};
 
@@ -38,65 +40,136 @@ pub enum GoalDefinition {
 
 impl GoalDefinition {
     #[inline(always)]
-    pub const fn new_atomic_formula(value: AtomicFormula<Term>) -> Self {
+    #[doc(alias = "new_atomic_formula")]
+    pub const fn atomic_formula(value: AtomicFormula<Term>) -> Self {
         Self::AtomicFormula(value)
     }
 
-    #[inline(always)]
-    pub const fn new_literal(value: TermLiteral) -> Self {
-        Self::Literal(value)
+    pub fn new_atomic_formula(value: AtomicFormula<Term>) -> Self {
+        Self::atomic_formula(value)
     }
 
     #[inline(always)]
-    pub fn new_and<T: IntoIterator<Item = GoalDefinition>>(values: T) -> Self {
+    #[doc(alias = "new_literal")]
+    pub const fn literal(value: TermLiteral) -> Self {
+        Self::Literal(value)
+    }
+
+    pub fn new_literal(value: TermLiteral) -> Self {
+        Self::literal(value)
+    }
+
+    #[inline(always)]
+    #[doc(alias = "new_and")]
+    pub fn and<T: IntoIterator<Item = GoalDefinition>>(values: T) -> Self {
         // TODO: Flatten `(and (and a b) (and x y))` into `(and a b c y)`.
         Self::And(values.into_iter().collect())
     }
 
+    pub fn new_and<T: IntoIterator<Item = GoalDefinition>>(values: T) -> Self {
+        Self::and(values)
+    }
+
     #[inline(always)]
-    pub fn new_or<T: IntoIterator<Item = GoalDefinition>>(values: T) -> Self {
+    #[doc(alias = "new_or")]
+    pub fn or<T: IntoIterator<Item = GoalDefinition>>(values: T) -> Self {
         // TODO: Flatten `(or (or a b) (or x y))` into `(or a b c y)`.
         Self::Or(values.into_iter().collect())
     }
 
+    pub fn new_or<T: IntoIterator<Item = GoalDefinition>>(values: T) -> Self {
+        Self::or(values)
+    }
+
+    #[allow(clippy::should_implement_trait)]
     #[inline(always)]
-    pub fn new_not(value: GoalDefinition) -> Self {
+    #[doc(alias = "new_not")]
+    pub fn not(value: GoalDefinition) -> Self {
         Self::Not(Box::new(value))
     }
+}
 
-    #[inline(always)]
-    pub fn new_imply_tuple(tuple: (GoalDefinition, GoalDefinition)) -> Self {
-        Self::new_imply(tuple.0, tuple.1)
+impl Not for GoalDefinition {
+    type Output = Self;
+
+    fn not(self) -> Self::Output {
+        Self::Not(Box::new(self))
+    }
+}
+
+impl GoalDefinition {
+    pub fn new_not(value: GoalDefinition) -> Self {
+        Self::not(value)
     }
 
     #[inline(always)]
-    pub fn new_imply(a: GoalDefinition, b: GoalDefinition) -> Self {
+    #[doc(alias = "new_imply_tuple")]
+    pub fn imply_tuple(tuple: (GoalDefinition, GoalDefinition)) -> Self {
+        Self::imply(tuple.0, tuple.1)
+    }
+
+    pub fn new_imply_tuple(tuple: (GoalDefinition, GoalDefinition)) -> Self {
+        Self::imply_tuple(tuple)
+    }
+
+    #[inline(always)]
+    #[doc(alias = "new_imply")]
+    pub fn imply(a: GoalDefinition, b: GoalDefinition) -> Self {
         Self::Imply(Box::new(a), Box::new(b))
     }
 
-    #[inline(always)]
-    pub fn new_exists_tuple(tuple: (TypedVariables, GoalDefinition)) -> Self {
-        Self::new_exists(tuple.0, tuple.1)
+    pub fn new_imply(a: GoalDefinition, b: GoalDefinition) -> Self {
+        Self::imply(a, b)
     }
 
     #[inline(always)]
-    pub fn new_exists(variables: TypedVariables, gd: GoalDefinition) -> Self {
+    #[doc(alias = "new_exists_tuple")]
+    pub fn exists_tuple(tuple: (TypedVariables, GoalDefinition)) -> Self {
+        Self::exists(tuple.0, tuple.1)
+    }
+
+    pub fn new_exists_tuple(tuple: (TypedVariables, GoalDefinition)) -> Self {
+        Self::exists_tuple(tuple)
+    }
+
+    #[inline(always)]
+    #[doc(alias = "new_exists")]
+    pub fn exists(variables: TypedVariables, gd: GoalDefinition) -> Self {
         Self::Exists(variables, Box::new(gd))
     }
 
-    #[inline(always)]
-    pub fn new_forall_tuple(tuple: (TypedVariables, GoalDefinition)) -> Self {
-        Self::new_forall(tuple.0, tuple.1)
+    pub fn new_exists(variables: TypedVariables, gd: GoalDefinition) -> Self {
+        Self::exists(variables, gd)
     }
 
     #[inline(always)]
-    pub fn new_forall(variables: TypedVariables, gd: GoalDefinition) -> Self {
+    #[doc(alias = "new_forall_tuple")]
+    pub fn forall_tuple(tuple: (TypedVariables, GoalDefinition)) -> Self {
+        Self::forall(tuple.0, tuple.1)
+    }
+
+    pub fn new_forall_tuple(tuple: (TypedVariables, GoalDefinition)) -> Self {
+        Self::forall_tuple(tuple)
+    }
+
+    #[inline(always)]
+    #[doc(alias = "new_forall")]
+    pub fn r#forall(variables: TypedVariables, gd: GoalDefinition) -> Self {
         Self::ForAll(variables, Box::new(gd))
     }
 
+    pub fn new_forall(variables: TypedVariables, gd: GoalDefinition) -> Self {
+        Self::r#forall(variables, gd)
+    }
+
     #[inline(always)]
-    pub const fn new_f_comp(f_comp: FluentComparison) -> Self {
+    #[doc(alias = "new_f_comp")]
+    pub const fn fluent_comparison(f_comp: FluentComparison) -> Self {
         Self::FluentComparison(f_comp)
+    }
+
+    pub fn new_f_comp(f_comp: FluentComparison) -> Self {
+        Self::fluent_comparison(f_comp)
     }
 
     pub fn is_empty(&self) -> bool {

--- a/src/types/gd.rs
+++ b/src/types/gd.rs
@@ -186,3 +186,116 @@ impl GoalDefinition {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{
+        AtomicFormula, BinaryComparison, FluentComparison, FluentExpression, Number, Predicate,
+        Term,
+    };
+
+    #[test]
+    #[allow(deprecated)]
+    fn deprecated_new_constructors() {
+        let af = AtomicFormula::predicate(Predicate::string("at"), Vec::<Term>::new());
+        let _ = GoalDefinition::new_atomic_formula(af.clone());
+
+        let literal = TermLiteral::new_not(AtomicFormula::predicate(
+            Predicate::string("x"),
+            Vec::<Term>::new(),
+        ));
+        let _ = GoalDefinition::new_literal(literal.clone());
+
+        let _ = GoalDefinition::new_and(vec![GoalDefinition::AtomicFormula(af.clone())]);
+        let _ = GoalDefinition::new_or(vec![GoalDefinition::AtomicFormula(af.clone())]);
+        let _ = GoalDefinition::new_not(GoalDefinition::AtomicFormula(af.clone()));
+
+        let _ = GoalDefinition::new_imply_tuple((
+            GoalDefinition::AtomicFormula(af.clone()),
+            GoalDefinition::AtomicFormula(af.clone()),
+        ));
+        let _ = GoalDefinition::new_imply(
+            GoalDefinition::AtomicFormula(af.clone()),
+            GoalDefinition::AtomicFormula(af.clone()),
+        );
+
+        let vars = TypedVariables::default();
+        let _ = GoalDefinition::new_exists_tuple((
+            vars.clone(),
+            GoalDefinition::AtomicFormula(af.clone()),
+        ));
+        let _ = GoalDefinition::new_exists(vars.clone(), GoalDefinition::AtomicFormula(af.clone()));
+        let _ = GoalDefinition::new_forall_tuple((
+            vars.clone(),
+            GoalDefinition::AtomicFormula(af.clone()),
+        ));
+        let _ = GoalDefinition::new_forall(vars, GoalDefinition::AtomicFormula(af.clone()));
+
+        let f_comp = FluentComparison::new(
+            BinaryComparison::GreaterThan,
+            FluentExpression::number(Number::from(1)),
+            FluentExpression::number(Number::from(0)),
+        );
+        let _ = GoalDefinition::new_f_comp(f_comp);
+    }
+
+    #[test]
+    fn not_trait() {
+        let gd = GoalDefinition::AtomicFormula(AtomicFormula::predicate(
+            Predicate::string("clear"),
+            Vec::<Term>::new(),
+        ));
+        let negated = !gd;
+        assert!(matches!(negated, GoalDefinition::Not(_)));
+    }
+
+    #[test]
+    fn is_empty_non_empty_variants() {
+        let af = AtomicFormula::predicate(Predicate::string("at"), Vec::<Term>::new());
+        assert!(!GoalDefinition::AtomicFormula(af).is_empty());
+
+        let literal = TermLiteral::new(AtomicFormula::predicate(
+            Predicate::string("x"),
+            Vec::<Term>::new(),
+        ));
+        assert!(!GoalDefinition::Literal(literal).is_empty());
+
+        let gd = GoalDefinition::AtomicFormula(AtomicFormula::predicate(
+            Predicate::string("on"),
+            Vec::<Term>::new(),
+        ));
+        assert!(!GoalDefinition::Not(Box::new(gd.clone())).is_empty());
+        assert!(!GoalDefinition::Imply(Box::new(gd.clone()), Box::new(gd.clone())).is_empty());
+        assert!(
+            !GoalDefinition::Exists(TypedVariables::default(), Box::new(gd.clone())).is_empty()
+        );
+        assert!(
+            !GoalDefinition::ForAll(TypedVariables::default(), Box::new(gd.clone())).is_empty()
+        );
+
+        let f_comp = FluentComparison::new(
+            BinaryComparison::GreaterThan,
+            FluentExpression::number(Number::from(1)),
+            FluentExpression::number(Number::from(0)),
+        );
+        assert!(!GoalDefinition::FluentComparison(f_comp).is_empty());
+    }
+
+    #[test]
+    fn is_empty_recursive() {
+        let empty_and = GoalDefinition::and(Vec::new());
+        assert!(empty_and.is_empty());
+
+        let empty_or = GoalDefinition::or(Vec::new());
+        assert!(empty_or.is_empty());
+
+        let nested_empty = GoalDefinition::Not(Box::new(GoalDefinition::and(Vec::new())));
+        assert!(nested_empty.is_empty());
+
+        let non_empty_and = GoalDefinition::and(vec![GoalDefinition::AtomicFormula(
+            AtomicFormula::predicate(Predicate::string("at"), Vec::<Term>::new()),
+        )]);
+        assert!(!non_empty_and.is_empty());
+    }
+}

--- a/src/types/gd.rs
+++ b/src/types/gd.rs
@@ -1,14 +1,14 @@
 //! Contains goal definitions via the [`GoalDefinition`] type.
 
 use crate::types::TermLiteral;
-use crate::types::{AtomicFormula, FComp, Term, TypedVariables};
+use crate::types::{AtomicFormula, FluentComparison, Term, TypedVariables};
 
 /// A goal definition.
 ///
 /// ## Usage
-/// Used by [`GoalDefinition`] itself, as well as [`PreferenceGD`](crate::PreferenceGD), [`CEffect`](crate::CEffect),
-/// [`TimedGD`](crate::TimedGD), [`DerivedPredicate`](crate::DerivedPredicate) and
-/// [`Con2GD`](crate::Con2GD).
+/// Used by [`GoalDefinition`] itself, as well as [`PreferenceGD`](crate::PreferenceGD), [`ConditionalEffect`](crate::ConditionalEffect),
+/// [`TimedGoalDefinition`](crate::TimedGoalDefinition), [`DerivedPredicate`](crate::DerivedPredicate) and
+/// [`ConstraintGoalDefinitionInner`](crate::ConstraintGoalDefinitionInner).
 #[derive(Debug, Clone, PartialEq)]
 pub enum GoalDefinition {
     AtomicFormula(AtomicFormula<Term>),
@@ -33,7 +33,7 @@ pub enum GoalDefinition {
     ForAll(TypedVariables, Box<GoalDefinition>),
     /// ## Requirements
     /// Requires [Numeric Fluents](crate::Requirement::NumericFluents).
-    FComp(FComp),
+    FluentComparison(FluentComparison),
 }
 
 impl GoalDefinition {
@@ -95,8 +95,8 @@ impl GoalDefinition {
     }
 
     #[inline(always)]
-    pub const fn new_f_comp(f_comp: FComp) -> Self {
-        Self::FComp(f_comp)
+    pub const fn new_f_comp(f_comp: FluentComparison) -> Self {
+        Self::FluentComparison(f_comp)
     }
 
     pub fn is_empty(&self) -> bool {
@@ -109,7 +109,7 @@ impl GoalDefinition {
             GoalDefinition::Imply(x, y) => x.is_empty() && y.is_empty(),
             GoalDefinition::Exists(_, x) => x.is_empty(),
             GoalDefinition::ForAll(_, x) => x.is_empty(),
-            GoalDefinition::FComp(_) => false,
+            GoalDefinition::FluentComparison(_) => false,
         }
     }
 }

--- a/src/types/goal_def.rs
+++ b/src/types/goal_def.rs
@@ -67,3 +67,30 @@ impl From<ProblemGoalDefinition> for PreconditionGoalDefinitions {
 /// Alias for [`ProblemGoalDefinition`].
 #[deprecated(since = "0.2.0", note = "Use `ProblemGoalDefinition` instead")]
 pub type GoalDef = ProblemGoalDefinition;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::GoalDefinition;
+
+    #[test]
+    fn problem_goal_definition_from_precondition_goal_definitions() {
+        let defs = PreconditionGoalDefinitions::new(Vec::new());
+        let pgd: ProblemGoalDefinition = defs.clone().into();
+        assert_eq!(*pgd.value(), defs);
+    }
+
+    #[test]
+    fn problem_goal_definition_from_precondition_goal_definition() {
+        let pref_gd = crate::PreferenceGoalDefinition::from_gd(GoalDefinition::and(Vec::new()));
+        let pre_gd = PreconditionGoalDefinition::preference(pref_gd);
+        let pgd: ProblemGoalDefinition = pre_gd.into();
+        assert_eq!(pgd.len(), 1);
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn deprecated_alias_exists() {
+        fn _assert_alias(_: GoalDef) {}
+    }
+}

--- a/src/types/goal_def.rs
+++ b/src/types/goal_def.rs
@@ -1,4 +1,4 @@
-//! Contains the [`GoalDef`] type.
+//! Contains the [`ProblemGoalDefinition`] type.
 
 use crate::types::pre_gd::PreconditionGoalDefinitions;
 use crate::PreconditionGoalDefinition;
@@ -6,12 +6,16 @@ use std::ops::Deref;
 
 /// A problem goal definition; wraps a [`PreconditionGoalDefinitions`].
 ///
+/// # BNF
+/// Corresponds to the `(:goal ...)` section of a PDDL problem definition.
+///
 /// ## Usage
 /// Used by [`Problem`](crate::Problem).
+#[doc(alias("goal"))]
 #[derive(Debug, Clone, PartialEq)]
-pub struct GoalDef(PreconditionGoalDefinitions);
+pub struct ProblemGoalDefinition(PreconditionGoalDefinitions);
 
-impl GoalDef {
+impl ProblemGoalDefinition {
     pub const fn new(gd: PreconditionGoalDefinitions) -> Self {
         Self(gd)
     }
@@ -22,31 +26,31 @@ impl GoalDef {
     }
 }
 
-impl PartialEq<PreconditionGoalDefinitions> for GoalDef {
+impl PartialEq<PreconditionGoalDefinitions> for ProblemGoalDefinition {
     fn eq(&self, other: &PreconditionGoalDefinitions) -> bool {
         self.0.eq(other)
     }
 }
 
-impl From<PreconditionGoalDefinitions> for GoalDef {
+impl From<PreconditionGoalDefinitions> for ProblemGoalDefinition {
     fn from(value: PreconditionGoalDefinitions) -> Self {
         Self::new(value)
     }
 }
 
-impl From<PreconditionGoalDefinition> for GoalDef {
+impl From<PreconditionGoalDefinition> for ProblemGoalDefinition {
     fn from(value: PreconditionGoalDefinition) -> Self {
         Self::new(PreconditionGoalDefinitions::from(value))
     }
 }
 
-impl FromIterator<PreconditionGoalDefinition> for GoalDef {
+impl FromIterator<PreconditionGoalDefinition> for ProblemGoalDefinition {
     fn from_iter<T: IntoIterator<Item = PreconditionGoalDefinition>>(iter: T) -> Self {
-        GoalDef::new(PreconditionGoalDefinitions::from_iter(iter))
+        ProblemGoalDefinition::new(PreconditionGoalDefinitions::from_iter(iter))
     }
 }
 
-impl Deref for GoalDef {
+impl Deref for ProblemGoalDefinition {
     type Target = PreconditionGoalDefinitions;
 
     fn deref(&self) -> &Self::Target {
@@ -54,8 +58,12 @@ impl Deref for GoalDef {
     }
 }
 
-impl From<GoalDef> for PreconditionGoalDefinitions {
-    fn from(val: GoalDef) -> Self {
+impl From<ProblemGoalDefinition> for PreconditionGoalDefinitions {
+    fn from(val: ProblemGoalDefinition) -> Self {
         val.0
     }
 }
+
+/// Alias for [`ProblemGoalDefinition`].
+#[deprecated(since = "0.2.0", note = "Use `ProblemGoalDefinition` instead")]
+pub type GoalDef = ProblemGoalDefinition;

--- a/src/types/literal.rs
+++ b/src/types/literal.rs
@@ -47,7 +47,7 @@ mod tests {
         let literal: Literal<Term> = effect.into();
         assert_eq!(
             literal,
-            Literal::AtomicFormula(AtomicFormula::new_equality(
+            Literal::AtomicFormula(AtomicFormula::equality(
                 Term::new_name("x".into()),
                 Term::new_name("y".into()),
             ))

--- a/src/types/metric_f_exp.rs
+++ b/src/types/metric_f_exp.rs
@@ -23,11 +23,17 @@ pub enum MetricFluentExpression {
 }
 
 impl MetricFluentExpression {
-    pub fn new_binary_op(op: BinaryOp, lhs: Self, rhs: Self) -> Self {
+    #[doc(alias = "new_binary_op")]
+    pub fn binary_op(op: BinaryOp, lhs: Self, rhs: Self) -> Self {
         Self::BinaryOp(op, Box::new(lhs), Box::new(rhs))
     }
 
-    pub fn new_multi_op<I: IntoIterator<Item = Self>>(op: MultiOp, lhs: Self, rhs: I) -> Self {
+    pub fn new_binary_op(op: BinaryOp, lhs: Self, rhs: Self) -> Self {
+        Self::binary_op(op, lhs, rhs)
+    }
+
+    #[doc(alias = "new_multi_op")]
+    pub fn multi_op<I: IntoIterator<Item = Self>>(op: MultiOp, lhs: Self, rhs: I) -> Self {
         let vec: Vec<_> = rhs.into_iter().collect();
         debug_assert!(
             !vec.is_empty(),
@@ -36,24 +42,53 @@ impl MetricFluentExpression {
         Self::MultiOp(op, Box::new(lhs), vec)
     }
 
-    pub fn new_negative(exp: Self) -> Self {
+    pub fn new_multi_op<I: IntoIterator<Item = Self>>(op: MultiOp, lhs: Self, rhs: I) -> Self {
+        Self::multi_op(op, lhs, rhs)
+    }
+
+    #[doc(alias = "new_negative")]
+    pub fn negative(exp: Self) -> Self {
         Self::Negative(Box::new(exp))
     }
 
-    pub fn new_number<N: Into<Number>>(number: N) -> Self {
+    pub fn new_negative(exp: Self) -> Self {
+        Self::negative(exp)
+    }
+
+    #[doc(alias = "new_number")]
+    pub fn number<N: Into<Number>>(number: N) -> Self {
         Self::Number(number.into())
     }
 
-    pub fn new_function<I: IntoIterator<Item = Name>>(symbol: FunctionSymbol, names: I) -> Self {
+    pub fn new_number<N: Into<Number>>(number: N) -> Self {
+        Self::number(number)
+    }
+
+    #[doc(alias = "new_function")]
+    pub fn function<I: IntoIterator<Item = Name>>(symbol: FunctionSymbol, names: I) -> Self {
         Self::Function(symbol, names.into_iter().collect())
     }
 
-    pub const fn new_total_time() -> Self {
+    pub fn new_function<I: IntoIterator<Item = Name>>(symbol: FunctionSymbol, names: I) -> Self {
+        Self::function(symbol, names)
+    }
+
+    #[doc(alias = "new_total_time")]
+    pub const fn total_time() -> Self {
         Self::TotalTime
     }
 
-    pub const fn new_is_violated(pref: PreferenceName) -> Self {
+    pub fn new_total_time() -> Self {
+        Self::total_time()
+    }
+
+    #[doc(alias = "new_is_violated")]
+    pub const fn is_violated(pref: PreferenceName) -> Self {
         Self::IsViolated(pref)
+    }
+
+    pub fn new_is_violated(pref: PreferenceName) -> Self {
+        Self::is_violated(pref)
     }
 }
 

--- a/src/types/metric_f_exp.rs
+++ b/src/types/metric_f_exp.rs
@@ -96,3 +96,80 @@ impl MetricFluentExpression {
 #[deprecated(since = "0.2.0", note = "Use `MetricFluentExpression` instead")]
 #[allow(dead_code)]
 pub type MetricFExp = MetricFluentExpression;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[allow(deprecated)]
+    fn deprecated_new_constructors() {
+        let _ = MetricFluentExpression::new_number(42);
+        let _ = MetricFluentExpression::new_total_time();
+
+        let pref = PreferenceName::new("p");
+        let _ = MetricFluentExpression::new_is_violated(pref);
+
+        let sym = FunctionSymbol::new(Name::new("cost"));
+        let _ = MetricFluentExpression::new_function(sym, vec![Name::new("x")]);
+
+        let lhs = MetricFluentExpression::number(1);
+        let rhs = MetricFluentExpression::number(2);
+        let _ = MetricFluentExpression::new_binary_op(BinaryOp::Addition, lhs.clone(), rhs.clone());
+        let _ =
+            MetricFluentExpression::new_multi_op(MultiOp::Addition, lhs.clone(), vec![rhs.clone()]);
+        let _ = MetricFluentExpression::new_negative(lhs);
+    }
+
+    #[test]
+    fn binary_op_constructor() {
+        let lhs = MetricFluentExpression::number(1);
+        let rhs = MetricFluentExpression::number(2);
+        let expr = MetricFluentExpression::binary_op(BinaryOp::Addition, lhs, rhs);
+        assert!(matches!(expr, MetricFluentExpression::BinaryOp(_, _, _)));
+    }
+
+    #[test]
+    fn multi_op_constructor() {
+        let lhs = MetricFluentExpression::number(1);
+        let rhs = vec![
+            MetricFluentExpression::number(2),
+            MetricFluentExpression::number(3),
+        ];
+        let expr = MetricFluentExpression::multi_op(MultiOp::Addition, lhs, rhs);
+        assert!(matches!(expr, MetricFluentExpression::MultiOp(_, _, _)));
+    }
+
+    #[test]
+    fn negative_constructor() {
+        let inner = MetricFluentExpression::number(5);
+        let expr = MetricFluentExpression::negative(inner);
+        assert!(matches!(expr, MetricFluentExpression::Negative(_)));
+    }
+
+    #[test]
+    fn number_constructor() {
+        let expr = MetricFluentExpression::number(42);
+        assert!(matches!(expr, MetricFluentExpression::Number(_)));
+    }
+
+    #[test]
+    fn function_constructor() {
+        let sym = FunctionSymbol::new(Name::new("cost"));
+        let expr = MetricFluentExpression::function(sym, vec![Name::new("x")]);
+        assert!(matches!(expr, MetricFluentExpression::Function(_, _)));
+    }
+
+    #[test]
+    fn total_time_constructor() {
+        let expr = MetricFluentExpression::total_time();
+        assert!(matches!(expr, MetricFluentExpression::TotalTime));
+    }
+
+    #[test]
+    fn is_violated_constructor() {
+        let pref = PreferenceName::new("p");
+        let expr = MetricFluentExpression::is_violated(pref);
+        assert!(matches!(expr, MetricFluentExpression::IsViolated(_)));
+    }
+}

--- a/src/types/metric_f_exp.rs
+++ b/src/types/metric_f_exp.rs
@@ -1,4 +1,4 @@
-//! Contains the [`MetricFExp`] type.
+//! Contains the [`MetricFluentExpression`] type.
 
 use crate::types::{BinaryOp, FunctionSymbol, MultiOp, Name, Number, PreferenceName};
 
@@ -10,7 +10,7 @@ use crate::types::{BinaryOp, FunctionSymbol, MultiOp, Name, Number, PreferenceNa
 /// ## Usage
 /// Used by [`MetricSpec`](crate::MetricSpec).
 #[derive(Debug, Clone, PartialEq)]
-pub enum MetricFExp {
+pub enum MetricFluentExpression {
     BinaryOp(BinaryOp, Box<Self>, Box<Self>),
     MultiOp(MultiOp, Box<Self>, Vec<Self>),
     Negative(Box<Self>),
@@ -22,7 +22,7 @@ pub enum MetricFExp {
     IsViolated(PreferenceName),
 }
 
-impl MetricFExp {
+impl MetricFluentExpression {
     pub fn new_binary_op(op: BinaryOp, lhs: Self, rhs: Self) -> Self {
         Self::BinaryOp(op, Box::new(lhs), Box::new(rhs))
     }
@@ -56,3 +56,8 @@ impl MetricFExp {
         Self::IsViolated(pref)
     }
 }
+
+/// Alias for [`MetricFluentExpression`]; matches BNF `<metric-f-exp>`.
+#[deprecated(since = "0.2.0", note = "Use `MetricFluentExpression` instead")]
+#[allow(dead_code)]
+pub type MetricFExp = MetricFluentExpression;

--- a/src/types/metric_spec.rs
+++ b/src/types/metric_spec.rs
@@ -1,6 +1,6 @@
 //! Contains the [`MetricSpec`] type.
 
-use crate::types::{MetricFExp, Optimization};
+use crate::types::{MetricFluentExpression, Optimization};
 
 /// A metric specification.
 ///
@@ -9,11 +9,11 @@ use crate::types::{MetricFExp, Optimization};
 #[derive(Debug, Clone, PartialEq)]
 pub struct MetricSpec {
     optimization: Optimization,
-    exp: MetricFExp,
+    exp: MetricFluentExpression,
 }
 
 impl MetricSpec {
-    pub const fn new(optimization: Optimization, exp: MetricFExp) -> Self {
+    pub const fn new(optimization: Optimization, exp: MetricFluentExpression) -> Self {
         Self { optimization, exp }
     }
 
@@ -23,7 +23,7 @@ impl MetricSpec {
     }
 
     /// Gets the expression to optimize.
-    pub const fn expression(&self) -> &MetricFExp {
+    pub const fn expression(&self) -> &MetricFluentExpression {
         &self.exp
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -84,18 +84,25 @@ mod pddl_file;
 pub use action_definition::ActionDefinition;
 pub use action_symbols::ActionSymbol;
 pub use assign_op::AssignOp;
-pub use assign_op_t::AssignOpT;
+#[allow(deprecated)]
+pub use assign_op_t::{AssignOpT, TimedAssignOperator};
 pub use atomic_formula::{AtomicFormula, EqualityAtomicFormula, PredicateAtomicFormula};
 pub use atomic_formula_skeleton::AtomicFormulaSkeleton;
 pub use atomic_function_skeleton::AtomicFunctionSkeleton;
 pub use basic_function_term::BasicFunctionTerm;
-pub use binary_comp::BinaryComp;
+pub use binary_comp::BinaryComparison;
 pub use binary_op::BinaryOp;
-pub use c_effect::{CEffect, ForallCEffect, WhenCEffect};
-pub use con_gd::{Con2GD, ConGD};
-pub use conditional_effect::ConditionalEffect;
+#[allow(deprecated)]
+pub use c_effect::{
+    CEffect, ConditionalEffect, ForallCEffect, ForallConditionalEffect, WhenCEffect,
+    WhenConditionalEffect,
+};
+#[allow(deprecated)]
+pub use con_gd::{Con2GD, ConGD, ConstraintGoalDefinition, ConstraintGoalDefinitionInner};
+pub use conditional_effect::EffectCondition;
 pub use constants::Constants;
-pub use d_op::DOp;
+#[allow(deprecated)]
+pub use d_op::{DOp, DurationOperator};
 pub use d_value::DurationValue;
 pub use da_def::DurativeActionDefinition;
 pub use da_effect::DurativeActionEffect;
@@ -106,12 +113,18 @@ pub use domain::Domain;
 pub use domain_constraints_def::DomainConstraintsDef;
 pub use duration_constraint::DurationConstraint;
 pub use effects::Effects;
-pub use f_assign_da::FAssignDa;
-pub use f_comp::FComp;
-pub use f_exp::FExp;
-pub use f_exp_da::FExpDa;
-pub use f_exp_t::FExpT;
-pub use f_head::FHead;
+#[allow(deprecated)]
+pub use f_assign_da::{DurativeActionFunctionAssignment, FAssignDa};
+#[allow(deprecated)]
+pub use f_comp::{FComp, FluentComparison};
+#[allow(deprecated)]
+pub use f_exp::{FExp, FluentExpression};
+#[allow(deprecated)]
+pub use f_exp_da::{DurativeActionFluentExpression, FExpDa};
+#[allow(deprecated)]
+pub use f_exp_t::{FExpT, TimedFluentExpression};
+#[allow(deprecated)]
+pub use f_head::{FHead, FunctionHead};
 pub use function_symbols::FunctionSymbol;
 pub use function_term::FunctionTerm;
 pub use function_type::FunctionType;
@@ -119,28 +132,37 @@ pub use function_typed::FunctionTyped;
 pub use function_typed_list::FunctionTypedList;
 pub use functions::Functions;
 pub use gd::GoalDefinition;
-pub use goal_def::GoalDef;
+#[allow(deprecated)]
+pub use goal_def::{GoalDef, ProblemGoalDefinition};
 pub use init_el::InitElement;
 pub use init_els::InitElements;
 pub use interval::Interval;
 pub use length_spec::LengthSpec;
 pub use literal::Literal;
+#[allow(deprecated)]
 pub use metric_f_exp::MetricFExp;
+pub use metric_f_exp::MetricFluentExpression;
 pub use metric_spec::MetricSpec;
 pub use multi_op::MultiOp;
 pub use name::Name;
 pub use number::Number;
 pub use objects::Objects;
 pub use optimization::Optimization;
+#[allow(deprecated)]
 pub use p_effect::PEffect;
+pub use p_effect::PrimitiveEffect;
 pub use pddl_file::PddlFile;
 pub use pre_gd::{PreconditionGoalDefinition, PreconditionGoalDefinitions};
 pub use predicate::Predicate;
 pub use predicate_definitions::PredicateDefinitions;
-pub use pref_con_gd::{PrefConGD, PrefConGDs};
+#[allow(deprecated)]
+pub use pref_con_gd::{
+    PrefConGD, PrefConGDs, PreferenceConstraintGoalDefinition, PreferenceConstraintGoalDefinitions,
+};
 pub use pref_gd::PreferenceGD;
 pub use pref_name::PreferenceName;
-pub use pref_timed_gd::PrefTimedGD;
+#[allow(deprecated)]
+pub use pref_timed_gd::{PrefTimedGD, PreferenceTimedGoalDefinition};
 pub use preference::Preference;
 pub use problem::Problem;
 pub use problem_constraints_def::ProblemConstraintsDef;
@@ -153,7 +175,8 @@ pub use structure_defs::StructureDefs;
 pub use term::Term;
 pub use time_specifier::TimeSpecifier;
 pub use timed_effect::TimedEffect;
-pub use timed_gd::TimedGD;
+#[allow(deprecated)]
+pub use timed_gd::{TimedGD, TimedGoalDefinition};
 pub use timeless::Timeless;
 pub use typed::{ToTyped, Typed};
 pub use typed_list::TypedList;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -159,7 +159,8 @@ pub use predicate_definitions::PredicateDefinitions;
 pub use pref_con_gd::{
     PrefConGD, PrefConGDs, PreferenceConstraintGoalDefinition, PreferenceConstraintGoalDefinitions,
 };
-pub use pref_gd::PreferenceGD;
+#[allow(deprecated)]
+pub use pref_gd::{PreferenceGD, PreferenceGoalDefinition};
 pub use pref_name::PreferenceName;
 #[allow(deprecated)]
 pub use pref_timed_gd::{PrefTimedGD, PreferenceTimedGoalDefinition};

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -90,7 +90,8 @@ pub use atomic_formula::{AtomicFormula, EqualityAtomicFormula, PredicateAtomicFo
 pub use atomic_formula_skeleton::AtomicFormulaSkeleton;
 pub use atomic_function_skeleton::AtomicFunctionSkeleton;
 pub use basic_function_term::BasicFunctionTerm;
-pub use binary_comp::BinaryComparison;
+#[allow(deprecated)]
+pub use binary_comp::{BinaryComp, BinaryComparison};
 pub use binary_op::BinaryOp;
 #[allow(deprecated)]
 pub use c_effect::{

--- a/src/types/multi_op.rs
+++ b/src/types/multi_op.rs
@@ -5,7 +5,7 @@ use std::fmt::{Display, Formatter};
 /// An operation with multiple operands.
 ///
 /// ## Usage
-/// Used by [`MetricFExp`](crate::MetricFExp) and [`FExpDa`](crate::FExpDa).
+/// Used by [`MetricFluentExpression`](crate::MetricFluentExpression) and [`FExpDa`](crate::FExpDa).
 /// Implicitly used by [`BinaryOp`](crate::BinaryOp).
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum MultiOp {

--- a/src/types/name.rs
+++ b/src/types/name.rs
@@ -14,7 +14,7 @@ static STRING_INTERNING: LazyLock<Mutex<Vec<Arc<String>>>> = LazyLock::new(Mutex
 ///
 /// ## Usage
 /// Used by [`Domain`](crate::Domain), [`InitElement`](crate::InitElement),
-/// [`BasicFunctionTerm`](crate::BasicFunctionTerm), [`MetricFExp`](crate::MetricFExp),
+/// [`BasicFunctionTerm`](crate::BasicFunctionTerm), [`MetricFluentExpression`](crate::MetricFluentExpression),
 /// [`PrimitiveType`](PrimitiveType), [`Predicate`](crate::Predicate), [`Variable`](crate::Variable),
 /// [`FunctionSymbol`](crate::FunctionSymbol), [`ActionSymbol`](crate::ActionSymbol),
 /// [`PreferenceName`](crate::PreferenceName), [`Term`](crate::Term),

--- a/src/types/number.rs
+++ b/src/types/number.rs
@@ -27,7 +27,7 @@ type UnderlyingType = f32;
 ///
 /// ## Usage
 /// Used by [`InitElement`](crate::InitElement), [`ConGD`](crate::ConGD),
-/// [`MetricFExp`](crate::MetricFExp) and [`DurationValue`](crate::DurationValue).
+/// [`MetricFluentExpression`](crate::MetricFluentExpression) and [`DurationValue`](crate::DurationValue).
 #[derive(Debug, Copy, Clone, Default)]
 pub struct Number(UnderlyingType);
 

--- a/src/types/number.rs
+++ b/src/types/number.rs
@@ -224,3 +224,200 @@ impl From<f64> for Number {
         Number::new(value as UnderlyingType)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::panic;
+
+    #[test]
+    fn new_works() {
+        let n = Number::new(42.0);
+        assert_eq!(*n, 42.0);
+    }
+
+    #[test]
+    fn try_new_finite_ok() {
+        assert!(Number::try_new(0.0).is_ok());
+        assert!(Number::try_new(-1.5).is_ok());
+        assert!(Number::try_new(f32::MAX).is_ok());
+        assert!(Number::try_new(f32::MIN).is_ok());
+    }
+
+    #[test]
+    fn try_new_nan_err() {
+        assert!(matches!(
+            Number::try_new(f32::NAN),
+            Err(NumberError::NotFinite)
+        ));
+    }
+
+    #[test]
+    fn try_new_inf_err() {
+        assert!(matches!(
+            Number::try_new(f32::INFINITY),
+            Err(NumberError::NotFinite)
+        ));
+        assert!(matches!(
+            Number::try_new(f32::NEG_INFINITY),
+            Err(NumberError::NotFinite)
+        ));
+    }
+
+    #[test]
+    fn from_str_valid() {
+        let n: Number = "2.5".parse().unwrap();
+        assert_eq!(*n, 2.5);
+    }
+
+    #[test]
+    fn from_str_invalid() {
+        let err = "not_a_number".parse::<Number>().unwrap_err();
+        assert!(matches!(err, NumberError::InvalidFormat(_)));
+    }
+
+    #[test]
+    fn error_display_not_finite() {
+        let err = NumberError::NotFinite;
+        assert_eq!(format!("{err}"), "The input was not a finite number");
+    }
+
+    #[test]
+    fn error_display_invalid_format() {
+        let err = NumberError::InvalidFormat("abc".parse::<f32>().unwrap_err());
+        let msg = format!("{err}");
+        assert!(msg.contains("Invalid format"));
+    }
+
+    #[test]
+    fn eq_int() {
+        let n = Number::from(42i32);
+        assert_eq!(n, 42);
+        assert_eq!(n, 42.0);
+    }
+
+    #[test]
+    fn eq_from_i8() {
+        let n = Number::from(5i8);
+        assert_eq!(*n, 5.0);
+    }
+
+    #[test]
+    fn eq_from_u8() {
+        let n = Number::from(5u8);
+        assert_eq!(*n, 5.0);
+    }
+
+    #[test]
+    fn eq_from_i16() {
+        let n = Number::from(5i16);
+        assert_eq!(*n, 5.0);
+    }
+
+    #[test]
+    fn eq_from_u16() {
+        let n = Number::from(5u16);
+        assert_eq!(*n, 5.0);
+    }
+
+    #[test]
+    fn eq_from_i32() {
+        let n = Number::from(5i32);
+        assert_eq!(*n, 5.0);
+    }
+
+    #[test]
+    fn eq_from_u32() {
+        let n = Number::from(5u32);
+        assert_eq!(*n, 5.0);
+    }
+
+    #[test]
+    fn eq_from_f32() {
+        let n = Number::from(2.5f32);
+        assert_eq!(*n, 2.5);
+    }
+
+    #[test]
+    fn eq_from_f64() {
+        let n = Number::from(2.5f64);
+        assert!((*n - 2.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn ord_works() {
+        let a = Number::from(1i32);
+        let b = Number::from(2i32);
+        assert!(a < b);
+        assert!(b > a);
+    }
+
+    #[test]
+    fn ord_equal() {
+        let a = Number::from(5i32);
+        let b = Number::from(5i32);
+        assert!(a <= b);
+        assert!(a >= b);
+    }
+
+    #[test]
+    fn ord_plus_minus_zero_equal() {
+        let a = Number::new(0.0);
+        let b = Number::new(-0.0);
+        assert_eq!(a.cmp(&b), Ordering::Equal);
+    }
+
+    #[test]
+    fn hash_zero_equals_neg_zero() {
+        use std::collections::hash_map::DefaultHasher;
+        let a = Number::new(0.0);
+        let b = Number::new(-0.0);
+        let mut ha = DefaultHasher::new();
+        let mut hb = DefaultHasher::new();
+        a.hash(&mut ha);
+        b.hash(&mut hb);
+        assert_eq!(ha.finish(), hb.finish());
+    }
+
+    #[test]
+    fn default_is_zero() {
+        let n = Number::default();
+        assert_eq!(*n, 0.0);
+    }
+
+    #[test]
+    fn deref_works() {
+        let n = Number::from(7i32);
+        let val: &f32 = &n;
+        assert_eq!(*val, 7.0);
+    }
+
+    #[test]
+    fn new_nan_panics() {
+        assert!(panic::catch_unwind(|| Number::new(f32::NAN)).is_err());
+    }
+
+    #[test]
+    fn from_f32_nan_panics() {
+        assert!(panic::catch_unwind(|| Number::from(f32::NAN)).is_err());
+    }
+
+    #[test]
+    fn from_f64_nan_panics() {
+        assert!(panic::catch_unwind(|| Number::from(f64::NAN)).is_err());
+    }
+
+    #[test]
+    fn copy_clone() {
+        let a = Number::from(10i32);
+        let b = a;
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn debug_impl() {
+        let n = Number::from(42i32);
+        let dbg = format!("{n:?}");
+        assert!(dbg.contains("42"));
+    }
+}

--- a/src/types/p_effect.rs
+++ b/src/types/p_effect.rs
@@ -1,25 +1,26 @@
-//! Contains p-effects.
+//! Contains primitive effects.
 
-use crate::types::{AssignOp, AtomicFormula, FExp, FHead, FunctionTerm, Term};
+use crate::types::{AssignOp, AtomicFormula, FluentExpression, FunctionHead, FunctionTerm, Term};
 
-/// A p-effect. Occurs as part of a [`CEffect`](crate::types::CEffect) (within an [`Effect`](crate::types::Effects))
+/// A primitive effect. Occurs as part of a [`ConditionalEffect`](crate::types::ConditionalEffect) (within an [`Effect`](crate::types::Effects))
 /// or a [`ConditionalEffect`](crate::types::ConditionalEffect).
 ///
 /// ## Usage
-/// Used by [`CEffect`](crate::CEffect) and [`ConditionalEffect`](crate::ConditionalEffect).
+/// Used by [`ConditionalEffect`](crate::ConditionalEffect) and [`ConditionalEffect`](crate::ConditionalEffect).
+#[doc(alias("p-effect"))]
 #[derive(Debug, Clone, PartialEq)]
-pub enum PEffect {
+pub enum PrimitiveEffect {
     AtomicFormula(AtomicFormula<Term>),
     NotAtomicFormula(AtomicFormula<Term>),
     /// ## Requirements
     /// Requires [Numeric Fluents](crate::Requirement::NumericFluents).
-    AssignNumericFluent(AssignOp, FHead, FExp),
+    AssignNumericFluent(AssignOp, FunctionHead, FluentExpression),
     /// ## Requirements
     /// Requires [Object Fluents](crate::Requirement::ObjectFluents).
     AssignObjectFluent(FunctionTerm, Option<Term>),
 }
 
-impl PEffect {
+impl PrimitiveEffect {
     pub const fn new(atomic_formula: AtomicFormula<Term>) -> Self {
         Self::AtomicFormula(atomic_formula)
     }
@@ -28,7 +29,7 @@ impl PEffect {
         Self::NotAtomicFormula(atomic_formula)
     }
 
-    pub const fn new_numeric_fluent(op: AssignOp, head: FHead, exp: FExp) -> Self {
+    pub const fn new_numeric_fluent(op: AssignOp, head: FunctionHead, exp: FluentExpression) -> Self {
         Self::AssignNumericFluent(op, head, exp)
     }
 
@@ -36,3 +37,7 @@ impl PEffect {
         Self::AssignObjectFluent(f_term, term)
     }
 }
+
+/// Alias for [`PrimitiveEffect`]; matches BNF `<p-effect>`.
+#[deprecated(since = "0.2.0", note = "Use `PrimitiveEffect` instead")]
+pub type PEffect = PrimitiveEffect;

--- a/src/types/p_effect.rs
+++ b/src/types/p_effect.rs
@@ -2,11 +2,11 @@
 
 use crate::types::{AssignOp, AtomicFormula, FluentExpression, FunctionHead, FunctionTerm, Term};
 
-/// A primitive effect. Occurs as part of a [`ConditionalEffect`](crate::types::ConditionalEffect) (within an [`Effect`](crate::types::Effects))
-/// or a [`ConditionalEffect`](crate::types::ConditionalEffect).
+/// A primitive effect. Occurs as part of a [`ConditionalEffect`](crate::ConditionalEffect) via its `Effect` variant,
+/// or nested within an [`EffectCondition`](crate::EffectCondition) inside `when` clauses.
 ///
 /// ## Usage
-/// Used by [`ConditionalEffect`](crate::ConditionalEffect) and [`ConditionalEffect`](crate::ConditionalEffect).
+/// Used by [`ConditionalEffect`](crate::ConditionalEffect) and [`EffectCondition`](crate::EffectCondition).
 #[doc(alias("p-effect"))]
 #[derive(Debug, Clone, PartialEq)]
 pub enum PrimitiveEffect {
@@ -25,23 +25,179 @@ impl PrimitiveEffect {
         Self::AtomicFormula(atomic_formula)
     }
 
-    pub const fn new_not(atomic_formula: AtomicFormula<Term>) -> Self {
+    pub const fn atomic_formula(atomic_formula: AtomicFormula<Term>) -> Self {
+        Self::AtomicFormula(atomic_formula)
+    }
+
+    #[deprecated(since = "0.2.0", note = "Use `atomic_formula` instead")]
+    pub const fn new_atomic_formula(atomic_formula: AtomicFormula<Term>) -> Self {
+        Self::atomic_formula(atomic_formula)
+    }
+
+    pub const fn not(atomic_formula: AtomicFormula<Term>) -> Self {
         Self::NotAtomicFormula(atomic_formula)
     }
 
+    #[deprecated(since = "0.2.0", note = "Use `not` instead")]
+    pub const fn new_not(atomic_formula: AtomicFormula<Term>) -> Self {
+        Self::not(atomic_formula)
+    }
+
+    pub const fn numeric_fluent(op: AssignOp, head: FunctionHead, exp: FluentExpression) -> Self {
+        Self::AssignNumericFluent(op, head, exp)
+    }
+
+    #[deprecated(since = "0.2.0", note = "Use `numeric_fluent` instead")]
     pub const fn new_numeric_fluent(
         op: AssignOp,
         head: FunctionHead,
         exp: FluentExpression,
     ) -> Self {
-        Self::AssignNumericFluent(op, head, exp)
+        Self::numeric_fluent(op, head, exp)
     }
 
-    pub const fn new_object_fluent(f_term: FunctionTerm, term: Option<Term>) -> Self {
+    pub const fn object_fluent(f_term: FunctionTerm, term: Option<Term>) -> Self {
         Self::AssignObjectFluent(f_term, term)
+    }
+
+    #[deprecated(since = "0.2.0", note = "Use `object_fluent` instead")]
+    pub const fn new_object_fluent(f_term: FunctionTerm, term: Option<Term>) -> Self {
+        Self::object_fluent(f_term, term)
     }
 }
 
 /// Alias for [`PrimitiveEffect`]; matches BNF `<p-effect>`.
 #[deprecated(since = "0.2.0", note = "Use `PrimitiveEffect` instead")]
 pub type PEffect = PrimitiveEffect;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{FunctionSymbol, Name};
+    use crate::Predicate;
+
+    fn make_atomic_formula() -> AtomicFormula<Term> {
+        AtomicFormula::predicate(
+            Predicate::string("on"),
+            vec![
+                Term::new_name(Name::new("a")),
+                Term::new_name(Name::new("b")),
+            ],
+        )
+    }
+
+    #[test]
+    fn atomic_formula_new() {
+        let af = make_atomic_formula();
+        let pe = PrimitiveEffect::new(af.clone());
+        assert_eq!(pe, PrimitiveEffect::AtomicFormula(af));
+    }
+
+    #[test]
+    fn atomic_formula_constructor() {
+        let af = make_atomic_formula();
+        let pe = PrimitiveEffect::atomic_formula(af.clone());
+        assert_eq!(pe, PrimitiveEffect::AtomicFormula(af));
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn atomic_formula_deprecated_new() {
+        let af = make_atomic_formula();
+        let pe = PrimitiveEffect::new_atomic_formula(af.clone());
+        assert_eq!(pe, PrimitiveEffect::AtomicFormula(af));
+    }
+
+    #[test]
+    fn not_constructor() {
+        let af = make_atomic_formula();
+        let pe = PrimitiveEffect::not(af.clone());
+        assert_eq!(pe, PrimitiveEffect::NotAtomicFormula(af));
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn not_deprecated_new() {
+        let af = make_atomic_formula();
+        let pe = PrimitiveEffect::new_not(af.clone());
+        assert_eq!(pe, PrimitiveEffect::NotAtomicFormula(af));
+    }
+
+    #[test]
+    fn numeric_fluent_constructor() {
+        let head = FunctionHead::Simple(FunctionSymbol::string("total-cost"));
+        let exp = FluentExpression::number(10);
+        let pe = PrimitiveEffect::numeric_fluent(AssignOp::Assign, head, exp);
+        assert!(matches!(pe, PrimitiveEffect::AssignNumericFluent(_, _, _)));
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn numeric_fluent_deprecated_new() {
+        let head = FunctionHead::Simple(FunctionSymbol::string("total-cost"));
+        let exp = FluentExpression::number(10);
+        let pe = PrimitiveEffect::new_numeric_fluent(AssignOp::Assign, head, exp);
+        assert!(matches!(pe, PrimitiveEffect::AssignNumericFluent(_, _, _)));
+    }
+
+    #[test]
+    fn object_fluent_with_value() {
+        let f_term = FunctionTerm::new(FunctionSymbol::string("loc"), vec![]);
+        let term = Term::new_name(Name::new("home"));
+        let pe = PrimitiveEffect::object_fluent(f_term.clone(), Some(term.clone()));
+        assert_eq!(pe, PrimitiveEffect::AssignObjectFluent(f_term, Some(term)));
+    }
+
+    #[test]
+    fn object_fluent_without_value() {
+        let f_term = FunctionTerm::new(FunctionSymbol::string("loc"), vec![]);
+        let pe = PrimitiveEffect::object_fluent(f_term.clone(), None);
+        assert_eq!(pe, PrimitiveEffect::AssignObjectFluent(f_term, None));
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn object_fluent_deprecated_new() {
+        let f_term = FunctionTerm::new(FunctionSymbol::string("loc"), vec![]);
+        let pe = PrimitiveEffect::new_object_fluent(f_term.clone(), None);
+        assert_eq!(pe, PrimitiveEffect::AssignObjectFluent(f_term, None));
+    }
+
+    #[test]
+    fn clone_works() {
+        let af = make_atomic_formula();
+        let pe = PrimitiveEffect::atomic_formula(af);
+        let clone = pe.clone();
+        assert_eq!(pe, clone);
+    }
+
+    #[test]
+    fn debug_impl() {
+        let af = make_atomic_formula();
+        let pe = PrimitiveEffect::atomic_formula(af);
+        let dbg = format!("{pe:?}");
+        assert!(dbg.contains("AtomicFormula"));
+    }
+
+    #[test]
+    fn all_assign_ops_numeric_fluent() {
+        let head = FunctionHead::Simple(FunctionSymbol::string("f"));
+        let exp = FluentExpression::number(1);
+        for op in [
+            AssignOp::Assign,
+            AssignOp::ScaleUp,
+            AssignOp::ScaleDown,
+            AssignOp::Increase,
+            AssignOp::Decrease,
+        ] {
+            let pe = PrimitiveEffect::numeric_fluent(op, head.clone(), exp.clone());
+            assert!(matches!(pe, PrimitiveEffect::AssignNumericFluent(_, _, _)));
+        }
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn deprecated_alias_exists() {
+        fn _assert_alias(_: PEffect) {}
+    }
+}

--- a/src/types/p_effect.rs
+++ b/src/types/p_effect.rs
@@ -29,7 +29,11 @@ impl PrimitiveEffect {
         Self::NotAtomicFormula(atomic_formula)
     }
 
-    pub const fn new_numeric_fluent(op: AssignOp, head: FunctionHead, exp: FluentExpression) -> Self {
+    pub const fn new_numeric_fluent(
+        op: AssignOp,
+        head: FunctionHead,
+        exp: FluentExpression,
+    ) -> Self {
         Self::AssignNumericFluent(op, head, exp)
     }
 

--- a/src/types/pre_gd.rs
+++ b/src/types/pre_gd.rs
@@ -1,7 +1,7 @@
 //! Contains precondition goal definitions.
 
 use crate::types::TypedVariables;
-use crate::types::{Preference, PreferenceGD};
+use crate::types::{Preference, PreferenceGoalDefinition};
 use std::ops::Deref;
 
 /// Zero, one or many precondition goal definitions.
@@ -18,7 +18,7 @@ impl PreconditionGoalDefinitions {
     }
 
     /// Constructs a list containing a single [`PreconditionGoalDefinition::Preference`] variant.
-    pub fn new_preference(pref: PreferenceGD) -> Self {
+    pub fn new_preference(pref: PreferenceGoalDefinition) -> Self {
         PreconditionGoalDefinition::new_preference(pref).into()
     }
 
@@ -127,9 +127,9 @@ impl TryInto<PreconditionGoalDefinition> for PreconditionGoalDefinitions {
 #[derive(Debug, Clone, PartialEq)]
 pub enum PreconditionGoalDefinition {
     /// ## Requirements
-    /// None per se: this branch may expand into [`PreferenceGD::Goal`](PreferenceGD::Goal),
+    /// None per se: this branch may expand into [`PreferenceGoalDefinition::Goal`](PreferenceGoalDefinition::Goal),
     /// which has no requirements.
-    Preference(PreferenceGD),
+    Preference(PreferenceGoalDefinition),
     /// ## Requirements
     /// Requires [Universal Preconditions](crate::Requirement::UniversalPreconditions).
     Forall(TypedVariables, PreconditionGoalDefinitions),
@@ -144,7 +144,7 @@ impl PreconditionGoalDefinition {
     }
 
     /// Constructs a new [`Preference`](Self::Preference) variant.
-    pub const fn new_preference(pref: PreferenceGD) -> Self {
+    pub const fn new_preference(pref: PreferenceGoalDefinition) -> Self {
         Self::Preference(pref)
     }
 
@@ -154,14 +154,14 @@ impl PreconditionGoalDefinition {
     }
 }
 
-impl From<PreferenceGD> for PreconditionGoalDefinition {
-    fn from(value: PreferenceGD) -> Self {
+impl From<PreferenceGoalDefinition> for PreconditionGoalDefinition {
+    fn from(value: PreferenceGoalDefinition) -> Self {
         PreconditionGoalDefinition::new_preference(value)
     }
 }
 
 impl From<Preference> for PreconditionGoalDefinition {
     fn from(value: Preference) -> Self {
-        PreconditionGoalDefinition::new_preference(PreferenceGD::from_preference(value))
+        PreconditionGoalDefinition::new_preference(PreferenceGoalDefinition::from_preference(value))
     }
 }

--- a/src/types/pre_gd.rs
+++ b/src/types/pre_gd.rs
@@ -192,3 +192,161 @@ impl From<Preference> for PreconditionGoalDefinition {
         PreconditionGoalDefinition::preference(PreferenceGoalDefinition::from_preference(value))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{GoalDefinition, PreferenceGoalDefinition};
+
+    fn make_preference_goal() -> PreferenceGoalDefinition {
+        let gd = GoalDefinition::and(Vec::new());
+        PreferenceGoalDefinition::from_gd(gd)
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn deprecated_new_constructors() {
+        let pref = make_preference_goal();
+        let _ = PreconditionGoalDefinitions::new_preference(pref.clone());
+        let _ = PreconditionGoalDefinitions::new_forall(
+            TypedVariables::default(),
+            PreconditionGoalDefinitions::default(),
+        );
+    }
+
+    #[test]
+    fn pre_gd_from_preference_goal() {
+        let pref = make_preference_goal();
+        let from_pref: PreconditionGoalDefinition = pref.clone().into();
+        assert_eq!(from_pref, PreconditionGoalDefinition::preference(pref));
+    }
+
+    #[test]
+    fn pre_gd_from_preference() {
+        let gd = GoalDefinition::and(Vec::new());
+        let pref = crate::Preference::new(None, gd);
+        let from_pref: PreconditionGoalDefinition = pref.into();
+        assert!(matches!(
+            from_pref,
+            PreconditionGoalDefinition::Preference(_)
+        ));
+    }
+
+    #[test]
+    fn pre_gds_from_option_some() {
+        let pref = make_preference_goal();
+        let single = PreconditionGoalDefinition::preference(pref);
+        let from_some: PreconditionGoalDefinitions = Some(single.clone()).into();
+        assert_eq!(from_some.len(), 1);
+        assert_eq!(from_some.try_get_single(), Some(single));
+    }
+
+    #[test]
+    fn pre_gds_from_option_none() {
+        let from_none: PreconditionGoalDefinitions =
+            Option::<PreconditionGoalDefinition>::None.into();
+        assert!(from_none.is_empty());
+    }
+
+    #[test]
+    fn pre_gds_from_option_list_some() {
+        let list = PreconditionGoalDefinitions::default();
+        let from_some: PreconditionGoalDefinitions = Some(list).into();
+        assert!(from_some.is_empty());
+    }
+
+    #[test]
+    fn pre_gds_from_option_list_none() {
+        let from_none: PreconditionGoalDefinitions =
+            Option::<PreconditionGoalDefinitions>::None.into();
+        assert!(from_none.is_empty());
+    }
+
+    #[test]
+    fn pre_gds_deref() {
+        let pref = make_preference_goal();
+        let single = PreconditionGoalDefinition::preference(pref);
+        let list = PreconditionGoalDefinitions::new(vec![single.clone()]);
+        let slice: &[PreconditionGoalDefinition] = &list;
+        assert_eq!(slice.len(), 1);
+        assert_eq!(&slice[0], &single);
+    }
+
+    #[test]
+    fn pre_gds_as_ref() {
+        let pref = make_preference_goal();
+        let single = PreconditionGoalDefinition::preference(pref);
+        let list = PreconditionGoalDefinitions::new(vec![single]);
+        let slice: &[PreconditionGoalDefinition] = list.as_ref();
+        assert_eq!(slice.len(), 1);
+    }
+
+    #[test]
+    fn pre_gds_into_iter() {
+        let pref = make_preference_goal();
+        let single = PreconditionGoalDefinition::preference(pref.clone());
+        let list = PreconditionGoalDefinitions::new(vec![single.clone()]);
+        let collected: Vec<_> = list.into_iter().collect();
+        assert_eq!(collected, vec![single]);
+    }
+
+    #[test]
+    fn pre_gds_into_vec() {
+        let pref = make_preference_goal();
+        let single = PreconditionGoalDefinition::preference(pref.clone());
+        let list = PreconditionGoalDefinitions::new(vec![single.clone()]);
+        let vec: Vec<PreconditionGoalDefinition> = list.into();
+        assert_eq!(vec, vec![single]);
+    }
+
+    #[test]
+    fn pre_gds_try_get_single() {
+        let pref = make_preference_goal();
+        let single = PreconditionGoalDefinition::preference(pref.clone());
+        let list = PreconditionGoalDefinitions::new(vec![single.clone()]);
+        assert_eq!(list.try_get_single(), Some(single.clone()));
+
+        let empty = PreconditionGoalDefinitions::default();
+        assert!(empty.try_get_single().is_none());
+
+        let multi = PreconditionGoalDefinitions::new(vec![single.clone(), single]);
+        assert!(multi.try_get_single().is_none());
+    }
+
+    #[test]
+    fn pre_gds_try_into() {
+        let pref = make_preference_goal();
+        let single = PreconditionGoalDefinition::preference(pref.clone());
+        let list = PreconditionGoalDefinitions::new(vec![single.clone()]);
+        let result: Result<PreconditionGoalDefinition, ()> = list.try_into();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), single);
+    }
+
+    #[test]
+    fn pre_gd_and() {
+        let pref = make_preference_goal();
+        let items = vec![
+            PreconditionGoalDefinition::preference(pref.clone()),
+            PreconditionGoalDefinition::preference(pref),
+        ];
+        let result: PreconditionGoalDefinitions = PreconditionGoalDefinition::and(items);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn pre_gd_and_deprecated() {
+        let pref = make_preference_goal();
+        let _ =
+            PreconditionGoalDefinition::new_and(vec![PreconditionGoalDefinition::preference(pref)]);
+    }
+
+    #[test]
+    fn pre_gd_forall() {
+        let vars = TypedVariables::default();
+        let gds = PreconditionGoalDefinitions::default();
+        let forall = PreconditionGoalDefinition::r#forall(vars.clone(), gds.clone());
+        assert!(matches!(forall, PreconditionGoalDefinition::Forall(_, _)));
+    }
+}

--- a/src/types/pre_gd.rs
+++ b/src/types/pre_gd.rs
@@ -18,13 +18,23 @@ impl PreconditionGoalDefinitions {
     }
 
     /// Constructs a list containing a single [`PreconditionGoalDefinition::Preference`] variant.
+    #[doc(alias = "new_preference")]
+    pub fn preference(pref: PreferenceGoalDefinition) -> Self {
+        PreconditionGoalDefinition::preference(pref).into()
+    }
+
     pub fn new_preference(pref: PreferenceGoalDefinition) -> Self {
-        PreconditionGoalDefinition::new_preference(pref).into()
+        Self::preference(pref)
     }
 
     /// Constructs a list containing a single [`PreconditionGoalDefinition::Forall`] variant.
+    #[doc(alias = "new_forall")]
+    pub fn r#forall(variables: TypedVariables, gd: PreconditionGoalDefinitions) -> Self {
+        PreconditionGoalDefinition::r#forall(variables, gd).into()
+    }
+
     pub fn new_forall(variables: TypedVariables, gd: PreconditionGoalDefinitions) -> Self {
-        PreconditionGoalDefinition::new_forall(variables, gd).into()
+        Self::r#forall(variables, gd)
     }
 
     /// Returns `true` if the list contains no elements.
@@ -136,32 +146,49 @@ pub enum PreconditionGoalDefinition {
 }
 
 impl PreconditionGoalDefinition {
-    pub fn new_and<I: IntoIterator<Item = PreconditionGoalDefinition>>(
+    #[doc(alias = "new_and")]
+    pub fn and<I: IntoIterator<Item = PreconditionGoalDefinition>>(
         iter: I,
     ) -> PreconditionGoalDefinitions {
         // TODO: Flatten `(and (and a b) (and x y))` into `(and a b c y)`.
         PreconditionGoalDefinitions::from_iter(iter)
     }
 
+    pub fn new_and<I: IntoIterator<Item = PreconditionGoalDefinition>>(
+        iter: I,
+    ) -> PreconditionGoalDefinitions {
+        Self::and(iter)
+    }
+
     /// Constructs a new [`Preference`](Self::Preference) variant.
-    pub const fn new_preference(pref: PreferenceGoalDefinition) -> Self {
+    #[doc(alias = "new_preference")]
+    pub const fn preference(pref: PreferenceGoalDefinition) -> Self {
         Self::Preference(pref)
     }
 
+    pub fn new_preference(pref: PreferenceGoalDefinition) -> Self {
+        Self::preference(pref)
+    }
+
     /// Constructs a new [`Forall`](Self::Forall) variant.
-    pub const fn new_forall(variables: TypedVariables, gd: PreconditionGoalDefinitions) -> Self {
+    #[doc(alias = "new_forall")]
+    pub const fn r#forall(variables: TypedVariables, gd: PreconditionGoalDefinitions) -> Self {
         Self::Forall(variables, gd)
+    }
+
+    pub fn new_forall(variables: TypedVariables, gd: PreconditionGoalDefinitions) -> Self {
+        Self::r#forall(variables, gd)
     }
 }
 
 impl From<PreferenceGoalDefinition> for PreconditionGoalDefinition {
     fn from(value: PreferenceGoalDefinition) -> Self {
-        PreconditionGoalDefinition::new_preference(value)
+        PreconditionGoalDefinition::preference(value)
     }
 }
 
 impl From<Preference> for PreconditionGoalDefinition {
     fn from(value: Preference) -> Self {
-        PreconditionGoalDefinition::new_preference(PreferenceGoalDefinition::from_preference(value))
+        PreconditionGoalDefinition::preference(PreferenceGoalDefinition::from_preference(value))
     }
 }

--- a/src/types/predicate.rs
+++ b/src/types/predicate.rs
@@ -17,8 +17,14 @@ impl Predicate {
     }
 
     #[inline(always)]
-    pub fn new_string(name: &str) -> Self {
+    #[doc(alias = "new_string")]
+    pub fn string(name: &str) -> Self {
         Self(Name::new(name))
+    }
+
+    #[inline(always)]
+    pub fn new_string(name: &str) -> Self {
+        Self::string(name)
     }
 
     #[inline(always)]

--- a/src/types/pref_con_gd.rs
+++ b/src/types/pref_con_gd.rs
@@ -1,9 +1,9 @@
-//! Contains the type [`PrefConGD`].
+//! Contains the types [`PreferenceConstraintGoalDefinition`] and [`PreferenceConstraintGoalDefinitions`].
 
-use crate::types::{ConGD, PreferenceName, TypedVariables};
+use crate::types::{ConstraintGoalDefinition, PreferenceName, TypedVariables};
 use std::ops::Deref;
 
-/// A list of [`PrefConGD`] values. This represents the `(and ...)` variant
+/// A list of [`PreferenceConstraintGoalDefinition`] values. This represents the `(and ...)` variant
 /// of the PDDL definition, modeling cases of zero, one or many values.
 ///
 /// ## Requirements
@@ -12,33 +12,38 @@ use std::ops::Deref;
 /// ## Usage
 /// Used by [`ProblemConstraintsDef`](crate::ProblemConstraintsDef).
 #[derive(Debug, Clone, PartialEq, Default)]
-pub struct PrefConGDs(Vec<PrefConGD>);
+#[doc(alias = "pref-con-GD")]
+pub struct PreferenceConstraintGoalDefinitions(Vec<PreferenceConstraintGoalDefinition>);
 
-impl PrefConGDs {
+impl PreferenceConstraintGoalDefinitions {
     /// Constructs a new instance from the provided vector of values.
-    pub const fn new(gds: Vec<PrefConGD>) -> Self {
+    pub const fn new(gds: Vec<PreferenceConstraintGoalDefinition>) -> Self {
         Self(gds)
     }
 
-    /// Constructs a list containing a single [`PrefConGD::Goal`] variant.
-    pub fn new_goal(gd: ConGD) -> Self {
-        Self::new(vec![PrefConGD::new_goal(gd)])
+    /// Constructs a list containing a single [`PreferenceConstraintGoalDefinition::Goal`] variant.
+    pub fn new_goal(gd: ConstraintGoalDefinition) -> Self {
+        Self::new(vec![PreferenceConstraintGoalDefinition::new_goal(gd)])
     }
 
-    /// Constructs a list containing a single [`PrefConGD::Preference`] variant.
+    /// Constructs a list containing a single [`PreferenceConstraintGoalDefinition::Preference`] variant.
     ///
     /// ## Requirements
     /// Requires [Preferences](crate::Requirement::Preferences).
-    pub fn new_preference(name: Option<PreferenceName>, gd: ConGD) -> Self {
-        Self::new(vec![PrefConGD::new_preference(name, gd)])
+    pub fn new_preference(name: Option<PreferenceName>, gd: ConstraintGoalDefinition) -> Self {
+        Self::new(vec![PreferenceConstraintGoalDefinition::new_preference(
+            name, gd,
+        )])
     }
 
-    /// Constructs a list containing a single [`PrefConGD::Forall`] variant.
+    /// Constructs a list containing a single [`PreferenceConstraintGoalDefinition::Forall`] variant.
     ///
     /// ## Requirements
     /// Requires [Universal Preconditions](crate::Requirement::UniversalPreconditions).
-    pub fn new_forall(variables: TypedVariables, gd: PrefConGDs) -> Self {
-        Self::new(vec![PrefConGD::new_forall(variables, gd)])
+    pub fn new_forall(variables: TypedVariables, gd: PreferenceConstraintGoalDefinitions) -> Self {
+        Self::new(vec![PreferenceConstraintGoalDefinition::new_forall(
+            variables, gd,
+        )])
     }
 
     /// Returns `true` if the list contains no elements.
@@ -55,13 +60,13 @@ impl PrefConGDs {
     /// Returns an iterator over the list.
     ///
     /// The iterator yields all items from start to end.
-    pub fn iter(&self) -> std::slice::Iter<'_, PrefConGD> {
+    pub fn iter(&self) -> std::slice::Iter<'_, PreferenceConstraintGoalDefinition> {
         self.0.iter()
     }
 
     /// Get the only element of this list if the list has
     /// exactly one element. Returns [`None`] in all other cases.
-    pub fn try_get_single(self) -> Option<PrefConGD> {
+    pub fn try_get_single(self) -> Option<PreferenceConstraintGoalDefinition> {
         if self.len() == 1 {
             self.into_iter().next()
         } else {
@@ -70,78 +75,78 @@ impl PrefConGDs {
     }
 }
 
-impl Deref for PrefConGDs {
-    type Target = [PrefConGD];
+impl Deref for PreferenceConstraintGoalDefinitions {
+    type Target = [PreferenceConstraintGoalDefinition];
 
     fn deref(&self) -> &Self::Target {
         self.0.as_slice()
     }
 }
 
-impl AsRef<[PrefConGD]> for PrefConGDs {
-    fn as_ref(&self) -> &[PrefConGD] {
+impl AsRef<[PreferenceConstraintGoalDefinition]> for PreferenceConstraintGoalDefinitions {
+    fn as_ref(&self) -> &[PreferenceConstraintGoalDefinition] {
         self.0.as_slice()
     }
 }
 
-impl IntoIterator for PrefConGDs {
-    type Item = PrefConGD;
-    type IntoIter = std::vec::IntoIter<PrefConGD>;
+impl IntoIterator for PreferenceConstraintGoalDefinitions {
+    type Item = PreferenceConstraintGoalDefinition;
+    type IntoIter = std::vec::IntoIter<PreferenceConstraintGoalDefinition>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
     }
 }
 
-impl From<PrefConGDs> for Vec<PrefConGD> {
-    fn from(value: PrefConGDs) -> Self {
+impl From<PreferenceConstraintGoalDefinitions> for Vec<PreferenceConstraintGoalDefinition> {
+    fn from(value: PreferenceConstraintGoalDefinitions) -> Self {
         value.0
     }
 }
 
-impl From<PrefConGD> for PrefConGDs {
-    fn from(value: PrefConGD) -> Self {
-        PrefConGDs::new(vec![value])
+impl From<PreferenceConstraintGoalDefinition> for PreferenceConstraintGoalDefinitions {
+    fn from(value: PreferenceConstraintGoalDefinition) -> Self {
+        PreferenceConstraintGoalDefinitions::new(vec![value])
     }
 }
 
-impl From<Vec<PrefConGD>> for PrefConGDs {
-    fn from(value: Vec<PrefConGD>) -> Self {
-        PrefConGDs::new(value)
+impl From<Vec<PreferenceConstraintGoalDefinition>> for PreferenceConstraintGoalDefinitions {
+    fn from(value: Vec<PreferenceConstraintGoalDefinition>) -> Self {
+        PreferenceConstraintGoalDefinitions::new(value)
     }
 }
 
-impl FromIterator<PrefConGD> for PrefConGDs {
-    fn from_iter<T: IntoIterator<Item = PrefConGD>>(iter: T) -> Self {
-        PrefConGDs::new(iter.into_iter().collect())
+impl FromIterator<PreferenceConstraintGoalDefinition> for PreferenceConstraintGoalDefinitions {
+    fn from_iter<T: IntoIterator<Item = PreferenceConstraintGoalDefinition>>(iter: T) -> Self {
+        PreferenceConstraintGoalDefinitions::new(iter.into_iter().collect())
     }
 }
 
-impl From<Option<PrefConGD>> for PrefConGDs {
-    fn from(value: Option<PrefConGD>) -> Self {
+impl From<Option<PreferenceConstraintGoalDefinition>> for PreferenceConstraintGoalDefinitions {
+    fn from(value: Option<PreferenceConstraintGoalDefinition>) -> Self {
         match value {
-            None => PrefConGDs::default(),
+            None => PreferenceConstraintGoalDefinitions::default(),
             Some(value) => value.into(),
         }
     }
 }
 
-impl From<Option<PrefConGDs>> for PrefConGDs {
-    fn from(value: Option<PrefConGDs>) -> Self {
+impl From<Option<PreferenceConstraintGoalDefinitions>> for PreferenceConstraintGoalDefinitions {
+    fn from(value: Option<PreferenceConstraintGoalDefinitions>) -> Self {
         value.unwrap_or_default()
     }
 }
 
-impl From<ConGD> for PrefConGDs {
-    fn from(value: ConGD) -> Self {
-        PrefConGDs::new_goal(value)
+impl From<ConstraintGoalDefinition> for PreferenceConstraintGoalDefinitions {
+    fn from(value: ConstraintGoalDefinition) -> Self {
+        PreferenceConstraintGoalDefinitions::new_goal(value)
     }
 }
 
-impl TryInto<PrefConGD> for PrefConGDs {
+impl TryInto<PreferenceConstraintGoalDefinition> for PreferenceConstraintGoalDefinitions {
     type Error = ();
 
-    fn try_into(self) -> Result<PrefConGD, Self::Error> {
+    fn try_into(self) -> Result<PreferenceConstraintGoalDefinition, Self::Error> {
         self.try_get_single().ok_or(())
     }
 }
@@ -150,40 +155,58 @@ impl TryInto<PrefConGD> for PrefConGDs {
 /// Requires [Constraints](crate::Requirement::Constraints).
 ///
 /// ## Usage
-/// Used by [`PrefConGD`] itself, as well as [`ProblemConstraintsDef`](crate::ProblemConstraintsDef).
+/// Used by [`PreferenceConstraintGoalDefinitions`] itself, as well as [`ProblemConstraintsDef`](crate::ProblemConstraintsDef).
 #[derive(Debug, Clone, PartialEq)]
-pub enum PrefConGD {
-    Goal(ConGD),
+#[doc(alias = "pref-con-GD")]
+pub enum PreferenceConstraintGoalDefinition {
+    Goal(ConstraintGoalDefinition),
     /// ## Requirements
     /// Requires [Universal Preconditions](crate::Requirement::UniversalPreconditions).
-    Forall(TypedVariables, PrefConGDs),
+    Forall(TypedVariables, PreferenceConstraintGoalDefinitions),
     /// ## Requirements
     /// Requires [Preferences](crate::Requirement::Preferences).
-    Preference(Option<PreferenceName>, ConGD),
+    Preference(Option<PreferenceName>, ConstraintGoalDefinition),
 }
 
-impl PrefConGD {
-    pub const fn new_goal(gd: ConGD) -> Self {
+impl PreferenceConstraintGoalDefinition {
+    pub const fn new_goal(gd: ConstraintGoalDefinition) -> Self {
         Self::Goal(gd)
     }
 
     /// ## Requirements
     /// Requires [Universal Preconditions](crate::Requirement::UniversalPreconditions).
-    pub fn new_forall(variables: TypedVariables, gd: PrefConGDs) -> Self {
+    pub fn new_forall(variables: TypedVariables, gd: PreferenceConstraintGoalDefinitions) -> Self {
         Self::Forall(variables, gd)
     }
 
     /// ## Requirements
     /// Requires [Preferences](crate::Requirement::Preferences).
-    pub const fn new_preference(name: Option<PreferenceName>, gd: ConGD) -> Self {
+    pub const fn new_preference(
+        name: Option<PreferenceName>,
+        gd: ConstraintGoalDefinition,
+    ) -> Self {
         Self::Preference(name, gd)
     }
 
     pub fn is_empty(&self) -> bool {
         match self {
-            PrefConGD::Forall(_, x) => x.is_empty(),
-            PrefConGD::Preference(_, x) => x.is_empty(),
-            PrefConGD::Goal(x) => x.is_empty(),
+            PreferenceConstraintGoalDefinition::Forall(_, x) => x.is_empty(),
+            PreferenceConstraintGoalDefinition::Preference(_, x) => x.is_empty(),
+            PreferenceConstraintGoalDefinition::Goal(x) => x.is_empty(),
         }
     }
 }
+
+/// Alias for [`PreferenceConstraintGoalDefinition`]; matches BNF `<pref-con-GD>`.
+#[deprecated(
+    since = "0.2.0",
+    note = "Use `PreferenceConstraintGoalDefinition` instead"
+)]
+pub type PrefConGD = PreferenceConstraintGoalDefinition;
+
+/// Alias for [`PreferenceConstraintGoalDefinitions`]; matches BNF `<pref-con-GD>` (list form).
+#[deprecated(
+    since = "0.2.0",
+    note = "Use `PreferenceConstraintGoalDefinitions` instead"
+)]
+pub type PrefConGDs = PreferenceConstraintGoalDefinitions;

--- a/src/types/pref_con_gd.rs
+++ b/src/types/pref_con_gd.rs
@@ -22,28 +22,43 @@ impl PreferenceConstraintGoalDefinitions {
     }
 
     /// Constructs a list containing a single [`PreferenceConstraintGoalDefinition::Goal`] variant.
+    #[doc(alias = "new_goal")]
+    pub fn goal(gd: ConstraintGoalDefinition) -> Self {
+        Self::new(vec![PreferenceConstraintGoalDefinition::goal(gd)])
+    }
+
     pub fn new_goal(gd: ConstraintGoalDefinition) -> Self {
-        Self::new(vec![PreferenceConstraintGoalDefinition::new_goal(gd)])
+        Self::goal(gd)
     }
 
     /// Constructs a list containing a single [`PreferenceConstraintGoalDefinition::Preference`] variant.
     ///
     /// ## Requirements
     /// Requires [Preferences](crate::Requirement::Preferences).
-    pub fn new_preference(name: Option<PreferenceName>, gd: ConstraintGoalDefinition) -> Self {
-        Self::new(vec![PreferenceConstraintGoalDefinition::new_preference(
+    #[doc(alias = "new_preference")]
+    pub fn preference(name: Option<PreferenceName>, gd: ConstraintGoalDefinition) -> Self {
+        Self::new(vec![PreferenceConstraintGoalDefinition::preference(
             name, gd,
         )])
+    }
+
+    pub fn new_preference(name: Option<PreferenceName>, gd: ConstraintGoalDefinition) -> Self {
+        Self::preference(name, gd)
     }
 
     /// Constructs a list containing a single [`PreferenceConstraintGoalDefinition::Forall`] variant.
     ///
     /// ## Requirements
     /// Requires [Universal Preconditions](crate::Requirement::UniversalPreconditions).
-    pub fn new_forall(variables: TypedVariables, gd: PreferenceConstraintGoalDefinitions) -> Self {
-        Self::new(vec![PreferenceConstraintGoalDefinition::new_forall(
+    #[doc(alias = "new_forall")]
+    pub fn r#forall(variables: TypedVariables, gd: PreferenceConstraintGoalDefinitions) -> Self {
+        Self::new(vec![PreferenceConstraintGoalDefinition::r#forall(
             variables, gd,
         )])
+    }
+
+    pub fn new_forall(variables: TypedVariables, gd: PreferenceConstraintGoalDefinitions) -> Self {
+        Self::r#forall(variables, gd)
     }
 
     /// Returns `true` if the list contains no elements.
@@ -139,7 +154,7 @@ impl From<Option<PreferenceConstraintGoalDefinitions>> for PreferenceConstraintG
 
 impl From<ConstraintGoalDefinition> for PreferenceConstraintGoalDefinitions {
     fn from(value: ConstraintGoalDefinition) -> Self {
-        PreferenceConstraintGoalDefinitions::new_goal(value)
+        PreferenceConstraintGoalDefinitions::goal(value)
     }
 }
 
@@ -169,23 +184,35 @@ pub enum PreferenceConstraintGoalDefinition {
 }
 
 impl PreferenceConstraintGoalDefinition {
-    pub const fn new_goal(gd: ConstraintGoalDefinition) -> Self {
+    #[doc(alias = "new_goal")]
+    pub const fn goal(gd: ConstraintGoalDefinition) -> Self {
         Self::Goal(gd)
+    }
+
+    pub fn new_goal(gd: ConstraintGoalDefinition) -> Self {
+        Self::goal(gd)
     }
 
     /// ## Requirements
     /// Requires [Universal Preconditions](crate::Requirement::UniversalPreconditions).
-    pub fn new_forall(variables: TypedVariables, gd: PreferenceConstraintGoalDefinitions) -> Self {
+    #[doc(alias = "new_forall")]
+    pub fn r#forall(variables: TypedVariables, gd: PreferenceConstraintGoalDefinitions) -> Self {
         Self::Forall(variables, gd)
+    }
+
+    pub fn new_forall(variables: TypedVariables, gd: PreferenceConstraintGoalDefinitions) -> Self {
+        Self::r#forall(variables, gd)
     }
 
     /// ## Requirements
     /// Requires [Preferences](crate::Requirement::Preferences).
-    pub const fn new_preference(
-        name: Option<PreferenceName>,
-        gd: ConstraintGoalDefinition,
-    ) -> Self {
+    #[doc(alias = "new_preference")]
+    pub const fn preference(name: Option<PreferenceName>, gd: ConstraintGoalDefinition) -> Self {
         Self::Preference(name, gd)
+    }
+
+    pub fn new_preference(name: Option<PreferenceName>, gd: ConstraintGoalDefinition) -> Self {
+        Self::preference(name, gd)
     }
 
     pub fn is_empty(&self) -> bool {
@@ -210,3 +237,98 @@ pub type PrefConGD = PreferenceConstraintGoalDefinition;
     note = "Use `PreferenceConstraintGoalDefinitions` instead"
 )]
 pub type PrefConGDs = PreferenceConstraintGoalDefinitions;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pref_con_gd_is_empty() {
+        let gds = PreferenceConstraintGoalDefinitions::default();
+        assert!(gds.is_empty());
+
+        let inner = ConstraintGoalDefinition::default();
+        let goal = PreferenceConstraintGoalDefinition::goal(inner);
+        let list = PreferenceConstraintGoalDefinitions::new(vec![goal]);
+        assert!(!list.is_empty());
+    }
+
+    #[test]
+    fn pref_con_gd_try_get_single() {
+        let inner = ConstraintGoalDefinition::default();
+        let goal = PreferenceConstraintGoalDefinition::goal(inner);
+        let list = PreferenceConstraintGoalDefinitions::new(vec![goal.clone()]);
+        assert_eq!(list.try_get_single(), Some(goal));
+
+        let empty = PreferenceConstraintGoalDefinitions::default();
+        assert!(empty.try_get_single().is_none());
+    }
+
+    #[test]
+    fn pref_con_gd_is_empty_variants() {
+        let inner = ConstraintGoalDefinition::default();
+        let goal = PreferenceConstraintGoalDefinition::goal(inner.clone());
+        assert!(goal.is_empty());
+
+        let pref = PreferenceConstraintGoalDefinition::preference(None, inner.clone());
+        assert!(pref.is_empty());
+
+        let forall = PreferenceConstraintGoalDefinition::r#forall(
+            crate::types::TypedVariables::default(),
+            PreferenceConstraintGoalDefinitions::default(),
+        );
+        assert!(forall.is_empty());
+    }
+
+    #[test]
+    fn pref_con_gd_from_variants() {
+        let inner = ConstraintGoalDefinition::default();
+        let from_inner: PreferenceConstraintGoalDefinitions = inner.into();
+        assert_eq!(from_inner.len(), 1);
+
+        let single = PreferenceConstraintGoalDefinition::Goal(ConstraintGoalDefinition::default());
+        let from_single: PreferenceConstraintGoalDefinitions = single.into();
+        assert_eq!(from_single.len(), 1);
+
+        let vec = vec![PreferenceConstraintGoalDefinition::goal(
+            ConstraintGoalDefinition::default(),
+        )];
+        let from_vec: PreferenceConstraintGoalDefinitions = vec.into();
+        assert_eq!(from_vec.len(), 1);
+
+        let from_some: PreferenceConstraintGoalDefinitions = Some(
+            PreferenceConstraintGoalDefinition::goal(ConstraintGoalDefinition::default()),
+        )
+        .into();
+        assert_eq!(from_some.len(), 1);
+
+        let from_none: PreferenceConstraintGoalDefinitions =
+            Option::<PreferenceConstraintGoalDefinition>::None.into();
+        assert!(from_none.is_empty());
+
+        let from_some_list: PreferenceConstraintGoalDefinitions = Some(
+            PreferenceConstraintGoalDefinitions::goal(ConstraintGoalDefinition::default()),
+        )
+        .into();
+        assert_eq!(from_some_list.len(), 1);
+
+        let from_none_list: PreferenceConstraintGoalDefinitions =
+            Option::<PreferenceConstraintGoalDefinitions>::None.into();
+        assert!(from_none_list.is_empty());
+    }
+
+    #[test]
+    fn pref_con_gd_try_into() {
+        let goal = PreferenceConstraintGoalDefinition::goal(ConstraintGoalDefinition::default());
+        let list = PreferenceConstraintGoalDefinitions::new(vec![goal.clone()]);
+        let result: Result<PreferenceConstraintGoalDefinition, ()> = list.try_into();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn deprecated_aliases_exist() {
+        fn _assert_alias(_: PrefConGD) {}
+        fn _assert_aliases(_: PrefConGDs) {}
+    }
+}

--- a/src/types/pref_con_gd.rs
+++ b/src/types/pref_con_gd.rs
@@ -331,4 +331,93 @@ mod tests {
         fn _assert_alias(_: PrefConGD) {}
         fn _assert_aliases(_: PrefConGDs) {}
     }
+
+    #[test]
+    #[allow(deprecated)]
+    fn deprecated_new_constructors() {
+        let inner = ConstraintGoalDefinition::default();
+        let _ = PreferenceConstraintGoalDefinitions::new_goal(inner.clone());
+        let _ = PreferenceConstraintGoalDefinitions::new_preference(None, inner.clone());
+        let _ = PreferenceConstraintGoalDefinitions::new_forall(
+            crate::types::TypedVariables::default(),
+            PreferenceConstraintGoalDefinitions::default(),
+        );
+
+        // PreferenceConstraintGoalDefinition
+        let _ = PreferenceConstraintGoalDefinition::new_goal(inner.clone());
+        let _ = PreferenceConstraintGoalDefinition::new_preference(None, inner.clone());
+        let _ = PreferenceConstraintGoalDefinition::new_forall(
+            crate::types::TypedVariables::default(),
+            PreferenceConstraintGoalDefinitions::default(),
+        );
+    }
+
+    #[test]
+    fn pre_con_gds_deref() {
+        let inner = ConstraintGoalDefinition::default();
+        let goal = PreferenceConstraintGoalDefinition::goal(inner);
+        let list = PreferenceConstraintGoalDefinitions::new(vec![goal.clone()]);
+        let slice: &[PreferenceConstraintGoalDefinition] = &list;
+        assert_eq!(slice.len(), 1);
+        assert_eq!(&slice[0], &goal);
+    }
+
+    #[test]
+    fn pre_con_gds_as_ref() {
+        let inner = ConstraintGoalDefinition::default();
+        let goal = PreferenceConstraintGoalDefinition::goal(inner);
+        let list = PreferenceConstraintGoalDefinitions::new(vec![goal]);
+        let slice: &[PreferenceConstraintGoalDefinition] = list.as_ref();
+        assert_eq!(slice.len(), 1);
+    }
+
+    #[test]
+    fn pre_con_gds_into_iter() {
+        let inner = ConstraintGoalDefinition::default();
+        let goal = PreferenceConstraintGoalDefinition::goal(inner.clone());
+        let list = PreferenceConstraintGoalDefinitions::new(vec![goal.clone()]);
+        let collected: Vec<_> = list.into_iter().collect();
+        assert_eq!(collected, vec![goal]);
+    }
+
+    #[test]
+    fn pre_con_gds_into_vec() {
+        let inner = ConstraintGoalDefinition::default();
+        let goal = PreferenceConstraintGoalDefinition::goal(inner.clone());
+        let list = PreferenceConstraintGoalDefinitions::new(vec![goal.clone()]);
+        let vec: Vec<PreferenceConstraintGoalDefinition> = list.into();
+        assert_eq!(vec, vec![goal]);
+    }
+
+    #[test]
+    fn pre_con_gds_from_iterator() {
+        let inner = ConstraintGoalDefinition::default();
+        let goal = PreferenceConstraintGoalDefinition::goal(inner.clone());
+        let from_iter: PreferenceConstraintGoalDefinitions =
+            vec![goal.clone()].into_iter().collect();
+        assert_eq!(from_iter.len(), 1);
+        assert_eq!(from_iter.try_get_single(), Some(goal));
+    }
+
+    #[test]
+    fn pre_con_gds_len() {
+        let list = PreferenceConstraintGoalDefinitions::default();
+        assert_eq!(list.len(), 0);
+
+        let inner = ConstraintGoalDefinition::default();
+        let goal = PreferenceConstraintGoalDefinition::goal(inner);
+        let list = PreferenceConstraintGoalDefinitions::new(vec![goal]);
+        assert_eq!(list.len(), 1);
+    }
+
+    #[test]
+    fn pre_con_gds_iter() {
+        let inner1 = ConstraintGoalDefinition::default();
+        let inner2 = ConstraintGoalDefinition::And(vec![]);
+        let goal1 = PreferenceConstraintGoalDefinition::goal(inner1);
+        let goal2 = PreferenceConstraintGoalDefinition::goal(inner2);
+        let list = PreferenceConstraintGoalDefinitions::new(vec![goal1.clone(), goal2.clone()]);
+        let collected: Vec<_> = list.iter().cloned().collect();
+        assert_eq!(collected, vec![goal1, goal2]);
+    }
 }

--- a/src/types/pref_gd.rs
+++ b/src/types/pref_gd.rs
@@ -7,14 +7,14 @@ use crate::types::{GoalDefinition, Preference};
 /// ## Usage
 /// Used by [`PreconditionGoalDefinition`](crate::PreconditionGoalDefinition).
 #[derive(Debug, Clone, PartialEq)]
-pub enum PreferenceGD {
+pub enum PreferenceGoalDefinition {
     Goal(GoalDefinition),
     /// ## Requirements
     /// Requires [Preferences](crate::Requirement::Preferences).
     Preference(Preference),
 }
 
-impl PreferenceGD {
+impl PreferenceGoalDefinition {
     pub const fn from_gd(gd: GoalDefinition) -> Self {
         Self::Goal(gd)
     }
@@ -24,14 +24,18 @@ impl PreferenceGD {
     }
 }
 
-impl From<GoalDefinition> for PreferenceGD {
+impl From<GoalDefinition> for PreferenceGoalDefinition {
     fn from(value: GoalDefinition) -> Self {
-        PreferenceGD::from_gd(value)
+        PreferenceGoalDefinition::from_gd(value)
     }
 }
 
-impl From<Preference> for PreferenceGD {
+impl From<Preference> for PreferenceGoalDefinition {
     fn from(value: Preference) -> Self {
-        PreferenceGD::from_preference(value)
+        PreferenceGoalDefinition::from_preference(value)
     }
 }
+
+/// Alias for [`PreferenceGoalDefinition`]; matches BNF `<pref-GD>`.
+#[deprecated(since = "0.2.0", note = "Use `PreferenceGoalDefinition` instead")]
+pub type PreferenceGD = PreferenceGoalDefinition;

--- a/src/types/pref_gd.rs
+++ b/src/types/pref_gd.rs
@@ -39,3 +39,59 @@ impl From<Preference> for PreferenceGoalDefinition {
 /// Alias for [`PreferenceGoalDefinition`]; matches BNF `<pref-GD>`.
 #[deprecated(since = "0.2.0", note = "Use `PreferenceGoalDefinition` instead")]
 pub type PreferenceGD = PreferenceGoalDefinition;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::GoalDefinition;
+
+    #[test]
+    fn from_gd() {
+        let gd = GoalDefinition::and(Vec::new());
+        let pref_gd = PreferenceGoalDefinition::from_gd(gd.clone());
+        assert!(matches!(pref_gd, PreferenceGoalDefinition::Goal(_)));
+    }
+
+    #[test]
+    fn from_preference() {
+        let pref = crate::Preference::from(GoalDefinition::and(Vec::new()));
+        let pref_gd = PreferenceGoalDefinition::from_preference(pref.clone());
+        assert!(matches!(pref_gd, PreferenceGoalDefinition::Preference(_)));
+    }
+
+    #[test]
+    fn from_gd_trait() {
+        let gd = GoalDefinition::and(Vec::new());
+        let pref_gd = PreferenceGoalDefinition::from(gd);
+        assert!(matches!(pref_gd, PreferenceGoalDefinition::Goal(_)));
+    }
+
+    #[test]
+    fn from_preference_trait() {
+        let pref = crate::Preference::from(GoalDefinition::and(Vec::new()));
+        let pref_gd = PreferenceGoalDefinition::from(pref);
+        assert!(matches!(pref_gd, PreferenceGoalDefinition::Preference(_)));
+    }
+
+    #[test]
+    fn clone_works() {
+        let gd = GoalDefinition::and(Vec::new());
+        let pref_gd = PreferenceGoalDefinition::from_gd(gd);
+        let clone = pref_gd.clone();
+        assert_eq!(pref_gd, clone);
+    }
+
+    #[test]
+    fn debug_impl() {
+        let gd = GoalDefinition::and(Vec::new());
+        let pref_gd = PreferenceGoalDefinition::from_gd(gd);
+        let dbg = format!("{pref_gd:?}");
+        assert!(dbg.contains("Goal"));
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn deprecated_alias_exists() {
+        fn _assert_alias(_: PreferenceGD) {}
+    }
+}

--- a/src/types/pref_name.rs
+++ b/src/types/pref_name.rs
@@ -7,7 +7,7 @@ use std::ops::Deref;
 ///
 /// ## Usage
 /// Used by [`PrefGD`](crate::PreferenceGD), [`PrefTimedGD`](crate::PrefTimedGD),
-/// [`PrefConGD`](crate::PrefConGD) and [`MetricFExp`](crate::MetricFExp).
+/// [`PrefConGD`](crate::PrefConGD) and [`MetricFluentExpression`](crate::MetricFluentExpression).
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct PreferenceName(Name);
 

--- a/src/types/pref_name.rs
+++ b/src/types/pref_name.rs
@@ -6,7 +6,7 @@ use std::ops::Deref;
 /// A name of a preference.
 ///
 /// ## Usage
-/// Used by [`PrefGD`](crate::PreferenceGD), [`PrefTimedGD`](crate::PrefTimedGD),
+/// Used by [`PrefGD`](crate::PreferenceGoalDefinition), [`PrefTimedGD`](crate::PrefTimedGD),
 /// [`PrefConGD`](crate::PrefConGD) and [`MetricFluentExpression`](crate::MetricFluentExpression).
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct PreferenceName(Name);

--- a/src/types/pref_name.rs
+++ b/src/types/pref_name.rs
@@ -6,8 +6,8 @@ use std::ops::Deref;
 /// A name of a preference.
 ///
 /// ## Usage
-/// Used by [`PrefGD`](crate::PreferenceGoalDefinition), [`PrefTimedGD`](crate::PrefTimedGD),
-/// [`PrefConGD`](crate::PrefConGD) and [`MetricFluentExpression`](crate::MetricFluentExpression).
+/// Used by [`Preference`](crate::Preference), [`PreferenceTimedGoalDefinition`](crate::PrefTimedGD),
+/// [`PreferenceConstraintGoalDefinition`](crate::PrefConGD) and [`MetricFluentExpression`](crate::MetricFluentExpression).
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct PreferenceName(Name);
 
@@ -18,8 +18,14 @@ impl PreferenceName {
     }
 
     #[inline(always)]
-    pub fn new_string(name: &str) -> Self {
+    #[doc(alias = "new_string")]
+    pub fn string(name: &str) -> Self {
         Self(Name::new(name))
+    }
+
+    #[inline(always)]
+    pub fn new_string(name: &str) -> Self {
+        Self::string(name)
     }
 
     #[inline(always)]

--- a/src/types/pref_timed_gd.rs
+++ b/src/types/pref_timed_gd.rs
@@ -52,3 +52,79 @@ impl From<(Option<PreferenceName>, TimedGoalDefinition)> for PreferenceTimedGoal
 /// Alias for [`PreferenceTimedGoalDefinition`]; matches BNF `<pref-timed-GD>`.
 #[deprecated(since = "0.2.0", note = "Use `PreferenceTimedGoalDefinition` instead")]
 pub type PrefTimedGD = PreferenceTimedGoalDefinition;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{
+        AtomicFormula, GoalDefinition, Predicate, Term, TimeSpecifier, TimedGoalDefinition,
+    };
+
+    fn make_timed_gd() -> TimedGoalDefinition {
+        let af = AtomicFormula::predicate(Predicate::string("at"), Vec::<Term>::new());
+        let gd = GoalDefinition::AtomicFormula(af);
+        TimedGoalDefinition::at(TimeSpecifier::Start, gd)
+    }
+
+    #[test]
+    fn required_constructor() {
+        let timed_gd = make_timed_gd();
+        let pref = PreferenceTimedGoalDefinition::required(timed_gd.clone());
+        assert_eq!(pref, PreferenceTimedGoalDefinition::Required(timed_gd));
+    }
+
+    #[test]
+    fn preference_with_name() {
+        let timed_gd = make_timed_gd();
+        let name = PreferenceName::new("pref1");
+        let pref = PreferenceTimedGoalDefinition::preference(Some(name.clone()), timed_gd.clone());
+        assert_eq!(
+            pref,
+            PreferenceTimedGoalDefinition::Preference(Some(name), timed_gd)
+        );
+    }
+
+    #[test]
+    fn preference_without_name() {
+        let timed_gd = make_timed_gd();
+        let pref = PreferenceTimedGoalDefinition::preference(None, timed_gd.clone());
+        assert_eq!(
+            pref,
+            PreferenceTimedGoalDefinition::Preference(None, timed_gd)
+        );
+    }
+
+    #[test]
+    fn from_timed_gd() {
+        let timed_gd = make_timed_gd();
+        let from_gd: PreferenceTimedGoalDefinition = timed_gd.clone().into();
+        assert_eq!(from_gd, PreferenceTimedGoalDefinition::Required(timed_gd));
+    }
+
+    #[test]
+    fn from_tuple() {
+        let timed_gd = make_timed_gd();
+        let name = PreferenceName::new("pref1");
+        let from_tuple: PreferenceTimedGoalDefinition =
+            (Some(name.clone()), timed_gd.clone()).into();
+        assert_eq!(
+            from_tuple,
+            PreferenceTimedGoalDefinition::Preference(Some(name), timed_gd)
+        );
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn deprecated_new_constructors() {
+        let timed_gd = make_timed_gd();
+        let _ = PreferenceTimedGoalDefinition::new_required(timed_gd.clone());
+        let _ =
+            PreferenceTimedGoalDefinition::new_preference(Some(PreferenceName::new("p")), timed_gd);
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn deprecated_alias() {
+        fn _assert_alias(_: PrefTimedGD) {}
+    }
+}

--- a/src/types/pref_timed_gd.rs
+++ b/src/types/pref_timed_gd.rs
@@ -1,37 +1,42 @@
-//! Contains the [`PrefTimedGD`] type.
+//! Contains the [`PreferenceTimedGoalDefinition`] type.
 
-use crate::types::{PreferenceName, TimedGD};
+use crate::types::{PreferenceName, TimedGoalDefinition};
 
 /// A (preferred) timed goal definition.
 ///
 /// ## Usage
 /// Used by [`DurativeActionGoalDefinition`](crate::DurativeActionGoalDefinition).
+#[doc(alias("pref-timed-GD"))]
 #[derive(Debug, Clone, PartialEq)]
-pub enum PrefTimedGD {
-    Required(TimedGD),
+pub enum PreferenceTimedGoalDefinition {
+    Required(TimedGoalDefinition),
     /// ## Requirements
     /// Requires [Preferences](crate::Requirement::Preferences).
-    Preference(Option<PreferenceName>, TimedGD),
+    Preference(Option<PreferenceName>, TimedGoalDefinition),
 }
 
-impl PrefTimedGD {
-    pub const fn new_required(gd: TimedGD) -> Self {
+impl PreferenceTimedGoalDefinition {
+    pub const fn new_required(gd: TimedGoalDefinition) -> Self {
         Self::Required(gd)
     }
 
-    pub const fn new_preference(name: Option<PreferenceName>, gd: TimedGD) -> Self {
+    pub const fn new_preference(name: Option<PreferenceName>, gd: TimedGoalDefinition) -> Self {
         Self::Preference(name, gd)
     }
 }
 
-impl From<TimedGD> for PrefTimedGD {
-    fn from(value: TimedGD) -> Self {
-        PrefTimedGD::Required(value)
+impl From<TimedGoalDefinition> for PreferenceTimedGoalDefinition {
+    fn from(value: TimedGoalDefinition) -> Self {
+        PreferenceTimedGoalDefinition::Required(value)
     }
 }
 
-impl From<(Option<PreferenceName>, TimedGD)> for PrefTimedGD {
-    fn from(value: (Option<PreferenceName>, TimedGD)) -> Self {
-        PrefTimedGD::Preference(value.0, value.1)
+impl From<(Option<PreferenceName>, TimedGoalDefinition)> for PreferenceTimedGoalDefinition {
+    fn from(value: (Option<PreferenceName>, TimedGoalDefinition)) -> Self {
+        PreferenceTimedGoalDefinition::Preference(value.0, value.1)
     }
 }
+
+/// Alias for [`PreferenceTimedGoalDefinition`]; matches BNF `<pref-timed-GD>`.
+#[deprecated(since = "0.2.0", note = "Use `PreferenceTimedGoalDefinition` instead")]
+pub type PrefTimedGD = PreferenceTimedGoalDefinition;

--- a/src/types/pref_timed_gd.rs
+++ b/src/types/pref_timed_gd.rs
@@ -16,12 +16,24 @@ pub enum PreferenceTimedGoalDefinition {
 }
 
 impl PreferenceTimedGoalDefinition {
-    pub const fn new_required(gd: TimedGoalDefinition) -> Self {
+    #[doc(alias = "new_required")]
+    pub const fn required(gd: TimedGoalDefinition) -> Self {
         Self::Required(gd)
     }
 
-    pub const fn new_preference(name: Option<PreferenceName>, gd: TimedGoalDefinition) -> Self {
+    #[doc(alias = "new_preference")]
+    pub const fn preference(name: Option<PreferenceName>, gd: TimedGoalDefinition) -> Self {
         Self::Preference(name, gd)
+    }
+
+    #[deprecated(since = "0.2.0", note = "Use `required` instead")]
+    pub const fn new_required(gd: TimedGoalDefinition) -> Self {
+        Self::required(gd)
+    }
+
+    #[deprecated(since = "0.2.0", note = "Use `preference` instead")]
+    pub const fn new_preference(name: Option<PreferenceName>, gd: TimedGoalDefinition) -> Self {
+        Self::preference(name, gd)
     }
 }
 

--- a/src/types/preference.rs
+++ b/src/types/preference.rs
@@ -8,7 +8,7 @@ use crate::types::{GoalDefinition, PreferenceName};
 /// Requires [Preferences](crate::Requirement::Preferences).
 ///
 /// ## Usage
-/// Used by [`PreferenceGD`](crate::PreferenceGD).
+/// Used by [`PreferenceGoalDefinition`](crate::PreferenceGoalDefinition).
 #[derive(Debug, Clone, PartialEq)]
 pub struct Preference(Option<PreferenceName>, GoalDefinition); // TODO: A similar type is used for PrefConGD
 

--- a/src/types/preference.rs
+++ b/src/types/preference.rs
@@ -49,3 +49,89 @@ impl From<GoalDefinition> for Preference {
         Self::new(None, value)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{GoalDefinition, Name, Term};
+
+    #[test]
+    fn new_with_name() {
+        let name = PreferenceName::string("pref1");
+        let gd = GoalDefinition::and(Vec::new());
+        let pref = Preference::new(Some(name.clone()), gd.clone());
+        assert_eq!(pref.name(), &Some(name));
+        assert_eq!(pref.goal(), &gd);
+    }
+
+    #[test]
+    fn new_without_name() {
+        let gd = GoalDefinition::and(Vec::new());
+        let pref = Preference::new(None, gd.clone());
+        assert_eq!(pref.name(), &None);
+        assert_eq!(pref.goal(), &gd);
+    }
+
+    #[test]
+    fn from_tuple_with_option() {
+        let gd = GoalDefinition::and(Vec::new());
+        let pref = Preference::from((None::<PreferenceName>, gd.clone()));
+        assert_eq!(pref.name(), &None);
+        assert_eq!(pref.goal(), &gd);
+    }
+
+    #[test]
+    fn from_tuple_with_name() {
+        let name = PreferenceName::string("my_pref");
+        let gd = GoalDefinition::and(Vec::new());
+        let pref = Preference::from((name.clone(), gd.clone()));
+        assert_eq!(pref.name(), &Some(name));
+        assert_eq!(pref.goal(), &gd);
+    }
+
+    #[test]
+    fn from_gd_only() {
+        let gd = GoalDefinition::and(Vec::new());
+        let pref = Preference::from(gd.clone());
+        assert_eq!(pref.name(), &None);
+        assert_eq!(pref.goal(), &gd);
+    }
+
+    #[test]
+    fn is_empty_true() {
+        let gd = GoalDefinition::and(Vec::new());
+        let pref = Preference::new(None, gd);
+        assert!(pref.is_empty());
+    }
+
+    #[test]
+    fn is_empty_false() {
+        use crate::AtomicFormula;
+        let af = AtomicFormula::<Term>::predicate(
+            crate::Predicate::new(Name::new("on")),
+            vec![
+                Term::new_name(Name::new("a")),
+                Term::new_name(Name::new("b")),
+            ],
+        );
+        let gd = GoalDefinition::AtomicFormula(af);
+        let pref = Preference::new(None, gd);
+        assert!(!pref.is_empty());
+    }
+
+    #[test]
+    fn clone_works() {
+        let gd = GoalDefinition::and(Vec::new());
+        let pref = Preference::new(None, gd);
+        let clone = pref.clone();
+        assert_eq!(pref, clone);
+    }
+
+    #[test]
+    fn debug_impl() {
+        let gd = GoalDefinition::and(Vec::new());
+        let pref = Preference::new(None, gd);
+        let dbg = format!("{pref:?}");
+        assert!(dbg.contains("Preference"));
+    }
+}

--- a/src/types/problem.rs
+++ b/src/types/problem.rs
@@ -192,3 +192,83 @@ impl Problem {
         &self.length_spec
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{InitElements, ProblemGoalDefinition};
+    use crate::{PreconditionGoalDefinitions, Requirement, Requirements};
+
+    fn make_minimal_problem() -> Problem {
+        let init = InitElements::new(Vec::new());
+        let goal = ProblemGoalDefinition::new(PreconditionGoalDefinitions::default());
+        Problem::builder("test-problem", "test-domain", init, goal)
+    }
+
+    #[test]
+    fn builder_works() {
+        let problem = make_minimal_problem();
+        assert_eq!(problem.name(), &Name::new("test-problem"));
+        assert_eq!(problem.domain(), &Name::new("test-domain"));
+        assert!(problem.requirements().is_empty());
+        assert!(problem.init().is_empty());
+        assert!(problem.goals().is_empty());
+        assert!(problem.constraints().is_empty());
+        assert!(problem.metric_spec().is_none());
+        assert!(problem.length_spec().is_none());
+    }
+
+    #[test]
+    fn with_requirements() {
+        let problem =
+            make_minimal_problem().with_requirements(Requirements::new([Requirement::Strips]));
+        assert_eq!(problem.requirements().len(), 1);
+    }
+
+    #[test]
+    fn with_objects() {
+        let problem = make_minimal_problem().with_objects(Objects::default());
+        assert!(problem.objects().is_empty());
+    }
+
+    #[test]
+    fn with_constraints() {
+        let problem = make_minimal_problem().with_constraints(ProblemConstraintsDef::default());
+        assert!(problem.constraints().is_empty());
+    }
+
+    #[test]
+    fn new_full() {
+        let init = InitElements::new(Vec::new());
+        let goal = ProblemGoalDefinition::new(PreconditionGoalDefinitions::default());
+        let problem = Problem::new(
+            Name::new("p"),
+            Name::new("d"),
+            Requirements::new([Requirement::Typing]),
+            Objects::default(),
+            init,
+            goal,
+            ProblemConstraintsDef::default(),
+            None,
+            None,
+        );
+        assert_eq!(problem.name(), &Name::new("p"));
+        assert_eq!(problem.domain(), &Name::new("d"));
+        assert_eq!(problem.requirements().len(), 1);
+    }
+
+    #[test]
+    fn clone_works() {
+        let problem = make_minimal_problem();
+        let clone = problem.clone();
+        assert_eq!(problem, clone);
+    }
+
+    #[test]
+    fn debug_impl() {
+        let problem = make_minimal_problem();
+        let dbg = format!("{problem:?}");
+        assert!(dbg.contains("Problem"));
+        assert!(dbg.contains("test-problem"));
+    }
+}

--- a/src/types/problem.rs
+++ b/src/types/problem.rs
@@ -1,8 +1,8 @@
 //! Contains the [`Problem`] type.
 
 use crate::types::{
-    ProblemGoalDefinition, InitElements, LengthSpec, MetricSpec, Name, Objects, ProblemConstraintsDef,
-    Requirements,
+    InitElements, LengthSpec, MetricSpec, Name, Objects, ProblemConstraintsDef,
+    ProblemGoalDefinition, Requirements,
 };
 use crate::{PreconditionGoalDefinitions, PreferenceConstraintGoalDefinitions};
 

--- a/src/types/problem.rs
+++ b/src/types/problem.rs
@@ -1,10 +1,10 @@
 //! Contains the [`Problem`] type.
 
 use crate::types::{
-    GoalDef, InitElements, LengthSpec, MetricSpec, Name, Objects, ProblemConstraintsDef,
+    ProblemGoalDefinition, InitElements, LengthSpec, MetricSpec, Name, Objects, ProblemConstraintsDef,
     Requirements,
 };
-use crate::{PreconditionGoalDefinitions, PrefConGDs};
+use crate::{PreconditionGoalDefinitions, PreferenceConstraintGoalDefinitions};
 
 /// A domain-specific problem declaration.
 ///
@@ -48,7 +48,7 @@ pub struct Problem {
     /// The initial state definition.
     init: InitElements,
     /// The goal definition.
-    goal: GoalDef,
+    goal: ProblemGoalDefinition,
     /// The optional list of constraints.
     ///
     /// ## Requirements
@@ -74,7 +74,7 @@ impl Problem {
         requires: Requirements,
         objects: Objects,
         init: InitElements,
-        goal: GoalDef,
+        goal: ProblemGoalDefinition,
         constraints: ProblemConstraintsDef,
         metric_spec: Option<MetricSpec>,
         length_spec: Option<LengthSpec>,
@@ -97,7 +97,7 @@ impl Problem {
         problem_name: P,
         domain_name: D,
         init: InitElements,
-        goal: GoalDef,
+        goal: ProblemGoalDefinition,
     ) -> Self {
         Self {
             name: problem_name.into(),
@@ -175,7 +175,7 @@ impl Problem {
     /// Returns the optional constraints of the problem.
     /// ## Requirements
     /// Requires [Constraints](crate::Requirement::Constraints).
-    pub const fn constraints(&self) -> &PrefConGDs {
+    pub const fn constraints(&self) -> &PreferenceConstraintGoalDefinitions {
         self.constraints.value()
     }
 

--- a/src/types/problem_constraints_def.rs
+++ b/src/types/problem_constraints_def.rs
@@ -46,3 +46,50 @@ impl From<ProblemConstraintsDef> for PreferenceConstraintGoalDefinitions {
         val.0
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_empty() {
+        let def = ProblemConstraintsDef::default();
+        assert!(def.is_empty());
+    }
+
+    #[test]
+    fn new_works() {
+        let defs = PreferenceConstraintGoalDefinitions::default();
+        let def = ProblemConstraintsDef::new(defs.clone());
+        assert_eq!(*def.value(), defs);
+    }
+
+    #[test]
+    fn from_works() {
+        let defs = PreferenceConstraintGoalDefinitions::default();
+        let def = ProblemConstraintsDef::from(defs.clone());
+        assert_eq!(def, ProblemConstraintsDef::new(defs));
+    }
+
+    #[test]
+    fn deref_works() {
+        let def = ProblemConstraintsDef::default();
+        let inner: &PreferenceConstraintGoalDefinitions = &def;
+        assert!(inner.is_empty());
+    }
+
+    #[test]
+    fn into_works() {
+        let defs = PreferenceConstraintGoalDefinitions::default();
+        let def = ProblemConstraintsDef::new(defs.clone());
+        let result: PreferenceConstraintGoalDefinitions = def.into();
+        assert_eq!(result, defs);
+    }
+
+    #[test]
+    fn clone_works() {
+        let def = ProblemConstraintsDef::default();
+        let clone = def.clone();
+        assert_eq!(def, clone);
+    }
+}

--- a/src/types/problem_constraints_def.rs
+++ b/src/types/problem_constraints_def.rs
@@ -1,47 +1,47 @@
 //! Contains the [`ProblemConstraintsDef`] type.
 
-use crate::PrefConGDs;
+use crate::PreferenceConstraintGoalDefinitions;
 use std::ops::Deref;
 
-/// A problem constraints definition; wraps a [`PrefConGDs`].
+/// A problem constraints definition; wraps a [`PreferenceConstraintGoalDefinitions`].
 ///
 /// ## Requirements
 /// Requires [Constraints](crate::Requirement::Constraints).
 #[derive(Debug, Default, Clone, PartialEq)]
-pub struct ProblemConstraintsDef(PrefConGDs);
+pub struct ProblemConstraintsDef(PreferenceConstraintGoalDefinitions);
 
 impl ProblemConstraintsDef {
-    pub const fn new(gd: PrefConGDs) -> Self {
+    pub const fn new(gd: PreferenceConstraintGoalDefinitions) -> Self {
         Self(gd)
     }
 
     /// Gets the value.
-    pub const fn value(&self) -> &PrefConGDs {
+    pub const fn value(&self) -> &PreferenceConstraintGoalDefinitions {
         &self.0
     }
 }
 
-impl PartialEq<PrefConGDs> for ProblemConstraintsDef {
-    fn eq(&self, other: &PrefConGDs) -> bool {
+impl PartialEq<PreferenceConstraintGoalDefinitions> for ProblemConstraintsDef {
+    fn eq(&self, other: &PreferenceConstraintGoalDefinitions) -> bool {
         self.0.eq(other)
     }
 }
 
-impl From<PrefConGDs> for ProblemConstraintsDef {
-    fn from(value: PrefConGDs) -> Self {
+impl From<PreferenceConstraintGoalDefinitions> for ProblemConstraintsDef {
+    fn from(value: PreferenceConstraintGoalDefinitions) -> Self {
         Self::new(value)
     }
 }
 
 impl Deref for ProblemConstraintsDef {
-    type Target = PrefConGDs;
+    type Target = PreferenceConstraintGoalDefinitions;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl From<ProblemConstraintsDef> for PrefConGDs {
+impl From<ProblemConstraintsDef> for PreferenceConstraintGoalDefinitions {
     fn from(val: ProblemConstraintsDef) -> Self {
         val.0
     }

--- a/src/types/requirements.rs
+++ b/src/types/requirements.rs
@@ -96,3 +96,125 @@ impl FromIterator<Requirement> for Requirements {
         Requirements::new(iter)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_empty() {
+        let reqs = Requirements::new([]);
+        assert!(reqs.is_empty());
+    }
+
+    #[test]
+    fn new_with_values() {
+        let reqs = Requirements::new([Requirement::Strips, Requirement::Typing]);
+        assert_eq!(reqs.len(), 2);
+    }
+
+    #[test]
+    fn default_is_empty() {
+        let reqs = Requirements::default();
+        assert!(reqs.is_empty());
+    }
+
+    #[test]
+    fn from_vec() {
+        let reqs = Requirements::from(vec![Requirement::Adl]);
+        assert_eq!(reqs.len(), 1);
+        assert_eq!(reqs[0], Requirement::Adl);
+    }
+
+    #[test]
+    fn from_iterator() {
+        let reqs: Requirements = [Requirement::Strips, Requirement::Equality]
+            .into_iter()
+            .collect();
+        assert_eq!(reqs.len(), 2);
+    }
+
+    #[test]
+    fn deref_to_vec() {
+        let reqs = Requirements::new([Requirement::Strips]);
+        let vec: &Vec<Requirement> = &reqs;
+        assert_eq!(vec.len(), 1);
+    }
+
+    #[test]
+    fn to_effective_empty_adds_strips() {
+        let reqs = Requirements::default();
+        let effective = reqs.to_effective();
+        assert_eq!(effective.len(), 1);
+        assert!(effective.contains(&Requirement::Strips));
+    }
+
+    #[test]
+    fn to_effective_strips_only() {
+        let reqs = Requirements::new([Requirement::Strips]);
+        let effective = reqs.to_effective();
+        assert_eq!(effective.len(), 1);
+    }
+
+    #[test]
+    fn to_effective_adl_expands() {
+        let reqs = Requirements::new([Requirement::Adl]);
+        let effective = reqs.to_effective();
+        assert!(effective.contains(&Requirement::Strips));
+        assert!(effective.contains(&Requirement::Typing));
+        assert!(effective.contains(&Requirement::NegativePreconditions));
+        assert!(effective.contains(&Requirement::DisjunctivePreconditions));
+        assert!(effective.contains(&Requirement::Equality));
+        assert!(effective.contains(&Requirement::ExistentialPreconditions));
+        assert!(effective.contains(&Requirement::UniversalPreconditions));
+        assert!(effective.contains(&Requirement::ConditionalEffects));
+    }
+
+    #[test]
+    fn to_effective_fluents_expands() {
+        let reqs = Requirements::new([Requirement::Fluents]);
+        let effective = reqs.to_effective();
+        assert!(effective.contains(&Requirement::NumericFluents));
+        assert!(effective.contains(&Requirement::ObjectFluents));
+    }
+
+    #[test]
+    fn to_effective_quantified_expands() {
+        let reqs = Requirements::new([Requirement::QuantifiedPreconditions]);
+        let effective = reqs.to_effective();
+        assert!(effective.contains(&Requirement::ExistentialPreconditions));
+        assert!(effective.contains(&Requirement::UniversalPreconditions));
+    }
+
+    #[test]
+    fn to_effective_combined() {
+        let reqs = Requirements::new([Requirement::Adl, Requirement::Constraints]);
+        let effective = reqs.to_effective();
+        assert_eq!(effective.len(), 9);
+        assert!(effective.contains(&Requirement::Constraints));
+    }
+
+    #[test]
+    fn to_effective_deduplicates() {
+        let reqs = Requirements::new([Requirement::Strips, Requirement::Adl, Requirement::Strips]);
+        let effective = reqs.to_effective();
+        assert!(effective.contains(&Requirement::Strips));
+        assert!(effective.contains(&Requirement::Typing));
+    }
+
+    #[test]
+    fn clone_works() {
+        let reqs = Requirements::new([Requirement::Strips]);
+        let clone = reqs.clone();
+        assert_eq!(reqs, clone);
+    }
+
+    #[test]
+    fn eq_works() {
+        let a = Requirements::new([Requirement::Strips]);
+        let b = Requirements::new([Requirement::Strips]);
+        let c = Requirements::new([Requirement::Typing]);
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+}

--- a/src/types/simple_duration_constraint.rs
+++ b/src/types/simple_duration_constraint.rs
@@ -15,23 +15,33 @@ pub enum SimpleDurationConstraint {
 }
 
 impl SimpleDurationConstraint {
-    pub const fn new_op(op: DurationOperator, value: DurationValue) -> Self {
+    #[doc(alias = "new_op")]
+    pub const fn op(op: DurationOperator, value: DurationValue) -> Self {
         Self::Op(op, value)
     }
 
-    pub fn new_at(time: TimeSpecifier, constraint: SimpleDurationConstraint) -> Self {
+    pub fn new_op(op: DurationOperator, value: DurationValue) -> Self {
+        Self::op(op, value)
+    }
+
+    #[doc(alias = "new_at")]
+    pub fn at(time: TimeSpecifier, constraint: SimpleDurationConstraint) -> Self {
         Self::At(time, Box::new(constraint))
+    }
+
+    pub fn new_at(time: TimeSpecifier, constraint: SimpleDurationConstraint) -> Self {
+        Self::at(time, constraint)
     }
 }
 
 impl From<(DurationOperator, DurationValue)> for SimpleDurationConstraint {
     fn from(value: (DurationOperator, DurationValue)) -> Self {
-        SimpleDurationConstraint::new_op(value.0, value.1)
+        SimpleDurationConstraint::op(value.0, value.1)
     }
 }
 
 impl From<(TimeSpecifier, SimpleDurationConstraint)> for SimpleDurationConstraint {
     fn from(value: (TimeSpecifier, SimpleDurationConstraint)) -> Self {
-        SimpleDurationConstraint::new_at(value.0, value.1)
+        SimpleDurationConstraint::at(value.0, value.1)
     }
 }

--- a/src/types/simple_duration_constraint.rs
+++ b/src/types/simple_duration_constraint.rs
@@ -1,6 +1,6 @@
 //! Contains the [`SimpleDurationConstraint`] type.
 
-use crate::types::{DOp, DurationValue, TimeSpecifier};
+use crate::types::{DurationOperator, DurationValue, TimeSpecifier};
 
 /// A simple duration constraint.
 ///
@@ -9,13 +9,13 @@ use crate::types::{DOp, DurationValue, TimeSpecifier};
 #[derive(Debug, Clone, PartialEq)]
 pub enum SimpleDurationConstraint {
     /// A comparison operation against a duration value.
-    Op(DOp, DurationValue),
+    Op(DurationOperator, DurationValue),
     /// A specific time at or after which a constraint applies.
     At(TimeSpecifier, Box<SimpleDurationConstraint>),
 }
 
 impl SimpleDurationConstraint {
-    pub const fn new_op(op: DOp, value: DurationValue) -> Self {
+    pub const fn new_op(op: DurationOperator, value: DurationValue) -> Self {
         Self::Op(op, value)
     }
 
@@ -24,8 +24,8 @@ impl SimpleDurationConstraint {
     }
 }
 
-impl From<(DOp, DurationValue)> for SimpleDurationConstraint {
-    fn from(value: (DOp, DurationValue)) -> Self {
+impl From<(DurationOperator, DurationValue)> for SimpleDurationConstraint {
+    fn from(value: (DurationOperator, DurationValue)) -> Self {
         SimpleDurationConstraint::new_op(value.0, value.1)
     }
 }

--- a/src/types/structure_def.rs
+++ b/src/types/structure_def.rs
@@ -18,31 +18,48 @@ pub enum StructureDef {
 }
 
 impl StructureDef {
-    pub const fn new_action(action: ActionDefinition) -> Self {
+    #[doc(alias = "new_action")]
+    pub const fn action(action: ActionDefinition) -> Self {
         Self::Action(action)
     }
-    pub fn new_durative_action(action: DurativeActionDefinition) -> Self {
+
+    pub fn new_action(action: ActionDefinition) -> Self {
+        Self::action(action)
+    }
+
+    #[doc(alias = "new_durative_action")]
+    pub fn durative_action(action: DurativeActionDefinition) -> Self {
         Self::DurativeAction(Box::new(action))
     }
-    pub const fn new_derived(predicate: DerivedPredicate) -> Self {
+
+    pub fn new_durative_action(action: DurativeActionDefinition) -> Self {
+        Self::durative_action(action)
+    }
+
+    #[doc(alias = "new_derived")]
+    pub const fn derived(predicate: DerivedPredicate) -> Self {
         Self::Derived(predicate)
+    }
+
+    pub fn new_derived(predicate: DerivedPredicate) -> Self {
+        Self::derived(predicate)
     }
 }
 
 impl From<ActionDefinition> for StructureDef {
     fn from(value: ActionDefinition) -> Self {
-        StructureDef::new_action(value)
+        StructureDef::action(value)
     }
 }
 
 impl From<DurativeActionDefinition> for StructureDef {
     fn from(value: DurativeActionDefinition) -> Self {
-        StructureDef::new_durative_action(value)
+        StructureDef::durative_action(value)
     }
 }
 
 impl From<DerivedPredicate> for StructureDef {
     fn from(value: DerivedPredicate) -> Self {
-        StructureDef::new_derived(value)
+        StructureDef::derived(value)
     }
 }

--- a/src/types/term.rs
+++ b/src/types/term.rs
@@ -6,7 +6,7 @@ use crate::types::Variable;
 ///
 /// ## Usage
 /// Used by [`GoalDefinition`](crate::GoalDefinition), [`FunctionTerm`](FunctionTerm),
-/// [`FHead`](crate::FHead), [`PEffect`](crate::PEffect) and [`InitElement`](crate::InitElement).
+/// [`FHead`](crate::FHead), [`PrimitiveEffect`](crate::PrimitiveEffect) and [`InitElement`](crate::InitElement).
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Term {
     Name(Name),

--- a/src/types/term.rs
+++ b/src/types/term.rs
@@ -6,7 +6,7 @@ use crate::types::Variable;
 ///
 /// ## Usage
 /// Used by [`GoalDefinition`](crate::GoalDefinition), [`FunctionTerm`](FunctionTerm),
-/// [`FHead`](crate::FHead), [`PrimitiveEffect`](crate::PrimitiveEffect) and [`InitElement`](crate::InitElement).
+/// [`FunctionHead`](crate::FunctionHead), [`PrimitiveEffect`](crate::PrimitiveEffect) and [`InitElement`](crate::InitElement).
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Term {
     Name(Name),

--- a/src/types/timed_effect.rs
+++ b/src/types/timed_effect.rs
@@ -35,20 +35,42 @@ pub enum TimedEffect {
 }
 
 impl TimedEffect {
-    pub const fn new_conditional(at: TimeSpecifier, effect: EffectCondition) -> Self {
+    #[doc(alias = "new_conditional")]
+    pub const fn conditional(at: TimeSpecifier, effect: EffectCondition) -> Self {
         Self::Conditional(at, effect)
     }
 
-    pub const fn new_fluent(at: TimeSpecifier, action: DurativeActionFunctionAssignment) -> Self {
+    #[doc(alias = "new_fluent")]
+    pub const fn fluent(at: TimeSpecifier, action: DurativeActionFunctionAssignment) -> Self {
         Self::NumericFluent(at, action)
     }
 
-    pub const fn new_continuous(
+    #[doc(alias = "new_continuous")]
+    pub const fn continuous(
         operation: TimedAssignOperator,
         f_head: FunctionHead,
         f_exp_t: TimedFluentExpression,
     ) -> Self {
         Self::ContinuousEffect(operation, f_head, f_exp_t)
+    }
+
+    #[deprecated(since = "0.2.0", note = "Use `conditional` instead")]
+    pub const fn new_conditional(at: TimeSpecifier, effect: EffectCondition) -> Self {
+        Self::conditional(at, effect)
+    }
+
+    #[deprecated(since = "0.2.0", note = "Use `fluent` instead")]
+    pub const fn new_fluent(at: TimeSpecifier, action: DurativeActionFunctionAssignment) -> Self {
+        Self::fluent(at, action)
+    }
+
+    #[deprecated(since = "0.2.0", note = "Use `continuous` instead")]
+    pub const fn new_continuous(
+        operation: TimedAssignOperator,
+        f_head: FunctionHead,
+        f_exp_t: TimedFluentExpression,
+    ) -> Self {
+        Self::continuous(operation, f_head, f_exp_t)
     }
 }
 
@@ -67,5 +89,125 @@ impl From<(TimeSpecifier, DurativeActionFunctionAssignment)> for TimedEffect {
 impl From<(TimedAssignOperator, FunctionHead, TimedFluentExpression)> for TimedEffect {
     fn from(value: (TimedAssignOperator, FunctionHead, TimedFluentExpression)) -> Self {
         TimedEffect::ContinuousEffect(value.0, value.1, value.2)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{
+        AssignOp, AtomicFormula, DurativeActionFluentExpression, DurativeActionFunctionAssignment,
+        EffectCondition, FluentExpression, FunctionSymbol, Name, Predicate, PrimitiveEffect, Term,
+    };
+
+    fn make_effect_condition() -> EffectCondition {
+        let af = AtomicFormula::<Term>::predicate(
+            Predicate::string("on"),
+            vec![Term::new_name(Name::new("a"))],
+        );
+        EffectCondition::new(PrimitiveEffect::atomic_formula(af))
+    }
+
+    #[test]
+    fn conditional_at_start() {
+        let ec = make_effect_condition();
+        let te = TimedEffect::conditional(TimeSpecifier::Start, ec);
+        assert!(matches!(
+            te,
+            TimedEffect::Conditional(TimeSpecifier::Start, _)
+        ));
+    }
+
+    #[test]
+    fn conditional_at_end() {
+        let ec = make_effect_condition();
+        let te = TimedEffect::conditional(TimeSpecifier::End, ec);
+        assert!(matches!(
+            te,
+            TimedEffect::Conditional(TimeSpecifier::End, _)
+        ));
+    }
+
+    #[test]
+    fn fluent_assignment() {
+        let fa = DurativeActionFunctionAssignment::new(
+            AssignOp::Assign,
+            FunctionHead::Simple(FunctionSymbol::string("cost")),
+            DurativeActionFluentExpression::FluentExpression(FluentExpression::number(10)),
+        );
+        let te = TimedEffect::fluent(TimeSpecifier::End, fa);
+        assert!(matches!(
+            te,
+            TimedEffect::NumericFluent(TimeSpecifier::End, _)
+        ));
+    }
+
+    #[test]
+    fn continuous_effect() {
+        let op = TimedAssignOperator::Increase;
+        let head = FunctionHead::Simple(FunctionSymbol::string("battery"));
+        let exp = TimedFluentExpression::scaled(FluentExpression::number(1));
+        let te = TimedEffect::continuous(op, head, exp);
+        assert!(matches!(te, TimedEffect::ContinuousEffect(_, _, _)));
+    }
+
+    #[test]
+    fn from_conditional_tuple() {
+        let ec = make_effect_condition();
+        let te = TimedEffect::from((TimeSpecifier::Start, ec));
+        assert!(matches!(
+            te,
+            TimedEffect::Conditional(TimeSpecifier::Start, _)
+        ));
+    }
+
+    #[test]
+    fn from_fluent_tuple() {
+        let fa = DurativeActionFunctionAssignment::new(
+            AssignOp::Assign,
+            FunctionHead::Simple(FunctionSymbol::string("cost")),
+            DurativeActionFluentExpression::FluentExpression(FluentExpression::number(10)),
+        );
+        let te = TimedEffect::from((TimeSpecifier::End, fa));
+        assert!(matches!(
+            te,
+            TimedEffect::NumericFluent(TimeSpecifier::End, _)
+        ));
+    }
+
+    #[test]
+    fn from_continuous_tuple() {
+        let op = TimedAssignOperator::Increase;
+        let head = FunctionHead::Simple(FunctionSymbol::string("battery"));
+        let exp = TimedFluentExpression::scaled(FluentExpression::number(1));
+        let te = TimedEffect::from((op, head, exp));
+        assert!(matches!(te, TimedEffect::ContinuousEffect(_, _, _)));
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn deprecated_conditional() {
+        let ec = make_effect_condition();
+        let te = TimedEffect::new_conditional(TimeSpecifier::Start, ec);
+        assert!(matches!(
+            te,
+            TimedEffect::Conditional(TimeSpecifier::Start, _)
+        ));
+    }
+
+    #[test]
+    fn clone_works() {
+        let ec = make_effect_condition();
+        let te = TimedEffect::conditional(TimeSpecifier::Start, ec);
+        let clone = te.clone();
+        assert_eq!(te, clone);
+    }
+
+    #[test]
+    fn debug_impl() {
+        let ec = make_effect_condition();
+        let te = TimedEffect::conditional(TimeSpecifier::Start, ec);
+        let dbg = format!("{te:?}");
+        assert!(dbg.contains("Conditional"));
     }
 }

--- a/src/types/timed_effect.rs
+++ b/src/types/timed_effect.rs
@@ -1,6 +1,9 @@
 //! Contains the [`TimedEffect`] type.
 
-use crate::types::{EffectCondition, TimedAssignOperator, DurativeActionFunctionAssignment, TimedFluentExpression, FunctionHead, TimeSpecifier};
+use crate::types::{
+    DurativeActionFunctionAssignment, EffectCondition, FunctionHead, TimeSpecifier,
+    TimedAssignOperator, TimedFluentExpression,
+};
 
 /// A timed effect, either conditional, continuous or derived from a fluent, e.g. [`DurativeActionEffect`](crate::types::DurativeActionEffect).
 ///
@@ -40,7 +43,11 @@ impl TimedEffect {
         Self::NumericFluent(at, action)
     }
 
-    pub const fn new_continuous(operation: TimedAssignOperator, f_head: FunctionHead, f_exp_t: TimedFluentExpression) -> Self {
+    pub const fn new_continuous(
+        operation: TimedAssignOperator,
+        f_head: FunctionHead,
+        f_exp_t: TimedFluentExpression,
+    ) -> Self {
         Self::ContinuousEffect(operation, f_head, f_exp_t)
     }
 }

--- a/src/types/timed_effect.rs
+++ b/src/types/timed_effect.rs
@@ -1,6 +1,6 @@
 //! Contains the [`TimedEffect`] type.
 
-use crate::types::{AssignOpT, ConditionalEffect, FAssignDa, FExpT, FHead, TimeSpecifier};
+use crate::types::{EffectCondition, TimedAssignOperator, DurativeActionFunctionAssignment, TimedFluentExpression, FunctionHead, TimeSpecifier};
 
 /// A timed effect, either conditional, continuous or derived from a fluent, e.g. [`DurativeActionEffect`](crate::types::DurativeActionEffect).
 ///
@@ -11,7 +11,7 @@ use crate::types::{AssignOpT, ConditionalEffect, FAssignDa, FExpT, FHead, TimeSp
 /// ## Notes
 ///
 /// Temporal expressions, such as `at start` and `at end` are available, however, `over all`
-/// is typically not used because it’s not common to express a boolean effect which is true
+/// is typically not used because it's not common to express a boolean effect which is true
 /// over the duration of the action.
 ///
 /// Instead you would set it to true at the start, using an `at start` and set it to false at
@@ -21,44 +21,44 @@ use crate::types::{AssignOpT, ConditionalEffect, FAssignDa, FExpT, FHead, TimeSp
 /// Used by [`DurativeActionEffect`](crate::DurativeActionEffect).
 #[derive(Debug, Clone, PartialEq)]
 pub enum TimedEffect {
-    Conditional(TimeSpecifier, ConditionalEffect),
+    Conditional(TimeSpecifier, EffectCondition),
     /// ## Requirements
     /// Requires [Numeric Fluents](crate::Requirement::NumericFluents).
-    NumericFluent(TimeSpecifier, FAssignDa),
+    NumericFluent(TimeSpecifier, DurativeActionFunctionAssignment),
     /// ## Requirements
     /// Requires [Continuous Effects](crate::Requirement::ContinuousEffects) and
     /// [Numeric Fluents](crate::Requirement::NumericFluents).
-    ContinuousEffect(AssignOpT, FHead, FExpT),
+    ContinuousEffect(TimedAssignOperator, FunctionHead, TimedFluentExpression),
 }
 
 impl TimedEffect {
-    pub const fn new_conditional(at: TimeSpecifier, effect: ConditionalEffect) -> Self {
+    pub const fn new_conditional(at: TimeSpecifier, effect: EffectCondition) -> Self {
         Self::Conditional(at, effect)
     }
 
-    pub const fn new_fluent(at: TimeSpecifier, action: FAssignDa) -> Self {
+    pub const fn new_fluent(at: TimeSpecifier, action: DurativeActionFunctionAssignment) -> Self {
         Self::NumericFluent(at, action)
     }
 
-    pub const fn new_continuous(operation: AssignOpT, f_head: FHead, f_exp_t: FExpT) -> Self {
+    pub const fn new_continuous(operation: TimedAssignOperator, f_head: FunctionHead, f_exp_t: TimedFluentExpression) -> Self {
         Self::ContinuousEffect(operation, f_head, f_exp_t)
     }
 }
 
-impl From<(TimeSpecifier, ConditionalEffect)> for TimedEffect {
-    fn from(value: (TimeSpecifier, ConditionalEffect)) -> Self {
+impl From<(TimeSpecifier, EffectCondition)> for TimedEffect {
+    fn from(value: (TimeSpecifier, EffectCondition)) -> Self {
         TimedEffect::Conditional(value.0, value.1)
     }
 }
 
-impl From<(TimeSpecifier, FAssignDa)> for TimedEffect {
-    fn from(value: (TimeSpecifier, FAssignDa)) -> Self {
+impl From<(TimeSpecifier, DurativeActionFunctionAssignment)> for TimedEffect {
+    fn from(value: (TimeSpecifier, DurativeActionFunctionAssignment)) -> Self {
         TimedEffect::NumericFluent(value.0, value.1)
     }
 }
 
-impl From<(AssignOpT, FHead, FExpT)> for TimedEffect {
-    fn from(value: (AssignOpT, FHead, FExpT)) -> Self {
+impl From<(TimedAssignOperator, FunctionHead, TimedFluentExpression)> for TimedEffect {
+    fn from(value: (TimedAssignOperator, FunctionHead, TimedFluentExpression)) -> Self {
         TimedEffect::ContinuousEffect(value.0, value.1, value.2)
     }
 }

--- a/src/types/timed_gd.rs
+++ b/src/types/timed_gd.rs
@@ -3,9 +3,10 @@ use crate::types::{GoalDefinition, Interval, TimeSpecifier};
 /// A timed goal definition.
 ///
 /// ## Usage
-/// Used by [`PrefTimedGD`](crate::PrefTimedGD).
+/// Used by [`PreferenceTimedGoalDefinition`](crate::PreferenceTimedGoalDefinition).
+#[doc(alias("timed-GD"))]
 #[derive(Debug, Clone, PartialEq)]
-pub enum TimedGD {
+pub enum TimedGoalDefinition {
     /// ## `at start`
     /// An expression or predicate with `at start` prefixed to it means that the condition
     /// must be true at the start of the action in order for the action to be applied. e.g.
@@ -47,7 +48,7 @@ pub enum TimedGD {
     Over(Interval, GoalDefinition),
 }
 
-impl TimedGD {
+impl TimedGoalDefinition {
     pub const fn new_at(time: TimeSpecifier, gd: GoalDefinition) -> Self {
         Self::At(time, gd)
     }
@@ -57,14 +58,18 @@ impl TimedGD {
     }
 }
 
-impl From<(TimeSpecifier, GoalDefinition)> for TimedGD {
+impl From<(TimeSpecifier, GoalDefinition)> for TimedGoalDefinition {
     fn from(value: (TimeSpecifier, GoalDefinition)) -> Self {
-        TimedGD::At(value.0, value.1)
+        TimedGoalDefinition::At(value.0, value.1)
     }
 }
 
-impl From<(Interval, GoalDefinition)> for TimedGD {
+impl From<(Interval, GoalDefinition)> for TimedGoalDefinition {
     fn from(value: (Interval, GoalDefinition)) -> Self {
-        TimedGD::Over(value.0, value.1)
+        TimedGoalDefinition::Over(value.0, value.1)
     }
 }
+
+/// Alias for [`TimedGoalDefinition`]; matches BNF `<timed-GD>`.
+#[deprecated(since = "0.2.0", note = "Use `TimedGoalDefinition` instead")]
+pub type TimedGD = TimedGoalDefinition;

--- a/src/types/timed_gd.rs
+++ b/src/types/timed_gd.rs
@@ -49,12 +49,22 @@ pub enum TimedGoalDefinition {
 }
 
 impl TimedGoalDefinition {
-    pub const fn new_at(time: TimeSpecifier, gd: GoalDefinition) -> Self {
+    pub const fn at(time: TimeSpecifier, gd: GoalDefinition) -> Self {
         Self::At(time, gd)
     }
 
-    pub const fn new_over(interval: Interval, gd: GoalDefinition) -> Self {
+    #[deprecated(since = "0.2.0", note = "Use `at` instead")]
+    pub const fn new_at(time: TimeSpecifier, gd: GoalDefinition) -> Self {
+        Self::at(time, gd)
+    }
+
+    pub const fn over(interval: Interval, gd: GoalDefinition) -> Self {
         Self::Over(interval, gd)
+    }
+
+    #[deprecated(since = "0.2.0", note = "Use `over` instead")]
+    pub const fn new_over(interval: Interval, gd: GoalDefinition) -> Self {
+        Self::over(interval, gd)
     }
 }
 
@@ -73,3 +83,83 @@ impl From<(Interval, GoalDefinition)> for TimedGoalDefinition {
 /// Alias for [`TimedGoalDefinition`]; matches BNF `<timed-GD>`.
 #[deprecated(since = "0.2.0", note = "Use `TimedGoalDefinition` instead")]
 pub type TimedGD = TimedGoalDefinition;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::GoalDefinition;
+
+    #[test]
+    fn at_start() {
+        let gd = GoalDefinition::and(Vec::new());
+        let timed = TimedGoalDefinition::at(TimeSpecifier::Start, gd.clone());
+        assert!(matches!(
+            timed,
+            TimedGoalDefinition::At(TimeSpecifier::Start, _)
+        ));
+    }
+
+    #[test]
+    fn at_end() {
+        let gd = GoalDefinition::and(Vec::new());
+        let timed = TimedGoalDefinition::at(TimeSpecifier::End, gd.clone());
+        assert!(matches!(
+            timed,
+            TimedGoalDefinition::At(TimeSpecifier::End, _)
+        ));
+    }
+
+    #[test]
+    fn over_all() {
+        let gd = GoalDefinition::and(Vec::new());
+        let timed = TimedGoalDefinition::over(Interval::All, gd.clone());
+        assert!(matches!(timed, TimedGoalDefinition::Over(Interval::All, _)));
+    }
+
+    #[test]
+    fn from_over_tuple() {
+        let gd = GoalDefinition::and(Vec::new());
+        let timed = TimedGoalDefinition::from((Interval::All, gd));
+        assert!(matches!(timed, TimedGoalDefinition::Over(Interval::All, _)));
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn deprecated_over() {
+        let gd = GoalDefinition::and(Vec::new());
+        let timed = TimedGoalDefinition::new_over(Interval::All, gd);
+        assert!(matches!(timed, TimedGoalDefinition::Over(Interval::All, _)));
+    }
+
+    #[test]
+    fn from_at_tuple() {
+        let gd = GoalDefinition::and(Vec::new());
+        let timed = TimedGoalDefinition::from((TimeSpecifier::Start, gd));
+        assert!(matches!(
+            timed,
+            TimedGoalDefinition::At(TimeSpecifier::Start, _)
+        ));
+    }
+
+    #[test]
+    fn clone_works() {
+        let gd = GoalDefinition::and(Vec::new());
+        let timed = TimedGoalDefinition::at(TimeSpecifier::Start, gd);
+        let clone = timed.clone();
+        assert_eq!(timed, clone);
+    }
+
+    #[test]
+    fn debug_impl() {
+        let gd = GoalDefinition::and(Vec::new());
+        let timed = TimedGoalDefinition::at(TimeSpecifier::Start, gd);
+        let dbg = format!("{timed:?}");
+        assert!(dbg.contains("At"));
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn deprecated_alias_exists() {
+        fn _assert_alias(_: TimedGD) {}
+    }
+}

--- a/src/types/type.rs
+++ b/src/types/type.rs
@@ -45,12 +45,22 @@ impl Type {
     /// The predefined type `number`.
     pub const NUMBER: Type = Type::Exactly(TYPE_NUMBER);
 
-    pub fn new_exactly<S: Into<PrimitiveType>>(t: S) -> Self {
+    #[doc(alias = "new_exactly")]
+    pub fn exactly<S: Into<PrimitiveType>>(t: S) -> Self {
         Self::Exactly(t.into())
     }
 
-    pub fn new_either<T: IntoIterator<Item = P>, P: Into<PrimitiveType>>(iter: T) -> Self {
+    pub fn new_exactly<S: Into<PrimitiveType>>(t: S) -> Self {
+        Self::exactly(t)
+    }
+
+    #[doc(alias = "new_either")]
+    pub fn either<T: IntoIterator<Item = P>, P: Into<PrimitiveType>>(iter: T) -> Self {
         Self::EitherOf(iter.into_iter().map(|x| x.into()).collect())
+    }
+
+    pub fn new_either<T: IntoIterator<Item = P>, P: Into<PrimitiveType>>(iter: T) -> Self {
+        Self::either(iter)
     }
 
     pub fn len(&self) -> usize {
@@ -172,7 +182,7 @@ mod tests {
 
     #[test]
     fn simple_works() {
-        let t = Type::new_exactly("location");
+        let t = Type::exactly("location");
         assert_eq!(format!("{t}"), "location");
     }
 
@@ -197,7 +207,7 @@ mod tests {
 
     #[test]
     fn either_works() {
-        let t = Type::new_either(["location", "memory"]);
+        let t = Type::either(["location", "memory"]);
         assert_eq!(format!("{t}"), "(either location memory)");
     }
 }

--- a/src/types/typed.rs
+++ b/src/types/typed.rs
@@ -15,8 +15,13 @@ impl<O> Typed<O> {
         Self(value, r#type)
     }
 
-    pub const fn new_object(value: O) -> Self {
+    pub const fn object(value: O) -> Self {
         Self::new(value, Type::OBJECT)
+    }
+
+    #[deprecated(since = "0.2.0", note = "Use `object` instead")]
+    pub const fn new_object(value: O) -> Self {
+        Self::object(value)
     }
 
     /// Gets the value.
@@ -66,7 +71,7 @@ pub trait ToTyped<T> {
 
 impl<O> From<O> for Typed<O> {
     fn from(value: O) -> Self {
-        Typed::new_object(value)
+        Typed::object(value)
     }
 }
 

--- a/src/types/typed_list.rs
+++ b/src/types/typed_list.rs
@@ -149,16 +149,16 @@ mod tests {
 
     #[test]
     fn simple_works() {
-        let name = TypedList::from_iter([Name::new("x").to_typed(Type::new_exactly("letter"))]);
+        let name = TypedList::from_iter([Name::new("x").to_typed(Type::exactly("letter"))]);
         assert_eq!(format!("{name}"), "x - letter");
     }
 
     #[test]
     fn multiple_same_works() {
         let name = TypedList::from_iter([
-            Name::new("x").to_typed(Type::new_exactly("letter")),
-            Name::new("y").to_typed(Type::new_exactly("letter")),
-            Name::new("z").to_typed(Type::new_exactly("letter")),
+            Name::new("x").to_typed(Type::exactly("letter")),
+            Name::new("y").to_typed(Type::exactly("letter")),
+            Name::new("z").to_typed(Type::exactly("letter")),
         ]);
         assert_eq!(format!("{name}"), "x y z - letter");
     }
@@ -166,9 +166,9 @@ mod tests {
     #[test]
     fn interleaved_at_end() {
         let name = TypedList::from_iter([
-            Name::new("x").to_typed(Type::new_exactly("letter")),
-            Name::new("y").to_typed(Type::new_exactly("letter")),
-            Name::new("z").to_typed(Type::new_exactly("car")),
+            Name::new("x").to_typed(Type::exactly("letter")),
+            Name::new("y").to_typed(Type::exactly("letter")),
+            Name::new("z").to_typed(Type::exactly("car")),
         ]);
         assert_eq!(format!("{name}"), "x y - letter z - car");
     }
@@ -176,9 +176,9 @@ mod tests {
     #[test]
     fn interleaved() {
         let name = TypedList::from_iter([
-            Name::new("x").to_typed(Type::new_exactly("letter")),
-            Name::new("y").to_typed(Type::new_exactly("car")),
-            Name::new("z").to_typed(Type::new_exactly("letter")),
+            Name::new("x").to_typed(Type::exactly("letter")),
+            Name::new("y").to_typed(Type::exactly("car")),
+            Name::new("z").to_typed(Type::exactly("letter")),
         ]);
         assert_eq!(format!("{name}"), "x - letter y - car z - letter");
     }
@@ -186,7 +186,7 @@ mod tests {
     #[test]
     fn object_at_end() {
         let name = TypedList::from_iter([
-            Name::new("x").to_typed(Type::new_exactly("letter")),
+            Name::new("x").to_typed(Type::exactly("letter")),
             Name::new("y").to_typed(Type::OBJECT),
             Name::new("z").to_typed(Type::OBJECT),
         ]);
@@ -196,9 +196,9 @@ mod tests {
     #[test]
     fn object_at_start() {
         let name = TypedList::from_iter([
-            Variable::new_string("x").to_typed(Type::OBJECT),
-            Variable::new_string("y").to_typed(Type::OBJECT),
-            Variable::new_string("z").to_typed(Type::new_exactly("letter")),
+            Variable::string("x").to_typed(Type::OBJECT),
+            Variable::string("y").to_typed(Type::OBJECT),
+            Variable::string("z").to_typed(Type::exactly("letter")),
         ]);
         assert_eq!(format!("{name}"), "?x ?y - object ?z - letter");
     }

--- a/src/types/variable.rs
+++ b/src/types/variable.rs
@@ -23,8 +23,14 @@ impl Variable {
     }
 
     #[inline(always)]
-    pub fn new_string(name: &str) -> Self {
+    #[doc(alias = "new_string")]
+    pub fn string(name: &str) -> Self {
         Self(Name::new(name))
+    }
+
+    #[inline(always)]
+    pub fn new_string(name: &str) -> Self {
+        Self::string(name)
     }
 
     #[inline(always)]
@@ -95,7 +101,7 @@ mod tests {
 
     #[test]
     fn it_works() {
-        let var = Variable::new_string("x");
+        let var = Variable::string("x");
         assert_eq!(format!("{var}"), "?x");
     }
 }

--- a/tests/briefcase_world.rs
+++ b/tests/briefcase_world.rs
@@ -1,6 +1,6 @@
 use pddl::{
-    AtomicFormula, Domain, GoalDefinition, Parser, PreconditionGoalDefinition, PreferenceGD,
-    Problem, TermLiteral,
+    AtomicFormula, Domain, GoalDefinition, Parser, PreconditionGoalDefinition,
+    PreferenceGoalDefinition, Problem, TermLiteral,
 };
 
 pub const BRIEFCASE_WORLD: &str = r#"
@@ -88,7 +88,7 @@ fn parse_problem_works() {
     for goal in problem.goals().iter() {
         match goal {
             PreconditionGoalDefinition::Preference(pref) => match pref {
-                PreferenceGD::Goal(goal) => match goal {
+                PreferenceGoalDefinition::Goal(goal) => match goal {
                     GoalDefinition::AtomicFormula(af) => match af {
                         AtomicFormula::Predicate(_) => atomic_formulas += 1,
                         AtomicFormula::Equality(_) => {}
@@ -109,7 +109,7 @@ fn parse_problem_works() {
                     GoalDefinition::ForAll(_, _) => {}
                     GoalDefinition::FluentComparison(_) => {}
                 },
-                PreferenceGD::Preference(_) => {}
+                PreferenceGoalDefinition::Preference(_) => {}
             },
             PreconditionGoalDefinition::Forall(_, _) => {}
         }

--- a/tests/briefcase_world.rs
+++ b/tests/briefcase_world.rs
@@ -107,7 +107,7 @@ fn parse_problem_works() {
                     GoalDefinition::Imply(_, _) => {}
                     GoalDefinition::Exists(_, _) => {}
                     GoalDefinition::ForAll(_, _) => {}
-                    GoalDefinition::FComp(_) => {}
+                    GoalDefinition::FluentComparison(_) => {}
                 },
                 PreferenceGD::Preference(_) => {}
             },


### PR DESCRIPTION
## Summary

Rename all abbreviated PDDL type names across the entire codebase (types, parsers, pretty-print, tests) to their full descriptive equivalents, improving readability and discoverability for library users. All old names are preserved as deprecated type aliases for backward compatibility.

## Before

Type names used PDDL BNF abbreviations that were hard to discover and read:
- `PEffect`, `CEffect`, `ForallCEffect`, `WhenCEffect`
- `FExp`, `FHead`, `FComp`, `FExpT`, `FExpDa`, `FAssignDa`
- `TimedGD`, `GoalDef`, `ConGD`, `Con2GD`, `PrefConGD`
- `AssignOpT`, `BinaryComp`, `DOp`, `MetricFExp`
- `PreferenceGD`, `PrefTimedGD`

## After

All types use full descriptive names with deprecated aliases pointing to them:
- `PrimitiveEffect`, `ConditionalEffect`, `ForallConditionalEffect`, `WhenConditionalEffect`
- `FluentExpression`, `FunctionHead`, `FluentComparison`, `TimedFluentExpression`, `DurativeActionFluentExpression`, `DurativeActionFunctionAssignment`
- `TimedGoalDefinition`, `ProblemGoalDefinition`, `ConstraintGoalDefinition`, `ConstraintGoalDefinitionInner`, `PreferenceConstraintGoalDefinition`
- `TimedAssignOperator`, `BinaryComparison`, `DurationOperator`, `MetricFluentExpression`
- `PreferenceGoalDefinition`, `PreferenceTimedGoalDefinition`

Also updated:
- `parse_cond_effect` → `parse_effect_condition` (with deprecated alias)
- `EffectCondition` extracted as a new public type (the recursive tree inside `when` clauses)
- Full rewrite of the `lib.rs` PDDL Type System Guide to use new names throughout

## Outcome

- 90 files changed, ~2150 insertions, ~1670 deletions
- All existing code using old abbreviations compiles with deprecation warnings
- All tests pass (116 doctests + unit tests)
- Docs build cleanly with no broken links
- The type system guide in `lib.rs` is now accurate and uses the new naming

## Findings

- `EffectCondition` was added as a distinct public type because the previous `ConditionalEffect` enum served dual purposes: as a top-level effect variant and as the recursive tree inside `when` clauses. Now `ConditionalEffect` wraps the three variants (primitive, forall, when), and `EffectCondition` represents the recursive tree specifically used in `when` conditions.

## Review Instructions

- Review `src/types/mod.rs` first to see the full mapping of new names to deprecated aliases
- Then check `src/lib.rs` for the updated type system guide accuracy
- Spot-check a few parser/type files to verify the rename pattern is consistent (e.g., `src/types/c_effect.rs`, `src/types/f_exp.rs`, `src/parsers/timed_effect.rs`)
- Verify that `#[allow(deprecated)]` is applied at the re-export level in `mod.rs` so downstream users see warnings but internal code does not